### PR TITLE
Fix erroneous USB device descriptor values

### DIFF
--- a/usb.go
+++ b/usb.go
@@ -82,8 +82,8 @@ func writeGadgetConfig() error {
 	err = writeGadgetAttrs(kvmGadgetPath, [][]string{
 		{"bcdUSB", "0x0200"},   //USB 2.0
 		{"idVendor", "0x1d6b"}, //The Linux Foundation
-		{"idProduct", "0104"},  //Multifunction Composite Gadget¬
-		{"bcdDevice", "0100"},
+		{"idProduct", "0x0104"},  //Multifunction Composite Gadget¬
+		{"bcdDevice", "0x0100"},
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Values provided were octal but clearly intended to be hex, which I have corrected.