### PR TITLE
Update to latest ISO versions

### DIFF
--- a/ui/src/components/MountMediaDialog.tsx
+++ b/ui/src/components/MountMediaDialog.tsx
@@ -534,17 +534,17 @@ function UrlView({
     },
     {
       name: "Debian 12",
-      url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.7.0-amd64-netinst.iso",
+      url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-12.9.0-amd64-netinst.iso",
       icon: DebianIcon,
     },
     {
-      name: "Fedora 38",
-      url: "https://mirror.ihost.md/fedora/releases/38/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-38-1.6.iso",
+      name: "Fedora 41",
+      url: "https://download.fedoraproject.org/pub/fedora/linux/releases/41/Workstation/x86_64/iso/Fedora-Workstation-Live-x86_64-41-1.4.iso",
       icon: FedoraIcon,
     },
     {
       name: "Arch Linux",
-      url: "https://archlinux.doridian.net/iso/2024.10.01/archlinux-2024.10.01-x86_64.iso",
+      url: "https://archlinux.doridian.net/iso/2025.02.01/archlinux-2025.02.01-x86_64.iso",
       icon: ArchIcon,
     },
     {


### PR DESCRIPTION
* Fedora 38 is EOL, bump to 41 and use main Fedora mirror
* Bumps Arch Linux and Debian to latest builds