### PR TITLE
Enable "Boot Interface Subclass" for keyboard and mouse.

### DIFF
--- a/usb.go
+++ b/usb.go
@@ -132,7 +132,7 @@ func writeGadgetConfig() error {
 	}
 	err = writeGadgetAttrs(hid0Path, [][]string{
 		{"protocol", "1"},
-		{"subclass", "0"},
+		{"subclass", "1"},
 		{"report_length", "8"},
 	})
 	if err != nil {
@@ -152,7 +152,7 @@ func writeGadgetConfig() error {
 	}
 	err = writeGadgetAttrs(hid1Path, [][]string{
 		{"protocol", "2"},
-		{"subclass", "0"},
+		{"subclass", "1"},
 		{"report_length", "6"},
 	})
 	if err != nil {


### PR DESCRIPTION
Fixes #56, #62 and #79 - Boot Protocol is (often) required for the keyboard/mouse to be recognized in BIOS/UEFI firmware.

