### PR TITLE
Fix: Update react-icons package

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -25,7 +25,7 @@
         "react-animate-height": "^3.2.3",
         "react-dom": "^18.2.0",
         "react-hot-toast": "^2.4.1",
-        "react-icons": "^5.3.0",
+        "react-icons": "^5.4.0",
         "react-router-dom": "^6.22.3",
         "react-simple-keyboard": "^3.7.112",
         "recharts": "^2.12.6",
@@ -4935,9 +4935,9 @@
       }
     },
     "node_modules/react-icons": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.3.0.tgz",
-      "integrity": "sha512-DnUk8aFbTyQPSkCfF8dbX6kQjXA9DktMeJqfjrg6cK9vwQVMxmcA3BfP4QoiztVmEHtwlTgLFsPuH2NskKT6eg==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.4.0.tgz",
+      "integrity": "sha512-7eltJxgVt7X64oHh6wSWNwwbKTCtMfK35hcjvJS0yxEAhPM8oUKdS3+kqaW1vicIltw+kR2unHaa12S9pPALoQ==",
       "peerDependencies": {
         "react": "*"
       }

--- a/ui/package.json
+++ b/ui/package.json
@@ -31,7 +31,7 @@
     "react-animate-height": "^3.2.3",
     "react-dom": "^18.2.0",
     "react-hot-toast": "^2.4.1",
-    "react-icons": "^5.3.0",
+    "react-icons": "^5.4.0",
     "react-router-dom": "^6.22.3",
     "react-simple-keyboard": "^3.7.112",
     "recharts": "^2.12.6",


### PR DESCRIPTION
Bump the react-icons NPM package to solve missing `LuEllipsisVertical` icon.