### PR TITLE
Fix: Alt Gr not recognized

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -332,18 +332,19 @@ export default function WebRTCVideo() {
           // Example: If altKey is true, keep all modifiers
           // If altKey is false, filter out 0x04 (AltLeft)
           //
-          // But intentionally do not filter out 0x40 (AltRight) to enable Alt Gr (Alt Graph)
-          // as a modifier. The altKey attribute is not set on key combinations involving the
-          // Alt Gr key, which means the modifier would otherwise unintentionally disappear
-          // from the filteredModifiers list.
+          // But intentionally do not filter out 0x40 (AltRight) to enable Alt Gr
+          // (Alt Graph) as a modifier. The `altKey` attribute is set to `false` on
+          // key combinations involving the Alt Gr key, which means the modifier
+          // would otherwise be unintentionally removed from the filteredModifiers
+          // list.
           //
           // For example, the KeyboardEvent for Alt Gr + 2 has the following structure:
           // - altKey: false
           // - code:   "Digit2"
           // - type:   ["keydown" | "keyup"]
           //
-          // Adding and removing 0x40 (AltRight) from and to the list of active modifiers is
-          // taken care of by the respective logic in the keyUpHandler an keyDownHandler.
+          // Adding and removing 0x40 (AltRight) from and to the list of active
+          // modifiers is handled by keyUpHandler an keyDownHandler.
           .filter(
             modifier =>
               altKey ||

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -330,11 +330,11 @@ export default function WebRTCVideo() {
           )
           // Alt: Keep if Alt is pressed or if the key isn't an Alt key
           // Example: If altKey is true, keep all modifiers
-          // If altKey is false, filter out 0x04 (AltLeft) and 0x40 (AltRight)
+          // If altKey is false, filter out 0x04 (AltLeft) and 0x40 (AltGraph)
           .filter(
             modifier =>
               altKey ||
-              (modifier !== modifiers["AltLeft"] && modifier !== modifiers["AltRight"]),
+              (modifier !== modifiers["AltLeft"] && modifier !== modifiers["AltGraph"]),
           )
           // Meta: Keep if Meta is pressed or if the key isn't a Meta key
           // Example: If metaKey is true, keep all modifiers

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -333,7 +333,7 @@ export default function WebRTCVideo() {
           // If altKey is false, filter out 0x04 (AltLeft)
           //
           // But intentionally do not filter out 0x40 (AltRight) to enable Alt Gr
-          // (Alt Graph) as a modifier. The `altKey` attribute is set to `false` on
+          // (Alt Graph) as a modifier. The altKey attribute is set to false on
           // key combinations involving the Alt Gr key, which means the modifier
           // would otherwise be unintentionally removed from the filteredModifiers
           // list.
@@ -341,7 +341,7 @@ export default function WebRTCVideo() {
           // For example, the KeyboardEvent for Alt Gr + 2 has the following structure:
           // - altKey: false
           // - code:   "Digit2"
-          // - type:   ["keydown" | "keyup"]
+          // - type:   ["keydown"|"keyup"]
           //
           // Adding and removing 0x40 (AltRight) from and to the list of active
           // modifiers is handled by keyUpHandler an keyDownHandler.

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -330,11 +330,18 @@ export default function WebRTCVideo() {
           )
           // Alt: Keep if Alt is pressed or if the key isn't an Alt key
           // Example: If altKey is true, keep all modifiers
-          // If altKey is false, filter out 0x04 (AltLeft) and 0x40 (AltGraph)
+          // If altKey is false, filter out 0x04 (AltLeft)
+          //
+          // Special case: Despite the Alt-Gr key being pressed, `altKey' on
+          // the event `e' is set to `false'. This means we cannot detect if Alt-Gr
+          // is being pressed while the user e.g. presses the `2' key. Instead, we
+          // we need to rely on keyUpHandler/keyDownHandler to toggle the state
+          // for 0x40 (AltRight) and avoid filtering for this code here, so that we
+          // can remember the state of the Alt-Gr modifier on subsequent key presses.
           .filter(
             modifier =>
               altKey ||
-              (modifier !== modifiers["AltLeft"] && modifier !== modifiers["AltGraph"]),
+              (modifier !== modifiers["AltLeft"]),
           )
           // Meta: Keep if Meta is pressed or if the key isn't a Meta key
           // Example: If metaKey is true, keep all modifiers

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -332,12 +332,18 @@ export default function WebRTCVideo() {
           // Example: If altKey is true, keep all modifiers
           // If altKey is false, filter out 0x04 (AltLeft)
           //
-          // Special case: Despite the Alt-Gr key being pressed, `altKey' on
-          // the event `e' is set to `false'. This means we cannot detect if Alt-Gr
-          // is being pressed while the user e.g. presses the `2' key. Instead, we
-          // we need to rely on keyUpHandler/keyDownHandler to toggle the state
-          // for 0x40 (AltRight) and avoid filtering for this code here, so that we
-          // can remember the state of the Alt-Gr modifier on subsequent key presses.
+          // But intentionally do not filter out 0x40 (AltRight) to enable Alt Gr (Alt Graph)
+          // as a modifier. The altKey attribute is not set on key combinations involving the
+          // Alt Gr key, which means the modifier would otherwise unintentionally disappear
+          // from the filteredModifiers list.
+          //
+          // For example, the KeyboardEvent for Alt Gr + 2 has the following structure:
+          // - altKey: false
+          // - code:   "Digit2"
+          // - type:   ["keydown" | "keyup"]
+          //
+          // Adding and removing 0x40 (AltRight) from and to the list of active modifiers is
+          // taken care of by the respective logic in the keyUpHandler an keyDownHandler.
           .filter(
             modifier =>
               altKey ||

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -332,19 +332,25 @@ export default function WebRTCVideo() {
           // Example: If altKey is true, keep all modifiers
           // If altKey is false, filter out 0x04 (AltLeft)
           //
-          // But intentionally do not filter out 0x40 (AltRight) to enable Alt Gr
-          // (Alt Graph) as a modifier. The altKey attribute is set to false on
-          // key combinations involving the Alt Gr key, which means the modifier
-          // would otherwise be unintentionally removed from the filteredModifiers
-          // list.
-          //
-          // For example, the KeyboardEvent for Alt Gr + 2 has the following structure:
+          // But intentionally do not filter out 0x40 (AltRight) to accomodate
+          // Alt Gr (Alt Graph) as a modifier. Oddly, Alt Gr does not declare
+          // itself to be an altKey. For example, the KeyboardEvent for
+          // Alt Gr + 2 has the following structure:
           // - altKey: false
           // - code:   "Digit2"
-          // - type:   ["keydown"|"keyup"]
+          // - type:   [ "keydown" | "keyup" ]
           //
-          // Adding and removing 0x40 (AltRight) from and to the list of active
-          // modifiers is handled by keyUpHandler an keyDownHandler.
+          // For context, filteredModifiers aims to keep track which modifiers
+          // are being pressed on the physical keyboard at any point in time.
+          // There is logic in the keyUpHandler and keyDownHandler to add and
+          // remove 0x40 (AltRight) from the list of new modifiers.
+          //
+          // But relying on the two handlers alone to track the state of the
+          // modifier bears the risk that the key up event for Alt Gr could
+          // get lost while the browser window is temporarily out of focus,
+          // which means the Alt Gr key state would then be "stuck". At this
+          // point, we would need to rely on the user to press Alt Gr again
+          // to properly release the state of that modifier.
           .filter(
             modifier =>
               altKey ||

--- a/ui/src/keyboardMappings.ts
+++ b/ui/src/keyboardMappings.ts
@@ -1,3 +1,5 @@
+// Key codes and modifiers correspond to definitions in the
+// [Linux USB HID gadget driver](https://www.kernel.org/doc/Documentation/usb/gadget_hid.txt)
 export const keys = {
   ArrowDown: 0x51,
   ArrowLeft: 0x50,

--- a/ui/src/keyboardMappings.ts
+++ b/ui/src/keyboardMappings.ts
@@ -99,6 +99,7 @@ export const keys = {
   Tab: 0x2b,
 } as Record<string, number>;
 
+// Mapping from characters entered into "Paste text" box to key codes and modifiers
 export const chars = {
   A: { key: "KeyA", shift: true },
   B: { key: "KeyB", shift: true },

--- a/ui/src/keyboardMappings.ts
+++ b/ui/src/keyboardMappings.ts
@@ -1,6 +1,4 @@
 export const keys = {
-  AltLeft: 0xe2,
-  AltRight: 0xe6,
   ArrowDown: 0x51,
   ArrowLeft: 0x50,
   ArrowRight: 0x4f,

--- a/ui/src/keyboardMappings.ts
+++ b/ui/src/keyboardMappings.ts
@@ -99,7 +99,6 @@ export const keys = {
   Tab: 0x2b,
 } as Record<string, number>;
 
-// Mapping from characters entered into "Paste text" box to key codes and modifiers
 export const chars = {
   A: { key: "KeyA", shift: true },
   B: { key: "KeyB", shift: true },


### PR DESCRIPTION
This PR fixes the Alt Graph key not being recognized.

Provides fixes for #30, #118, #313.

This can be tested by adding following log statements to `internal/usbgadget/hid_keyboard.go`:

```golang
func (u *UsbGadget) keyboardWriteHidFile(data []byte) error {
        if u.keyboardHidFile == nil {
                var err error
                u.keyboardHidFile, err = os.OpenFile("/dev/hidg0", os.O_RDWR, 0666)
                if err != nil {
                        return fmt.Errorf("failed to open hidg0: %w", err)
                }
        }

        fmt.Println("-- hid_keyboard --")
        fmt.Printf("modf: 0x%x\n", data[0])
        fmt.Printf("key1: 0x%x\n", data[2])
        fmt.Printf("key2: 0x%x\n", data[3])
        fmt.Printf("key3: 0x%x\n", data[4])
        fmt.Printf("key4: 0x%x\n", data[5])
        fmt.Printf("key5: 0x%x\n", data[6])
        fmt.Printf("key6: 0x%x\n", data[7])
        fmt.Println("------------------")

        _, err := u.keyboardHidFile.Write(data)
        if err != nil {
                u.log.Error().Err(err).Msg("failed to write to hidg0")
                u.keyboardHidFile.Close()
                u.keyboardHidFile = nil
                return err
        }

        return nil
}
```

The correct output after applying this PR for pressing Alt-Gr + 2 is:

```
-- hid_keyboard --
modf: 0x40
key1: 0x1f
key2: 0x0
key3: 0x0
key4: 0x0
key5: 0x0
key6: 0x0
------------------
```

Previously, JetKVM would output this instead:

```
-- hid_keyboard --
modf: 0x0
key1: 0xe6
key2: 0x0
key3: 0x0
key4: 0x0
key5: 0x0
key6: 0x0
------------------
```

Alternatively, the `keyboardReport` log entries can be observed (I did not initially know about it when investigating this issue).

The key codes correspond to definitions in the [Linux USB HID gadget driver](https://www.kernel.org/doc/Documentation/usb/gadget_hid.txt).

Steps to validate:

1. Use [Swiss German](https://kbdlayout.info/KBDSG/) keyboard on your host computer
2. Start Debian Linux with Gnome on the computer attached to JetKVM
3. Configure `German (Switzerland)` as keyboard layout on the computer attached to JetKVM
4. Open LibreOffice Writer
5. Type Alt Gr + 2 (for the `@` sign). Previously: this would output `2`, now it outputs `@`

![image](https://github.com/user-attachments/assets/cfb32d88-bb1c-4afb-8039-83aff5c6ecd7)
