### PR TITLE
fix: Shell linting

### DIFF
--- a/dev_deploy.sh
+++ b/dev_deploy.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/env bash
+#
 # Exit immediately if a command exits with a non-zero status
 set -e
 
@@ -16,7 +18,6 @@ show_help() {
     echo "Example:"
     echo "  $0 -r 192.168.0.17"
     echo "  $0 -r 192.168.0.17 -u admin"
-    exit 0
 }
 
 # Default values
@@ -70,10 +71,10 @@ cd bin
 ssh "${REMOTE_USER}@${REMOTE_HOST}" "killall jetkvm_app_debug || true"
 
 # Copy the binary to the remote host
-cat jetkvm_app | ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > $REMOTE_PATH/jetkvm_app_debug"
+ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > ${REMOTE_PATH}/jetkvm_app_debug" < jetkvm_app
 
 # Deploy and run the application on the remote host
-ssh "${REMOTE_USER}@${REMOTE_HOST}" ash <<EOF
+ssh "${REMOTE_USER}@${REMOTE_HOST}" ash << EOF
 set -e
 
 # Set the library path to include the directory where librockit.so is located
@@ -84,7 +85,7 @@ killall jetkvm_app || true
 killall jetkvm_app_debug || true
 
 # Navigate to the directory where the binary will be stored
-cd "$REMOTE_PATH"
+cd "${REMOTE_PATH}"
 
 # Make the new binary executable
 chmod +x jetkvm_app_debug

--- a/publish_source.sh
+++ b/publish_source.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if a commit message was provided
 if [ -z "$1" ]; then
@@ -26,7 +26,7 @@ git checkout -b release-temp
 if git ls-remote --heads public main | grep -q 'refs/heads/main'; then
     git reset --soft public/main
 else
-    git reset --soft $(git rev-list --max-parents=0 HEAD)
+    git reset --soft "$(git rev-list --max-parents=0 HEAD)"
 fi
 
 # Merge changes from main

--- a/ui/dev_device.sh
+++ b/ui/dev_device.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Check if an IP address was provided as an argument
 if [ -z "$1" ]; then


### PR DESCRIPTION
Cleanup various shell linting issues
* Use `/usr/bin/env` consistently for better platform compatibility.
* SC2317 (info): Command appears to be unreachable.
* SC2002 (style): Useless cat.