### PR TITLE
fix: Logging cleanup

### DIFF
--- a/block_device.go
+++ b/block_device.go
@@ -142,7 +142,7 @@ func (d *NBDDevice) runClientConn() {
 		ExportName: "jetkvm",
 		BlockSize:  uint32(4 * 1024),
 	})
-	logger.Infof("nbd client exited: %w", err)
+	logger.Infof("nbd client exited: %v", err)
 }
 
 func (d *NBDDevice) Close() {

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -58,7 +58,7 @@ func setMassStorageMode(cdrom bool) error {
 }
 
 func onDiskMessage(msg webrtc.DataChannelMessage) {
-	fmt.Println("Disk Message, len:", len(msg.Data))
+	logger.Infof("Disk Message, len: %d", len(msg.Data))
 	diskReadChan <- msg.Data
 }
 
@@ -176,7 +176,7 @@ func rpcUnmountImage() error {
 	defer virtualMediaStateMutex.Unlock()
 	err := setMassStorageImage("\n")
 	if err != nil {
-		fmt.Println("Remove Mass Storage Image Error", err)
+		logger.Warnf("Remove Mass Storage Image Error: %v", err)
 	}
 	//TODO: check if we still need it
 	time.Sleep(500 * time.Millisecond)


### PR DESCRIPTION
* Cleanup additional `fmt.Println()` that should call logger.
* Use `%v` for logging errors.