### PR TITLE
fix(cloud): only start WS Client if config.CloudToken is set

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -68,6 +68,11 @@ func handleCloudRegister(c *gin.Context) {
 		return
 	}
 
+	if config.CloudToken == "" {
+		logger.Info("Starting websocket client due to adoption")
+		go RunWebsocketClient()
+	}
+
 	config.CloudToken = tokenResp.SecretToken
 	config.CloudURL = req.CloudAPI
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,11 @@ func Main() {
 	}()
 	//go RunFuseServer()
 	go RunWebServer()
-	go RunWebsocketClient()
+	// If the cloud token isn't set, the client won't be started by default.
+	// However, if the user adopts the device via the web interface, handleCloudRegister will start the client.
+	if config.CloudToken != "" {
+		go RunWebsocketClient()
+	}
 	sigs := make(chan os.Signal, 1)
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 	<-sigs


### PR DESCRIPTION
This PR only starts the WebSocket client loop if a token was set in `config.CloudToken` at start time, it also starts the loop if the adoption process runs after the fact.

This avoids your log being full of `Websocket client error: cloud token is not set` while working on the application, and stops the loop pointlessly running.