### PR TITLE
chore: Add devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "JetKVM",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			// Should match what is defined in ui/package.json
+			"version": "21.1.0"
+		}
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ build_dev: hash_resource
 	GOOS=linux GOARCH=arm GOARM=7 go build -ldflags="-s -w -X kvm.builtAppVersion=$(VERSION_DEV)" -o bin/jetkvm_app cmd/main.go
 
 frontend:
-	cd ui && npm run build:device
+	cd ui && npm ci && npm run build:device
 
 dev_release: build_dev
 	@echo "Uploading release..."

--- a/dev_deploy.sh
+++ b/dev_deploy.sh
@@ -3,45 +3,34 @@ set -e
 
 # Function to display help message
 show_help() {
-    echo "Usage: $0 [options] -h <host_ip> -r <remote_ip>"
+    echo "Usage: $0 [options] -r <remote_ip>"
     echo
     echo "Required:"
-    echo "  -h, --host <host_ip>      Local host IP address"
     echo "  -r, --remote <remote_ip>   Remote host IP address"
     echo
     echo "Optional:"
     echo "  -u, --user <remote_user>   Remote username (default: root)"
-    echo "  -p, --port <port>          Python server port (default: 8000)"
     echo "      --help                 Display this help message"
     echo
     echo "Example:"
-    echo "  $0 -h 192.168.0.13 -r 192.168.0.17"
-    echo "  $0 -h 192.168.0.13 -r 192.168.0.17 -u admin -p 8080"
+    echo "  $0 -r 192.168.0.17"
+    echo "  $0 -r 192.168.0.17 -u admin"
     exit 0
 }
 
 # Default values
-PYTHON_PORT=8000
 REMOTE_USER="root"
 REMOTE_PATH="/userdata/jetkvm/bin"
 
 # Parse command line arguments
 while [[ $# -gt 0 ]]; do
     case $1 in
-        -h|--host)
-            HOST_IP="$2"
-            shift 2
-            ;;
         -r|--remote)
             REMOTE_HOST="$2"
             shift 2
             ;;
         -u|--user)
             REMOTE_USER="$2"
-            shift 2
-            ;;
-        -p|--port)
-            PYTHON_PORT="$2"
             shift 2
             ;;
         --help)
@@ -57,8 +46,8 @@ while [[ $# -gt 0 ]]; do
 done
 
 # Verify required parameters
-if [ -z "$HOST_IP" ] || [ -z "$REMOTE_HOST" ]; then
-    echo "Error: Host IP and Remote IP are required parameters"
+if [ -z "$REMOTE_HOST" ]; then
+    echo "Error: Remote IP is a required parameter"
     show_help
 fi
 
@@ -69,12 +58,8 @@ make build_dev
 # Change directory to the binary output directory
 cd bin
 
-# Start a Python HTTP server in the background to serve files
-python3 -m http.server "$PYTHON_PORT" &
-PYTHON_SERVER_PID=$!
-
-# Ensure that the Python server is terminated if the script exits unexpectedly
-trap "echo 'Terminating Python server...'; kill $PYTHON_SERVER_PID" EXIT
+# Copy the binary to the remote host
+cat jetkvm_app | ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > $REMOTE_PATH/jetkvm_app_debug"
 
 # Deploy and run the application on the remote host
 ssh "${REMOTE_USER}@${REMOTE_HOST}" ash <<EOF
@@ -90,23 +75,12 @@ killall jetkvm_app_debug || true
 # Navigate to the directory where the binary will be stored
 cd "$REMOTE_PATH"
 
-# Remove any old binary
-rm -f jetkvm_app
-
-# Download the new binary from the host
-wget ${HOST_IP}:${PYTHON_PORT}/jetkvm_app
-
 # Make the new binary executable
-chmod +x jetkvm_app
-
-# Rename the binary to jetkvm_app_debug
-mv jetkvm_app jetkvm_app_debug
+chmod +x jetkvm_app_debug
 
 # Run the application in the background
 ./jetkvm_app_debug
 
 EOF
 
-# Once the SSH session finishes, shut down the Python server
-kill "$PYTHON_SERVER_PID"
 echo "Deployment complete."


### PR DESCRIPTION
Adds a devcontainer configuration with golang and nodejs support. Also updates `./dev_deploy.sh` to not require a python http server, making it easier to deploy from within a container network environment. 

This was tested on my JetKVM device, but a second round of validation wouldn't hurt.