### PR TITLE
feat: Add scroll sensitivity configuration and improved wheel event h…

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -764,6 +764,17 @@ func rpcSetCloudUrl(apiUrl string, appUrl string) error {
 	return nil
 }
 
+var currentScrollSensitivity string = "default"
+
+func rpcGetScrollSensitivity() (string, error) {
+	return currentScrollSensitivity, nil
+}
+
+func rpcSetScrollSensitivity(sensitivity string) error {
+	currentScrollSensitivity = sensitivity
+	return nil
+}
+
 var rpcHandlers = map[string]RPCHandler{
 	"ping":                   {Func: rpcPing},
 	"getDeviceID":            {Func: rpcGetDeviceID},
@@ -823,4 +834,6 @@ var rpcHandlers = map[string]RPCHandler{
 	"getSerialSettings":      {Func: rpcGetSerialSettings},
 	"setSerialSettings":      {Func: rpcSetSerialSettings, Params: []string{"settings"}},
 	"setCloudUrl":            {Func: rpcSetCloudUrl, Params: []string{"apiUrl", "appUrl"}},
+	"getScrollSensitivity":   {Func: rpcGetScrollSensitivity},
+	"setScrollSensitivity":   {Func: rpcSetScrollSensitivity, Params: []string{"sensitivity"}},
 }

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -306,6 +306,78 @@ export const useSettingsStore = create(
   ),
 );
 
+export interface DeviceSettingsState {
+  trackpadSensitivity: number;
+  mouseSensitivity: number;
+  clampMin: number;
+  clampMax: number;
+  blockDelay: number;
+  trackpadThreshold: number;
+  scrollSensitivity: "low" | "default" | "high";
+  setScrollSensitivity: (sensitivity: DeviceSettingsState["scrollSensitivity"]) => void;
+}
+
+export const useDeviceSettingsStore = create<DeviceSettingsState>(set => ({
+  trackpadSensitivity: 3.0,
+  mouseSensitivity: 5.0,
+  clampMin: -8,
+  clampMax: 8,
+  blockDelay: 25,
+  trackpadThreshold: 10,
+
+  scrollSensitivity: "default",
+  setScrollSensitivity: sensitivity => {
+    const wheelSettings: Record<
+      DeviceSettingsState["scrollSensitivity"],
+      {
+        trackpadSensitivity: DeviceSettingsState["trackpadSensitivity"];
+        mouseSensitivity: DeviceSettingsState["mouseSensitivity"];
+        clampMin: DeviceSettingsState["clampMin"];
+        clampMax: DeviceSettingsState["clampMax"];
+        blockDelay: DeviceSettingsState["blockDelay"];
+        trackpadThreshold: DeviceSettingsState["trackpadThreshold"];
+      }
+    > = {
+      low: {
+        trackpadSensitivity: 2.0,
+        mouseSensitivity: 3.0,
+        clampMin: -6,
+        clampMax: 6,
+        blockDelay: 30,
+        trackpadThreshold: 10,
+      },
+      default: {
+        trackpadSensitivity: 3.0,
+        mouseSensitivity: 5.0,
+        clampMin: -8,
+        clampMax: 8,
+        blockDelay: 25,
+        trackpadThreshold: 10,
+      },
+      high: {
+        trackpadSensitivity: 4.0,
+        mouseSensitivity: 6.0,
+        clampMin: -9,
+        clampMax: 9,
+        blockDelay: 20,
+        trackpadThreshold: 10,
+      },
+    };
+
+    const settings = wheelSettings[sensitivity];
+
+    return set({
+      trackpadSensitivity: settings.trackpadSensitivity,
+      trackpadThreshold: settings.trackpadThreshold,
+      mouseSensitivity: settings.mouseSensitivity,
+      clampMin: settings.clampMin,
+      clampMax: settings.clampMax,
+      blockDelay: settings.blockDelay,
+      scrollSensitivity: sensitivity,
+    });
+  },
+}));
+
 export interface RemoteVirtualMediaState {
   source: "WebRTC" | "HTTP" | "Storage" | null;
   mode: "CDROM" | "Disk" | null;

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -1,8 +1,10 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { cx } from "@/cva.config";
 import {
+  DeviceSettingsState,
   HidState,
   UpdateState,
+  useDeviceSettingsStore,
   useDeviceStore,
   useHidStore,
   useMountMediaStore,
@@ -428,18 +430,6 @@ export default function KvmIdRoute() {
     }
   }, [kvmTerminal, peerConnection, serialConsole]);
 
-  useEffect(() => {
-    kvmTerminal?.addEventListener("message", e => {
-      console.log(e.data);
-    });
-
-    return () => {
-      kvmTerminal?.removeEventListener("message", e => {
-        console.log(e.data);
-      });
-    };
-  }, [kvmTerminal]);
-
   const outlet = useOutlet();
   const location = useLocation();
   const onModalClose = useCallback(() => {
@@ -463,6 +453,21 @@ export default function KvmIdRoute() {
       }
     });
   }, [appVersion, send, setAppVersion, setSystemVersion]);
+
+  const setScrollSensitivity = useDeviceSettingsStore(
+    state => state.setScrollSensitivity,
+  );
+
+  // Initialize device settings
+  useEffect(
+    function initializeDeviceSettings() {
+      send("getScrollSensitivity", {}, resp => {
+        if ("error" in resp) return;
+        setScrollSensitivity(resp.result as DeviceSettingsState["scrollSensitivity"]);
+      });
+    },
+    [send, setScrollSensitivity],
+  );
 
   return (
     <FeatureFlagProvider appVersion={appVersion}>


### PR DESCRIPTION
Improve scrolling and add a setting for slow, default and High

Added a new store called DeviceSettingsStore. We should migrate all settings there and get all the relevant ones on page load. Currently, some settings are in Localstorage, and some stored on device - causes both confusion and bugs. We should move all the settings to the DeviceSettingsStore moving forward. Didn't want to blow this PR up, so migrating other settings will be done later.