### PR TITLE
fix(ui): Fix & Update Ubuntu 24.04 LTS ISO download URL to latest

### DIFF
--- a/ui/src/components/MountMediaDialog.tsx
+++ b/ui/src/components/MountMediaDialog.tsx
@@ -531,7 +531,7 @@ function UrlView({
   const popularImages = [
     {
       name: "Ubuntu 24.04 LTS",
-      url: "https://releases.ubuntu.com/noble/ubuntu-24.04.1-desktop-amd64.iso",
+      url: "https://releases.ubuntu.com/24.04.2/ubuntu-24.04.2-desktop-amd64.iso",
       icon: UbuntuIcon,
     },
     {


### PR DESCRIPTION
The previous URL no longer works because the noble folder replaces old version files with new ones.