### PR TITLE
chore: Enable more linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,22 @@
 ---
 linters:
   enable:
-  # - goimports
-  # - misspell
+  - forbidigo
+  - goimports
+  - misspell
   # - revive
+  - whitespace
 
 issues:
   exclude-rules:
     - path: _test.go
       linters:
         - errcheck
+
+linters-settings:
+  forbidigo:
+    forbid:
+      - p: ^fmt\.Print.*$
+        msg: Do not commit print statements. Use logger package.
+      - p: ^log\.(Fatal|Panic|Print)(f|ln)?.*$
+        msg: Do not commit log statements. Use logger package.

--- a/prometheus.go
+++ b/prometheus.go
@@ -1,14 +1,10 @@
 package kvm
 
 import (
-	"net/http"
-
 	"github.com/prometheus/client_golang/prometheus"
 	versioncollector "github.com/prometheus/client_golang/prometheus/collectors/version"
 	"github.com/prometheus/common/version"
 )
-
-var promHandler http.Handler
 
 func initPrometheus() {
 	// A Prometheus metrics endpoint.

--- a/serial.go
+++ b/serial.go
@@ -66,7 +66,6 @@ func runATXControl() {
 			newLedPWRState != ledPWRState ||
 			newBtnRSTState != btnRSTState ||
 			newBtnPWRState != btnPWRState {
-
 			logger.Debugf("Status changed: HDD LED: %v, PWR LED: %v, RST BTN: %v, PWR BTN: %v",
 				newLedHDDState, newLedPWRState, newBtnRSTState, newBtnPWRState)
 

--- a/web.go
+++ b/web.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/crypto/bcrypt"
 )
 
+//nolint:typecheck
 //go:embed all:static
 var staticFiles embed.FS
 
@@ -419,7 +420,6 @@ func handleSetup(c *gin.Context) {
 
 		// Set the cookie
 		c.SetCookie("authToken", config.LocalAuthToken, 7*24*60*60, "/", "", false, true)
-
 	} else {
 		// For noPassword mode, ensure the password field is empty
 		config.HashedPassword = ""

--- a/web_tls.go
+++ b/web_tls.go
@@ -8,10 +8,10 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/pem"
-	"log"
 	"math/big"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -38,7 +38,7 @@ func RunWebSecureServer() {
 		TLSConfig: &tls.Config{
 			// TODO: cache certificate in persistent storage
 			GetCertificate: func(info *tls.ClientHelloInfo) (*tls.Certificate, error) {
-				hostname := WebSecureSelfSignedDefaultDomain
+				var hostname string
 				if info.ServerName != "" {
 					hostname = info.ServerName
 				} else {
@@ -58,7 +58,6 @@ func RunWebSecureServer() {
 	if err != nil {
 		panic(err)
 	}
-	return
 }
 
 func createSelfSignedCert(hostname string) *tls.Certificate {
@@ -72,7 +71,8 @@ func createSelfSignedCert(hostname string) *tls.Certificate {
 
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	if err != nil {
-		log.Fatalf("Failed to generate private key: %v", err)
+		logger.Errorf("Failed to generate private key: %v", err)
+		os.Exit(1)
 	}
 	keyUsage := x509.KeyUsageDigitalSignature
 


### PR DESCRIPTION
Enable more golangci-lint linters.
* `forbidigo` to stop use of non-logger console printing.
* `goimports` to make sure `import` blocks are formatted nicely.
* `misspell` to catch spelling mistakes.
* `whitespace` to catch whitespace issues.