### PR TITLE
Adds Podman support to Devcontainers

### DIFF
--- a/.devcontainer/default/devcontainer.json
+++ b/.devcontainer/default/devcontainer.json
@@ -1,0 +1,10 @@
+{
+	"name": "JetKVM Default",
+	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			// Should match what is defined in ui/package.json
+			"version": "21.1.0"
+		}
+	}
+}

--- a/.devcontainer/podman/devcontainer.json
+++ b/.devcontainer/podman/devcontainer.json
@@ -1,10 +1,19 @@
 {
-	"name": "JetKVM",
+	"name": "JetKVM Podman",
 	"image": "mcr.microsoft.com/devcontainers/go:1-1.23-bookworm",
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			// Should match what is defined in ui/package.json
 			"version": "21.1.0"
 		}
+	},
+	"runArgs": [
+		"--userns=keep-id",
+		"--security-opt=label=disable",
+		"--security-opt=label=nested"
+	],
+	"containerUser": "vscode",
+	"containerEnv": {
+		"HOME": "/home/vscode"
 	}
 }

--- a/dev_deploy.sh
+++ b/dev_deploy.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 # Exit immediately if a command exits with a non-zero status
 set -e
 


### PR DESCRIPTION
I'm developing against Fedora which has Podman installed by default. To use a devcontainer, it was necessary to ensure SELinux was not blocking access to the kvm project files in my home directory. 

To configure the Devcontainer extension to use Podman, it must be configured by the user first in their settings.json with `"dev.containers.dockerPath": "podman"`

- Creates a podman devcontainer config
- ~Ensures dev_update.sh runs in bash as the container image uses zsh by default and it is not compatible~ No longer needed