### PR TITLE
Re-add old signaling for when upgrading

### DIFF
--- a/web.go
+++ b/web.go
@@ -99,7 +99,6 @@ func setupRouter() *gin.Engine {
 	protected := r.Group("/")
 	protected.Use(protectedMiddleware())
 	{
-
 		/*
 		 * Legacy WebRTC session endpoint
 		 *


### PR DESCRIPTION
The Legacy WebRTC session endpoint is maintained for backward compatibility when users upgrade from a version using the legacy HTTP-based signaling method to the new Web Socket-based signaling method.

During the upgrade process, when the "Rebooting device after update..." message appears, the browser still runs the previous JavaScript code which polls this endpoint to establish a new WebRTC session. Once the session is established, the page will automatically reload with the updated code.

Without this endpoint, the stale JavaScript would fail to establish a connection, causing users to see the "Rebooting device after update..." message indefinitely until they manually refresh the page, leading to a confusing user experience.
