### PR TITLE
Add more public NTP servers

### DIFF
--- a/ntp.go
+++ b/ntp.go
@@ -22,8 +22,12 @@ const (
 var (
 	timeSyncRetryInterval = 0 * time.Second
 	defaultNTPServers     = []string{
+		"pool.ntp.org",
 		"time.cloudflare.com",
+		"time.google.com",
+		"time.aws.com",
 		"time.apple.com",
+		"time.windows.com",
 	}
 )
 

--- a/ntp.go
+++ b/ntp.go
@@ -24,10 +24,6 @@ var (
 	defaultNTPServers     = []string{
 		"pool.ntp.org",
 		"time.cloudflare.com",
-		"time.google.com",
-		"time.aws.com",
-		"time.apple.com",
-		"time.windows.com",
 	}
 )
 
@@ -98,8 +94,9 @@ func queryNetworkTime() (*time.Time, error) {
 		}
 	}
 	httpUrls := []string{
+		"http://pool.ntp.org",
 		"http://apple.com",
-		"http://cloudflare.com",
+		"http://microsoft.com",
 	}
 	for _, url := range httpUrls {
 		now, err := queryHttpTime(url, timeSyncTimeout)


### PR DESCRIPTION
Using the [this comprehensive list](https://gist.github.com/mutin-sa/eea1c396b1e610a2da1e5550d94b0453)

- Added pool.ntp.org at the top since it's globally distributed and isolated from specific manufacturers (and is what most routers default use)
- Added the other major network providers Google and AWS
- Added Windows to pair with Apple