### PR TITLE
ntp: fix panic on NTP query error and add IPv6 server for IPv6-only support

### DIFF
--- a/internal/timesync/ntp.go
+++ b/internal/timesync/ntp.go
@@ -13,7 +13,8 @@ var defaultNTPServers = []string{
 	"time.aws.com",
 	"time.windows.com",
 	"time.google.com",
-	"162.159.200.123", // time.cloudflare.com
+	"162.159.200.123",   // time.cloudflare.com IPv4
+	"2606:4700:f1::123", // time.cloudflare.com IPv6
 	"0.pool.ntp.org",
 	"1.pool.ntp.org",
 	"2.pool.ntp.org",
@@ -57,6 +58,12 @@ func (t *TimeSync) queryMultipleNTP(servers []string, timeout time.Duration) (no
 
 			// query the server
 			now, response, err := queryNtpServer(server, timeout)
+			if err != nil {
+				scopedLogger.Warn().
+					Str("error", err.Error()).
+					Msg("failed to query NTP server")
+				return
+			}
 
 			// set the last RTT
 			metricNtpServerLastRTT.WithLabelValues(
@@ -76,26 +83,20 @@ func (t *TimeSync) queryMultipleNTP(servers []string, timeout time.Duration) (no
 				strconv.Itoa(int(response.Precision)),
 			).Set(1)
 
-			if err == nil {
-				// increase success count
-				metricNtpTotalSuccessCount.Inc()
-				metricNtpSuccessCount.WithLabelValues(server).Inc()
+			// increase success count
+			metricNtpTotalSuccessCount.Inc()
+			metricNtpSuccessCount.WithLabelValues(server).Inc()
 
-				scopedLogger.Info().
-					Str("time", now.Format(time.RFC3339)).
-					Str("reference", response.ReferenceString()).
-					Str("rtt", response.RTT.String()).
-					Str("clockOffset", response.ClockOffset.String()).
-					Uint8("stratum", response.Stratum).
-					Msg("NTP server returned time")
-				results <- &ntpResult{
-					now:    now,
-					offset: &response.ClockOffset,
-				}
-			} else {
-				scopedLogger.Warn().
-					Str("error", err.Error()).
-					Msg("failed to query NTP server")
+			scopedLogger.Info().
+				Str("time", now.Format(time.RFC3339)).
+				Str("reference", response.ReferenceString()).
+				Str("rtt", response.RTT.String()).
+				Str("clockOffset", response.ClockOffset.String()).
+				Uint8("stratum", response.Stratum).
+				Msg("NTP server returned time")
+			results <- &ntpResult{
+				now:    now,
+				offset: &response.ClockOffset,
 			}
 		}(server)
 	}


### PR DESCRIPTION
This PR addresses two issues in the NTP time sync logic:

1. Fix panic on query error
Previously, if `queryNtpServer` failed, `jetkvm_app` would panic at startup due to unchecked errors. This has been fixed by adding proper error handling before using the response.

2. Support IPv6-only environments
The default NTP server list included only hostnames or IPv4 addresses, which fail in pure IPv6 setups—especially since IPv6 RA RDNSS is not yet supported, preventing hostname resolution. This PR adds a known IPv6-accessible NTP server to defaultNTPServers to ensure compatibility in such environments.