### PR TITLE
Improve connection error handling

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -19,7 +19,7 @@ import { HDMIErrorOverlay } from "./VideoOverlay";
 import { ConnectionErrorOverlay } from "./VideoOverlay";
 import { LoadingOverlay } from "./VideoOverlay";
 
-export default function WebRTCVideo() {
+export default function WebRTCVideo({ connectionFailed }: { connectionFailed: boolean }) {
   // Video and stream related refs and states
   const videoElm = useRef<HTMLVideoElement>(null);
   const mediaStream = useRTCStore(state => state.mediaStream);
@@ -47,9 +47,10 @@ export default function WebRTCVideo() {
   const hdmiState = useVideoStore(state => state.hdmiState);
   const hdmiError = ["no_lock", "no_signal", "out_of_range"].includes(hdmiState);
   const isLoading = !hdmiError && !isPlaying;
-  const isConnectionError = ["error", "failed", "disconnected"].includes(
-    peerConnectionState || "",
-  );
+  const isConnectionError =
+    ["error", "failed", "disconnected"].includes(peerConnectionState || "") ||
+    // Connection failed is passed from the parent component and becomes true after multiple failed connection attempts, indicating we should stop trying
+    connectionFailed;
 
   // Keyboard related states
   const { setIsNumLockActive, setIsCapsLockActive, setIsScrollLockActive } =

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -19,7 +19,7 @@ import { HDMIErrorOverlay } from "./VideoOverlay";
 import { ConnectionErrorOverlay } from "./VideoOverlay";
 import { LoadingOverlay } from "./VideoOverlay";
 
-export default function WebRTCVideo({ connectionFailed }: { connectionFailed: boolean }) {
+export default function WebRTCVideo() {
   // Video and stream related refs and states
   const videoElm = useRef<HTMLVideoElement>(null);
   const mediaStream = useRTCStore(state => state.mediaStream);
@@ -47,10 +47,9 @@ export default function WebRTCVideo({ connectionFailed }: { connectionFailed: bo
   const hdmiState = useVideoStore(state => state.hdmiState);
   const hdmiError = ["no_lock", "no_signal", "out_of_range"].includes(hdmiState);
   const isLoading = !hdmiError && !isPlaying;
-  const isConnectionError =
-    ["error", "failed", "disconnected"].includes(peerConnectionState || "") ||
-    // Connection failed is passed from the parent component and becomes true after multiple failed connection attempts, indicating we should stop trying
-    connectionFailed;
+  const isConnectionError = ["error", "failed", "disconnected", "closed"].includes(
+    peerConnectionState || "",
+  );
 
   // Keyboard related states
   const { setIsNumLockActive, setIsCapsLockActive, setIsScrollLockActive } =

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -182,7 +182,7 @@ export default function KvmIdRoute() {
       );
 
       // Fail connection if it's been over X seconds since we started connecting
-      if (elapsedTime > 1 * 1000) {
+      if (elapsedTime > 60 * 1000) {
         console.error(`Connection failed after ${elapsedTime} ms.`);
         setConnectionFailed(true);
         closePeerConnection();


### PR DESCRIPTION
The current error handling implementation assumes that the PeerConnection will declare failure when the user has an issue establishing a connection. This is not the case, often the PeerConnection will be "Connecting" forever.

This results in that the user never sees the Connection Error modal. This PR, implements a proper failure after either 30 connection attempts or 60s of time. After that, we show the Connection Error modal. 

The failures thresholds can be changed, but I started with a rather large retry limit and long timeout.


