### PR TITLE
[draft] Reset HID on startup

### DIFF
--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -200,6 +200,14 @@ func (u *UsbGadget) Init() error {
 		u.log.Error().Err(err).Msg("failed to mount configfs, usb stack might not function properly")
 	}
 
+	if _, err := os.Stat(u.configC1Path); err == nil {
+		u.log.Error().Str("configC1Path", u.configC1Path).Msg("removing existing config path")
+		err := os.RemoveAll(u.configC1Path);
+		if err != nil {
+			u.log.Error().Err(err).Msg("failed to remove existing config path")
+		}
+	}
+
 	if err := os.MkdirAll(u.configC1Path, 0755); err != nil {
 		u.log.Error().Err(err).Msg("failed to create config path")
 	}


### PR DESCRIPTION
Recently we introduced some USB descriptor changes in #434 that introduced issues with development flow in #438, which a was addressed in #440. However, @dlorch  brings up a valid issue [here](https://github.com/jetkvm/kvm/pull/440#issuecomment-2880516929):

"What seems not yet solved however is when a user upgrades to the latest app version. This would require a reboot of the JetKVM device or a "reset" like the one you added in the shell script, or else the users might see a breaking change. Would this not be an issue? I am unsure how the upgrade procedure works."

Looking into this, I think he's right. If the next version of JetKVM only targets only an app update and not a system update, it won't initiate a system reboot and there will be HID issues until the next manual reboot.

So I've created this PR as a draft to have this discussion. The changes here will remove the HID configs upon startup before trying to write new ones. This should prevent any issues with the next upgrade and any future descriptor updates.

I've tested the commit and it _seems_ to work, but I am far from an expert in this area. So I'm not entirely sure if this 1) is required or 2) is the proper way to accomplish this.

So I'm not asking for this to be merged (at least, not yet), but rather for feedback.

Thank you!