### PR TITLE
Remove rounded corners from video stream

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -425,7 +425,7 @@ export default function WebRTCVideo() {
                         disablePictureInPicture
                         controlsList="nofullscreen"
                         className={cx(
-                          "outline-50 max-h-full max-w-full rounded-md object-contain transition-all duration-1000",
+                          "outline-50 max-h-full max-w-full object-contain transition-all duration-1000",
                           {
                             "cursor-none": settings.isCursorHidden,
                             "opacity-0": isLoading || isConnectionError || hdmiError,


### PR DESCRIPTION
Fixes #70 by just removing it all together, with a preference towards usability over appearance allowing the user to see the corners without using fullscreen mode

![image](https://github.com/user-attachments/assets/2c2ab8ba-e09a-4ffe-a997-1ca51f660ec6)
