### PR TITLE
Feat/Trickle ice

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -76,7 +76,7 @@ var (
 	metricConnectionTotalPingCount = promauto.NewCounter(
 		prometheus.CounterOpts{
 			Name: "jetkvm_connection_total_ping_count",
-			Help: "The total number of pings sent to the",
+			Help: "The total number of pings sent to the connection",
 		},
 	)
 	metricConnectionSessionRequestCount = promauto.NewCounter(

--- a/cloud.go
+++ b/cloud.go
@@ -272,7 +272,7 @@ func runWebsocketClient() error {
 	// set the metrics when we successfully connect to the cloud.
 	cloudResetMetrics(true)
 
-	return handleWebRTCSignalWsConnection(c, true)
+	return handleWebRTCSignalWsMessages(c, true)
 }
 
 func authenticateSession(ctx context.Context, c *websocket.Conn, req WebRTCSessionRequest) error {

--- a/cloud.go
+++ b/cloud.go
@@ -268,6 +268,7 @@ func runWebsocketClient() error {
 
 	header := http.Header{}
 	header.Set("X-Device-ID", GetDeviceID())
+	header.Set("X-App-Version", builtAppVersion)
 	header.Set("Authorization", "Bearer "+config.CloudToken)
 	dialCtx, cancelDial := context.WithTimeout(context.Background(), CloudWebSocketConnectTimeout)
 

--- a/cloud.go
+++ b/cloud.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/coder/websocket/wsjson"
@@ -119,6 +120,11 @@ var (
 			Help: "The number of times the cloud connection has failed",
 		},
 	)
+)
+
+var (
+	cloudDisconnectChan chan error
+	cloudDisconnectLock = &sync.Mutex{}
 )
 
 func wsResetMetrics(established bool, sourceType string, source string) {

--- a/dev_deploy.sh
+++ b/dev_deploy.sh
@@ -67,10 +67,10 @@ make build_dev
 cd bin
 
 # Kill any existing instances of the application
-ssh "${REMOTE_USER}@${REMOTE_HOST}" "killall jetkvm_app || true"
+ssh "${REMOTE_USER}@${REMOTE_HOST}" "killall jetkvm_app_debug || true"
 
 # Copy the binary to the remote host
-cat jetkvm_app | ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > $REMOTE_PATH/jetkvm_app"
+cat jetkvm_app | ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > $REMOTE_PATH/jetkvm_app_debug"
 
 # Deploy and run the application on the remote host
 ssh "${REMOTE_USER}@${REMOTE_HOST}" ash <<EOF
@@ -81,16 +81,16 @@ export LD_LIBRARY_PATH=/oem/usr/lib:\$LD_LIBRARY_PATH
 
 # Kill any existing instances of the application
 killall jetkvm_app || true
-killall jetkvm_app || true
+killall jetkvm_app_debug || true
 
 # Navigate to the directory where the binary will be stored
 cd "$REMOTE_PATH"
 
 # Make the new binary executable
-chmod +x jetkvm_app
+chmod +x jetkvm_app_debug
 
 # Run the application in the background
-PION_LOG_TRACE=jetkvm,cloud ./jetkvm_app
+PION_LOG_TRACE=jetkvm,cloud ./jetkvm_app_debug
 EOF
 
 echo "Deployment complete."

--- a/dev_deploy.sh
+++ b/dev_deploy.sh
@@ -67,10 +67,10 @@ make build_dev
 cd bin
 
 # Kill any existing instances of the application
-ssh "${REMOTE_USER}@${REMOTE_HOST}" "killall jetkvm_app_debug || true"
+ssh "${REMOTE_USER}@${REMOTE_HOST}" "killall jetkvm_app || true"
 
 # Copy the binary to the remote host
-cat jetkvm_app | ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > $REMOTE_PATH/jetkvm_app_debug"
+cat jetkvm_app | ssh "${REMOTE_USER}@${REMOTE_HOST}" "cat > $REMOTE_PATH/jetkvm_app"
 
 # Deploy and run the application on the remote host
 ssh "${REMOTE_USER}@${REMOTE_HOST}" ash <<EOF
@@ -81,16 +81,16 @@ export LD_LIBRARY_PATH=/oem/usr/lib:\$LD_LIBRARY_PATH
 
 # Kill any existing instances of the application
 killall jetkvm_app || true
-killall jetkvm_app_debug || true
+killall jetkvm_app || true
 
 # Navigate to the directory where the binary will be stored
 cd "$REMOTE_PATH"
 
 # Make the new binary executable
-chmod +x jetkvm_app_debug
+chmod +x jetkvm_app
 
 # Run the application in the background
-PION_LOG_TRACE=jetkvm,cloud ./jetkvm_app_debug
+PION_LOG_TRACE=jetkvm,cloud ./jetkvm_app
 EOF
 
 echo "Deployment complete."

--- a/log.go
+++ b/log.go
@@ -6,3 +6,4 @@ import "github.com/pion/logging"
 // ref: https://github.com/pion/webrtc/wiki/Debugging-WebRTC
 var logger = logging.NewDefaultLoggerFactory().NewLogger("jetkvm")
 var cloudLogger = logging.NewDefaultLoggerFactory().NewLogger("cloud")
+var websocketLogger = logging.NewDefaultLoggerFactory().NewLogger("websocket")

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -30,6 +30,7 @@
         "react-icons": "^5.4.0",
         "react-router-dom": "^6.22.3",
         "react-simple-keyboard": "^3.7.112",
+        "react-use-websocket": "^4.13.0",
         "react-xtermjs": "^1.0.9",
         "recharts": "^2.15.0",
         "tailwind-merge": "^2.5.5",
@@ -5179,6 +5180,11 @@
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
       }
+    },
+    "node_modules/react-use-websocket": {
+      "version": "4.13.0",
+      "resolved": "https://registry.npmjs.org/react-use-websocket/-/react-use-websocket-4.13.0.tgz",
+      "integrity": "sha512-anMuVoV//g2N76Wxqvqjjo1X48r9Np3y1/gMl7arX84tAPXdy5R7sB5lO5hvCzQRYjqXwV8XMAiEBOUbyrZFrw=="
     },
     "node_modules/react-xtermjs": {
       "version": "1.0.9",

--- a/ui/package.json
+++ b/ui/package.json
@@ -40,6 +40,7 @@
     "react-icons": "^5.4.0",
     "react-router-dom": "^6.22.3",
     "react-simple-keyboard": "^3.7.112",
+    "react-use-websocket": "^4.13.0",
     "react-xtermjs": "^1.0.9",
     "recharts": "^2.15.0",
     "tailwind-merge": "^2.5.5",

--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -36,7 +36,7 @@ export default function DashboardNavbar({
   picture,
   kvmName,
 }: NavbarProps) {
-  const peerConnection = useRTCStore(state => state.peerConnection);
+  const peerConnectionState = useRTCStore(state => state.peerConnectionState);
   const setUser = useUserStore(state => state.setUser);
   const navigate = useNavigate();
   const onLogout = useCallback(async () => {
@@ -82,14 +82,14 @@ export default function DashboardNavbar({
                 <div className="hidden items-center gap-x-2 md:flex">
                   <div className="w-[159px]">
                     <PeerConnectionStatusCard
-                      state={peerConnection?.connectionState}
+                      state={peerConnectionState}
                       title={kvmName}
                     />
                   </div>
                   <div className="hidden w-[159px] md:block">
                     <USBStateStatus
                       state={usbState}
-                      peerConnectionState={peerConnection?.connectionState}
+                        peerConnectionState={peerConnectionState}
                     />
                   </div>
                 </div>

--- a/ui/src/components/VideoOverlay.tsx
+++ b/ui/src/components/VideoOverlay.tsx
@@ -94,7 +94,7 @@ interface ConnectionErrorOverlayProps {
   setupPeerConnection: () => Promise<void>;
 }
 
-export function ConnectionErrorOverlay({
+export function ConnectionFailedOverlay({
   show,
   setupPeerConnection,
 }: ConnectionErrorOverlayProps) {
@@ -140,6 +140,57 @@ export function ConnectionErrorOverlay({
                       size="SM"
                       theme="light"
                     />
+                  </div>
+                </div>
+              </div>
+            </div>
+          </OverlayContent>
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}
+
+interface PeerConnectionDisconnectedOverlay {
+  show: boolean;
+  setupPeerConnection: () => Promise<void>;
+}
+
+export function PeerConnectionDisconnectedOverlay({ show }: ConnectionErrorOverlayProps) {
+  return (
+    <AnimatePresence>
+      {show && (
+        <motion.div
+          className="aspect-video h-full w-full"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0, transition: { duration: 0 } }}
+          transition={{
+            duration: 0.4,
+            ease: "easeInOut",
+          }}
+        >
+          <OverlayContent>
+            <div className="flex flex-col items-start gap-y-1">
+              <ExclamationTriangleIcon className="h-12 w-12 text-yellow-500" />
+              <div className="text-left text-sm text-slate-700 dark:text-slate-300">
+                <div className="space-y-4">
+                  <div className="space-y-2 text-black dark:text-white">
+                    <h2 className="text-xl font-bold">Connection Issue Detected</h2>
+                    <ul className="list-disc space-y-2 pl-4 text-left">
+                      <li>Verify that the device is powered on and properly connected</li>
+                      <li>Check all cable connections for any loose or damaged wires</li>
+                      <li>Ensure your network connection is stable and active</li>
+                      <li>Try restarting both the device and your computer</li>
+                    </ul>
+                  </div>
+                  <div className="flex items-center gap-x-2">
+                    <div className="flex flex-col items-center gap-y-2">
+                      <LoadingSpinner className="h-4 w-4 text-blue-800 dark:text-blue-200" />
+                      <p className="text-sm text-slate-700 dark:text-slate-300">
+                        Retrying connection...
+                      </p>
+                    </div>
                   </div>
                 </div>
               </div>

--- a/ui/src/components/VideoOverlay.tsx
+++ b/ui/src/components/VideoOverlay.tsx
@@ -6,7 +6,7 @@ import { LuPlay } from "react-icons/lu";
 
 import { Button, LinkButton } from "@components/Button";
 import LoadingSpinner from "@components/LoadingSpinner";
-import { GridCard } from "@components/Card";
+import Card, { GridCard } from "@components/Card";
 
 interface OverlayContentProps {
   children: React.ReactNode;
@@ -153,10 +153,11 @@ export function ConnectionFailedOverlay({
 
 interface PeerConnectionDisconnectedOverlay {
   show: boolean;
-  setupPeerConnection: () => Promise<void>;
 }
 
-export function PeerConnectionDisconnectedOverlay({ show }: ConnectionErrorOverlayProps) {
+export function PeerConnectionDisconnectedOverlay({
+  show,
+}: PeerConnectionDisconnectedOverlay) {
   return (
     <AnimatePresence>
       {show && (
@@ -185,12 +186,14 @@ export function PeerConnectionDisconnectedOverlay({ show }: ConnectionErrorOverl
                     </ul>
                   </div>
                   <div className="flex items-center gap-x-2">
-                    <div className="flex flex-col items-center gap-y-2">
-                      <LoadingSpinner className="h-4 w-4 text-blue-800 dark:text-blue-200" />
-                      <p className="text-sm text-slate-700 dark:text-slate-300">
-                        Retrying connection...
-                      </p>
-                    </div>
+                    <Card>
+                      <div className="flex items-center gap-x-2 p-4">
+                        <LoadingSpinner className="h-4 w-4 text-blue-800 dark:text-blue-200" />
+                        <p className="text-sm text-slate-700 dark:text-slate-300">
+                          Retrying connection...
+                        </p>
+                      </div>
+                    </Card>
                   </div>
                 </div>
               </div>

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -380,7 +380,7 @@ export default function WebRTCVideo() {
     (mediaStream: MediaStream) => {
       if (!videoElm.current) return;
       const videoElmRefValue = videoElm.current;
-      console.log("Adding stream to video element", videoElmRefValue);
+      // console.log("Adding stream to video element", videoElmRefValue);
       videoElmRefValue.srcObject = mediaStream;
       updateVideoSizeStore(videoElmRefValue);
     },
@@ -396,7 +396,7 @@ export default function WebRTCVideo() {
       peerConnection.addEventListener(
         "track",
         (e: RTCTrackEvent) => {
-          console.log("Adding stream to video element");
+          // console.log("Adding stream to video element");
           addStreamToVideoElm(e.streams[0]);
         },
         { signal },

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -232,10 +232,12 @@ export default function KvmIdRoute() {
   const isSettingRemoteAnswerPending = useRef(false);
   const makingOffer = useRef(false);
 
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+
   console.log("isondevice", isOnDevice);
   const { sendMessage } = useWebSocket(
     isOnDevice
-      ? `ws://${window.location.host}/webrtc/signaling`
+      ? `${wsProtocol}//${window.location.host}/webrtc/signaling`
       : `${CLOUD_API.replace("http", "ws")}/webrtc/signaling?id=${params.id}`,
     {
       heartbeat: true,

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -287,7 +287,7 @@ export default function KvmIdRoute() {
           if (ignoreOffer.current) return;
 
           // Set so we don't accept an answer while we're setting the remote description
-          isSettingRemoteAnswerPending.current = parsedMessage.type == "answer";
+          isSettingRemoteAnswerPending.current = parsedMessage.type === "answer";
           console.log(
             "[Websocket] Setting remote answer pending",
             isSettingRemoteAnswerPending.current,

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -232,9 +232,10 @@ export default function KvmIdRoute() {
   const isSettingRemoteAnswerPending = useRef(false);
   const makingOffer = useRef(false);
 
+  console.log("isondevice", isOnDevice);
   const { sendMessage } = useWebSocket(
     isOnDevice
-      ? `ws://192.168.1.77/webrtc/signaling`
+      ? `ws://${window.location.host}/webrtc/signaling`
       : `${CLOUD_API.replace("http", "ws")}/webrtc/signaling?id=${params.id}`,
     {
       heartbeat: true,

--- a/web.go
+++ b/web.go
@@ -98,7 +98,7 @@ func setupRouter() *gin.Engine {
 	protected := r.Group("/")
 	protected.Use(protectedMiddleware())
 	{
-		protected.GET("/webrtc/signaling", handLocalWebRTCSignal)
+		protected.GET("/webrtc/signaling", handleLocalWebRTCSignal)
 		protected.POST("/webrtc/session", handleWebRTCSession)
 		protected.POST("/cloud/register", handleCloudRegister)
 		protected.GET("/cloud/state", handleCloudState)
@@ -126,7 +126,7 @@ func setupRouter() *gin.Engine {
 // TODO: support multiple sessions?
 var currentSession *Session
 
-func handLocalWebRTCSignal(c *gin.Context) {
+func handleLocalWebRTCSignal(c *gin.Context) {
 	cloudLogger.Infof("new websocket connection established")
 	// Create WebSocket options with InsecureSkipVerify to bypass origin check
 	wsOptions := &websocket.AcceptOptions{

--- a/web.go
+++ b/web.go
@@ -145,7 +145,11 @@ func handleLocalWebRTCSignal(c *gin.Context) {
 	// Now use conn for websocket operations
 	defer wsCon.Close(websocket.StatusNormalClosure, "")
 
-	wsjson.Write(context.Background(), wsCon, gin.H{"type": "device-metadata", "data": gin.H{"deviceVersion": builtAppVersion}})
+	err = wsjson.Write(context.Background(), wsCon, gin.H{"type": "device-metadata", "data": gin.H{"deviceVersion": builtAppVersion}})
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
 
 	err = handleWebRTCSignalWsMessages(wsCon, false, source)
 	if err != nil {

--- a/web.go
+++ b/web.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/pion/webrtc/v4"
@@ -98,7 +99,7 @@ func setupRouter() *gin.Engine {
 	protected := r.Group("/")
 	protected.Use(protectedMiddleware())
 	{
-		protected.GET("/webrtc/signaling", handleLocalWebRTCSignal)
+		protected.GET("/webrtc/signaling/client", handleLocalWebRTCSignal)
 		protected.POST("/cloud/register", handleCloudRegister)
 		protected.GET("/cloud/state", handleCloudState)
 		protected.GET("/device", handleDevice)
@@ -143,6 +144,9 @@ func handleLocalWebRTCSignal(c *gin.Context) {
 
 	// Now use conn for websocket operations
 	defer wsCon.Close(websocket.StatusNormalClosure, "")
+
+	wsjson.Write(context.Background(), wsCon, gin.H{"type": "device-metadata", "data": gin.H{"deviceVersion": builtAppVersion}})
+
 	err = handleWebRTCSignalWsMessages(wsCon, false, source)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})

--- a/webrtc.go
+++ b/webrtc.go
@@ -1,11 +1,15 @@
 package kvm
 
 import (
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"net"
 	"strings"
 
+	"github.com/coder/websocket"
+	"github.com/coder/websocket/wsjson"
+	"github.com/gin-gonic/gin"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -23,6 +27,7 @@ type SessionConfig struct {
 	ICEServers []string
 	LocalIP    string
 	IsCloud    bool
+	ws         *websocket.Conn
 }
 
 func (s *Session) ExchangeOffer(offerStr string) (string, error) {
@@ -46,18 +51,10 @@ func (s *Session) ExchangeOffer(offerStr string) (string, error) {
 		return "", err
 	}
 
-	// Create channel that is blocked until ICE Gathering is complete
-	gatherComplete := webrtc.GatheringCompletePromise(s.peerConnection)
-
 	// Sets the LocalDescription, and starts our UDP listeners
 	if err = s.peerConnection.SetLocalDescription(answer); err != nil {
 		return "", err
 	}
-
-	// Block until ICE Gathering is complete, disabling trickle ICE
-	// we do this because we only can exchange one signaling message
-	// in a production application you should exchange ICE Candidates via OnICECandidate
-	<-gatherComplete
 
 	localDescription, err := json.Marshal(s.peerConnection.LocalDescription())
 	if err != nil {
@@ -143,6 +140,13 @@ func newSession(config SessionConfig) (*Session, error) {
 		}
 	}()
 	var isConnected bool
+
+	peerConnection.OnICECandidate(func(candidate *webrtc.ICECandidate) {
+		cloudLogger.Infof("we got a new ICE candidate: %v", candidate)
+		if candidate != nil {
+			wsjson.Write(context.Background(), config.ws, gin.H{"type": "new-ice-candidate", "data": candidate.ToJSON()})
+		}
+	})
 
 	peerConnection.OnICEConnectionStateChange(func(connectionState webrtc.ICEConnectionState) {
 		logger.Infof("Connection State has changed %s", connectionState)

--- a/webrtc.go
+++ b/webrtc.go
@@ -144,7 +144,10 @@ func newSession(config SessionConfig) (*Session, error) {
 	peerConnection.OnICECandidate(func(candidate *webrtc.ICECandidate) {
 		logger.Infof("Our WebRTC peerConnection has a new ICE candidate: %v", candidate)
 		if candidate != nil {
-			wsjson.Write(context.Background(), config.ws, gin.H{"type": "new-ice-candidate", "data": candidate.ToJSON()})
+			err := wsjson.Write(context.Background(), config.ws, gin.H{"type": "new-ice-candidate", "data": candidate.ToJSON()})
+			if err != nil {
+				logger.Errorf("failed to write new-ice-candidate to WebRTC signaling channel: %v", err)
+			}
 		}
 	})
 

--- a/webrtc.go
+++ b/webrtc.go
@@ -142,7 +142,7 @@ func newSession(config SessionConfig) (*Session, error) {
 	var isConnected bool
 
 	peerConnection.OnICECandidate(func(candidate *webrtc.ICECandidate) {
-		cloudLogger.Infof("AAAAAAA got a new ICE candidate: %v", candidate)
+		logger.Infof("Our WebRTC peerConnection has a new ICE candidate: %v", candidate)
 		if candidate != nil {
 			wsjson.Write(context.Background(), config.ws, gin.H{"type": "new-ice-candidate", "data": candidate.ToJSON()})
 		}

--- a/webrtc.go
+++ b/webrtc.go
@@ -142,7 +142,7 @@ func newSession(config SessionConfig) (*Session, error) {
 	var isConnected bool
 
 	peerConnection.OnICECandidate(func(candidate *webrtc.ICECandidate) {
-		cloudLogger.Infof("we got a new ICE candidate: %v", candidate)
+		cloudLogger.Infof("AAAAAAA got a new ICE candidate: %v", candidate)
 		if candidate != nil {
 			wsjson.Write(context.Background(), config.ws, gin.H{"type": "new-ice-candidate", "data": candidate.ToJSON()})
 		}


### PR DESCRIPTION
Previously, the device connected to the cloud API with a WebSocket and just waited. On the client side, the browser would create a peer connection, gather all ICE candidates, then send a long-running HTTP request to the API. The API would look up the right WebSocket connection, forward the session description from the HTTP request, and wait for a response over WS - all while keeping the HTTP request open. Once the device sent back the remote session description over WS, the HTTP request would return it. This setup was a bit fragile.

In local mode, we just did that HTTP request to the device, and it responded with the remote session description.

With this implementation, we implement what MDN calls [the perfect negotiation pattern](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API/Perfect_negotiation) which does Trickle ICE. Instead of waiting for all the ICE candidates, we simply send them once they are ready. For this, we need 2-way communication, so both peers can update each other at any given time. 

We chose WebSocket as the transport layer. In cloud mode, the Cloud API now just proxies WebSocket messages - no more long-running HTTP. In local mode, the device runs its own WebSocket server, and the client connects directly to it.

In addition to implementing "Trickle ICE", we also added:
- Better retry mechanism - Much easier to follow now
- Proper failure modes for known connection issues, like the ones in our [docs](https://jetkvm.com/docs/getting-started/troubleshooting)
- Informative Loading screens, with real connection information. No more "Loading video stream…" 
- Improved logging to pinpoint exactly where things fail.

Overall, this will at best solve a lot of the standing connection issues, at worst it will give us a lot of troubleshooting opportunity with the new logs.

Note: 
- In cloud mode, you need the Cloud API changes. I'm currently working on tidying up the code, should soon have a PR. Just try in local mode for now.
- There are some To-dos left - I will address those
- Spoke with @ym about the Prometheus metrics, and he will properly tag then in the PR, so the consumer knows what the metrics are about.

Create in draft mode, but the branch in fully testable - no major changes expected