### PR TITLE
chore: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 10
+  - package-ecosystem: npm
+    directory: /ui
+    open-pull-requests-limit: 10
+    schedule:
+      interval: monthly


### PR DESCRIPTION
Enable dependabot to auto-update dependencies.
* Update montly to avoid too much PR noise.
* Enable updates for Go modules.
* Enable updates for GitHub Actions.
* Enable updates for NPM in /ui.