### PR TITLE
Fix fullscreen video absolute position

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -10,6 +10,7 @@
     "dev": "vite dev --mode=development",
     "build": "npm run build:prod",
     "build:device": "tsc && vite build --mode=device --emptyOutDir",
+    "dev:device": "vite dev --mode=device",
     "build:prod": "tsc && vite build --mode=production",
     "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0"
   },

--- a/ui/src/components/ActionBar.tsx
+++ b/ui/src/components/ActionBar.tsx
@@ -4,6 +4,7 @@ import {
   useMountMediaStore,
   useUiStore,
   useSettingsStore,
+  useVideoStore,
 } from "@/hooks/stores";
 import { MdOutlineContentPasteGo } from "react-icons/md";
 import Container from "@components/Container";
@@ -33,6 +34,7 @@ export default function Actionbar({
     state => state.remoteVirtualMediaState,
   );
   const developerMode = useSettingsStore(state => state.developerMode);
+  const hdmiState = useVideoStore(state => state.hdmiState);
 
   // This is the only way to get a reliable state change for the popover
   // at time of writing this there is no mount, or unmount event for the popover
@@ -247,6 +249,7 @@ export default function Actionbar({
               size="XS"
               theme="light"
               text="Fullscreen"
+              disabled={hdmiState !== 'ready'}
               LeadingIcon={LuMaximize}
               onClick={() => requestFullscreen()}
             />

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -2,13 +2,31 @@ import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tsconfigPaths from "vite-tsconfig-paths";
 
-export default defineConfig(({ mode }) => {
+declare const process: {
+  env: {
+    JETKVM_PROXY_URL: string;
+  };
+};
+
+export default defineConfig(({ mode, command }) => {
   const isCloud = mode === "production";
   const onDevice = mode === "device";
+  const { JETKVM_PROXY_URL } = process.env;
+
   return {
     plugins: [tsconfigPaths(), react()],
     build: { outDir: isCloud ? "dist" : "../static" },
-    server: { host: "0.0.0.0" },
-    base: onDevice ? "/static" : "/",
+    server: {
+      host: "0.0.0.0",
+      proxy: JETKVM_PROXY_URL ? {
+        '/me': JETKVM_PROXY_URL,
+        '/device': JETKVM_PROXY_URL,
+        '/webrtc': JETKVM_PROXY_URL,
+        '/auth': JETKVM_PROXY_URL,
+        '/storage': JETKVM_PROXY_URL,
+        '/cloud': JETKVM_PROXY_URL,
+      } : undefined
+    },
+    base: onDevice && command === 'build' ? "/static" : "/",
   };
 });


### PR DESCRIPTION
Fixes #21 

Updates the absolute mouse position calculation to take into account differing aspect ratio between the video element and the video stream, which happens when fullscreening the screen share.

This also adds `dev:device` package.json script to allow doing live-reload against a development JetKVM device. As introduced in #10 