### PR TITLE
fix(devcontainer): Map local ssh keys to container

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,5 +6,9 @@
 			// Should match what is defined in ui/package.json
 			"version": "21.1.0"
 		}
-	}
+	},
+	"mounts": [
+    	"source=${localEnv:HOME}/.ssh,target=/home/vscode/.ssh,type=bind,consistency=cached"
+	]
 }
+


### PR DESCRIPTION
This setting is needed to run `dev_deploy.sh` successfully.  If you are developing inside of the container the container doesn't have any ssh keys and falls back to password auth.  This setting maps your keys local to the container so the deploy to device will work. 

