### PR TITLE
feat: set hardware clock after NTP sync, fix#319

### DIFF
--- a/ntp.go
+++ b/ntp.go
@@ -193,5 +193,9 @@ func setSystemTime(now time.Time) error {
 	if err != nil {
 		return fmt.Errorf("failed to run date -s: %w, %s", err, string(output))
 	}
+	output, err = exec.Command("hwclock", "-w").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("failed to run hwclock -w: %w, %s", err, string(output))
+	}
 	return nil
 }


### PR DESCRIPTION
Not synchronising the hardware clock causes the time to be lost on next reboot, making features such as OTA updates check fail.