### PR TITLE
fix: NTP requests sleep for 1 hour between failed attempts.

### DIFF
--- a/ntp.go
+++ b/ntp.go
@@ -20,6 +20,8 @@ func TimeSyncLoop() {
 		err := SyncSystemTime()
 		if err != nil {
 			log.Printf("Failed to sync system time: %v", err)
+			// Sync failed for all 4 endpoints, likely network issue, wait for 1 hour before retrying
+			time.Sleep(1 * time.Hour)
 			continue
 		}
 		log.Printf("Time sync successful, now is: %v, time taken: %v", time.Now(), time.Since(start))


### PR DESCRIPTION
Fixes #74 - When the device is unable to connect to the time servers, it was looping every two seconds.  This lead to unecessary processing, and if the device was able to connect to DNS but not the time servers, it was causing undue load on the DNS server as well.

## Background

After disconnecting my JetKVM from the internet at my router, I observed that it attempted to set its time every two seconds.  I believe this issue is isolated to the `TimeSyncLoop` method.  This PR attempts to ensure a 1 hour delay between sync attempts.

I am fairly new to go, and very open to feedback on my solution.  I also did not readily see any tests for the Go code, so did not change them.

In [the previous version](https://github.com/exegeteio/jetkvm/blob/8ffe66a/ntp.go#L21), the failure state would `continue` the for loop, without sleeping.  That means that the only delay in the attempts was the [two second timeout for NTP server attempts](https://github.com/exegeteio/jetkvm/blob/8ffe66a/ntp.go#L49), and the [two second timeout for HTTP server attempts](https://github.com/exegeteio/jetkvm/blob/8ffe66a/ntp.go#L59).

## Speculation

I have no proof of this, but I fear that if the device was completely disconnected from the internet (e.g. no DNS, or instantly failing connections to the remote servers), that it may find itself in an infinite lop processing NTP requests with no delay.  Might this cause thermal issues if one green thread is infinitely retrying?