### PR TITLE
feat(ui/ActionBar): Add a CTRL + ALT + DEL Button to the Action Bar

### DIFF
--- a/ui/src/components/ActionBar.tsx
+++ b/ui/src/components/ActionBar.tsx
@@ -207,22 +207,23 @@ export default function Actionbar({
               onClick={() => setVirtualKeyboard(!virtualKeyboard)}
             />
           </div>
-          <div className="hidden lg:block">
-            <Button
+            {useSettingsStore().actionBarCtrlAltDel && (
+            <div className="hidden lg:block">
+              <Button
               size="XS"
               theme="light"
               text="Ctrl + Alt + Del"
               LeadingIcon={FaLock}
               onClick={() => {
                 sendKeyboardEvent(
-                  [keys["Delete"]],
-                  [modifiers["ControlLeft"], modifiers["AltLeft"]],
-                )
+                [keys["Delete"]],
+                [modifiers["ControlLeft"], modifiers["AltLeft"]],
+                );
                 setTimeout(resetKeyboardState, 100);
-              }
-              }
-            />
-          </div>
+              }}
+              />
+            </div>
+            )}
         </div>
 
         <div className="flex flex-wrap items-center gap-x-2 gap-y-2">

--- a/ui/src/components/ActionBar.tsx
+++ b/ui/src/components/ActionBar.tsx
@@ -10,12 +10,14 @@ import Container from "@components/Container";
 import { LuHardDrive, LuMaximize, LuSettings, LuSignal } from "react-icons/lu";
 import { cx } from "@/cva.config";
 import PasteModal from "@/components/popovers/PasteModal";
-import { FaKeyboard } from "react-icons/fa6";
+import { FaKeyboard, FaLock } from "react-icons/fa6";
 import WakeOnLanModal from "@/components/popovers/WakeOnLan/Index";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import MountPopopover from "./popovers/MountPopover";
 import { Fragment, useCallback, useRef } from "react";
 import { CommandLineIcon } from "@heroicons/react/20/solid";
+import useKeyboard from "@/hooks/useKeyboard";
+import { keys, modifiers } from "@/keyboardMappings";
 
 export default function Actionbar({
   requestFullscreen,
@@ -51,6 +53,8 @@ export default function Actionbar({
     },
     [setDisableFocusTrap],
   );
+
+  const { sendKeyboardEvent, resetKeyboardState } = useKeyboard();
 
   return (
     <Container className="bg-white border-b border-b-slate-800/20 dark:bg-slate-900 dark:border-b-slate-300/20">
@@ -201,6 +205,22 @@ export default function Actionbar({
               text="Virtual Keyboard"
               LeadingIcon={FaKeyboard}
               onClick={() => setVirtualKeyboard(!virtualKeyboard)}
+            />
+          </div>
+          <div className="hidden lg:block">
+            <Button
+              size="XS"
+              theme="light"
+              text="Ctrl + Alt + Del"
+              LeadingIcon={FaLock}
+              onClick={() => {
+                sendKeyboardEvent(
+                  [keys["Delete"]],
+                  [modifiers["ControlLeft"], modifiers["AltLeft"]],
+                )
+                setTimeout(resetKeyboardState, 100);
+              }
+              }
             />
           </div>
         </div>

--- a/ui/src/components/sidebar/settings.tsx
+++ b/ui/src/components/sidebar/settings.tsx
@@ -796,6 +796,15 @@ export default function SettingsSidebar() {
             }}
           />
         </SettingsItem>
+        <SettingsItem
+          title="Ctrl + Alt + Del Button"
+          description="Display Ctrl + Alt + Del button on the Action Bar"
+        >
+          <Checkbox
+            checked={settings.actionBarCtrlAltDel}
+            onChange={e => settings.setActionBarCtrlAltDel(e.target.checked)}
+          />
+        </SettingsItem>
         <div className="h-[1px] w-full bg-slate-800/10 dark:bg-slate-300/20" />
         <div className="pb-2 space-y-4">
           <SectionHeader

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -270,6 +270,9 @@ interface SettingsState {
   // Add new developer mode state
   developerMode: boolean;
   setDeveloperMode: (enabled: boolean) => void;
+
+  actionBarCtrlAltDel: boolean;
+  setActionBarCtrlAltDel: (enabled: boolean) => void;
 }
 
 export const useSettingsStore = create(
@@ -287,6 +290,9 @@ export const useSettingsStore = create(
       // Add developer mode with default value
       developerMode: false,
       setDeveloperMode: enabled => set({ developerMode: enabled }),
+
+      actionBarCtrlAltDel: false,
+      setActionBarCtrlAltDel: enabled => set({ actionBarCtrlAltDel: enabled }),
     }),
     {
       name: "settings",


### PR DESCRIPTION
This PR introduces a CTRL + ALT + DEL button to the Action Bar which works the same way as the button on the virtual keyboard.

## Overview/Rationale
This is primarily for people installing or debugging operating systems that may need to reboot the system frequently, it avoids having to open the Virtual Keyboard as would otherwise be required to send this key combination.

The second commit in this PR makes the button a setting, which defaults to off, allowing the button to be hidden if the user doesn't need it.

## Screenshots

Button on Action Bar: (I'm not 100% set on the lock icon, suggestions welcome on that)
![image](https://github.com/user-attachments/assets/2e92187f-c4e1-44b3-bd50-1b6cce2e44a3)


Toggle in Settings
![image](https://github.com/user-attachments/assets/9f779aa2-d151-4d9f-9747-e5168144afaa)
