### PR TITLE
feat: restore EDID on reboot

### DIFF
--- a/config.go
+++ b/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	LocalAuthToken    string            `json:"local_auth_token"`
 	LocalAuthMode     string            `json:"localAuthMode"` //TODO: fix it with migration
 	WakeOnLanDevices  []WakeOnLanDevice `json:"wake_on_lan_devices"`
+	EdidString        string            `json:"hdmi_edid_string"`
 }
 
 const configPath = "/userdata/kvm_config.json"

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -183,6 +183,12 @@ func rpcSetEDID(edid string) error {
 	if err != nil {
 		return err
 	}
+
+	// Save EDID to config, allowing it to be restored on reboot.
+	LoadConfig()
+	config.EdidString = edid
+	SaveConfig()
+
 	return nil
 }
 

--- a/native.go
+++ b/native.go
@@ -151,6 +151,9 @@ func handleCtrlClient(conn net.Conn) {
 
 	ctrlSocketConn = conn
 
+	// Restore HDMI EDID if applicable
+	go restoreHdmiEdid()
+
 	readBuf := make([]byte, 4096)
 	for {
 		n, err := conn.Read(readBuf)
@@ -296,4 +299,17 @@ func ensureBinaryUpdated(destPath string) error {
 	}
 
 	return nil
+}
+
+// Restore the HDMI EDID value from the config.
+// Called after successful connection to jetkvm_native.
+func restoreHdmiEdid() {
+	LoadConfig()
+	if config.EdidString != "" {
+		logger.Infof("Restoring HDMI EDID to %v", config.EdidString)
+		_, err := CallCtrlAction("set_edid", map[string]interface{}{"edid": config.EdidString})
+		if err != nil {
+			logger.Errorf("Failed to restore HDMI EDID: %v", err)
+		}
+	}
 }


### PR DESCRIPTION
This pull request fixes #33 by introducing a new config entry `EdidString` and saves the EDID string to it when it's modified in the frontend.

This PR also introduces a method to restore the EDID on reboot/app restart by sending the `EdidString` back to jetkvm_native when it connects to the control socket.