### PR TITLE
Improve/Simplify Mouse Wheel Scroll Behavior

### DIFF
--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -109,7 +109,7 @@ func (u *UsbGadget) AbsMouseReport(x, y int, buttons uint8) error {
 	return nil
 }
 
-func (u *UsbGadget) AbsMouseWheelReport(wheelY int8, wheelX int8) error {
+func (u *UsbGadget) AbsMouseWheelReport(wheelY, wheelX int8) error {
 	u.absMouseLock.Lock()
 	defer u.absMouseLock.Unlock()
 

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -107,23 +107,10 @@ func (u *UsbGadget) AbsMouseWheelReport(wheelY int8) error {
 	u.absMouseLock.Lock()
 	defer u.absMouseLock.Unlock()
 
-	// Accumulate the wheelY value
-	u.absMouseAccumulatedWheelY += float64(wheelY) / 8.0
-
-	// Only send a report if the accumulated value is significant
-	if abs(u.absMouseAccumulatedWheelY) < 1.0 {
-		return nil
-	}
-
-	scaledWheelY := int8(u.absMouseAccumulatedWheelY)
-
 	err := u.absMouseWriteHidFile([]byte{
-		2,                  // Report ID 2
-		byte(scaledWheelY), // Scaled Wheel Y (signed)
+		2,            // Report ID 2
+		byte(wheelY), // Wheel Y (signed)
 	})
-
-	// Reset the accumulator, keeping any remainder
-	u.absMouseAccumulatedWheelY -= float64(scaledWheelY)
 
 	u.resetUserInputTime()
 	return err

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -60,7 +60,13 @@ var absoluteMouseCombinedReportDesc = []byte{
 	0x75, 0x08, //     Report Size (8)
 	0x95, 0x01, //     Report Count (1)
 	0x81, 0x06, //     Input (Data, Var, Rel)
-
+	0x05, 0x0C, //     Usage Page (Consumer Ctrls)
+	0x0A, 0x38, 0x02, // Usage (AC Pan)
+	0x15, 0x81, //     Logical Minimum (-127)
+	0x25, 0x7F, //     Logical Maximum (127)
+	0x75, 0x08, //     Report Size (8)
+	0x95, 0x01, //     Report Count (1)
+	0x81, 0x06, //     Input (Data, Var, Rel)
 	0xC0, // End Collection
 }
 
@@ -103,13 +109,14 @@ func (u *UsbGadget) AbsMouseReport(x, y int, buttons uint8) error {
 	return nil
 }
 
-func (u *UsbGadget) AbsMouseWheelReport(wheelY int8) error {
+func (u *UsbGadget) AbsMouseWheelReport(wheelY int8, wheelX int8) error {
 	u.absMouseLock.Lock()
 	defer u.absMouseLock.Unlock()
 
 	err := u.absMouseWriteHidFile([]byte{
 		2,            // Report ID 2
 		byte(wheelY), // Wheel Y (signed)
+		byte(wheelX), // Wheel X (signed)
 	})
 
 	u.resetUserInputTime()

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -994,7 +994,7 @@ var rpcHandlers = map[string]RPCHandler{
 	"keyboardReport":         {Func: rpcKeyboardReport, Params: []string{"modifier", "keys"}},
 	"absMouseReport":         {Func: rpcAbsMouseReport, Params: []string{"x", "y", "buttons"}},
 	"relMouseReport":         {Func: rpcRelMouseReport, Params: []string{"dx", "dy", "buttons"}},
-	"wheelReport":            {Func: rpcWheelReport, Params: []string{"wheelY"}},
+	"wheelReport":            {Func: rpcWheelReport, Params: []string{"wheelY", "wheelX"}},
 	"getVideoState":          {Func: rpcGetVideoState},
 	"getUSBState":            {Func: rpcGetUSBState},
 	"unmountImage":           {Func: rpcUnmountImage},

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -260,21 +260,26 @@ export default function WebRTCVideo() {
       if (blockWheelEvent) return;
 
       // Determine if the wheel event is an accelerable scroll value
-      const isAccel = Math.abs(e.deltaY) >= 100;
+      const isAccelY = Math.abs(e.deltaY) >= 100;
+      const isAccelX = Math.abs(e.deltaX) >= 100;
 
       // Calculate the accelerable scroll value
-      const accelScrollValue = e.deltaY / 100;
+      const accelScrollValueY = e.deltaY / 100;
+      const accelScrollValueX = e.deltaX / 100;
 
       // Calculate the non-accelerable scroll value
-      const nonAccelScrollValue = e.deltaY > 0 ? 1: -1;
+      const nonAccelScrollValueY = e.deltaY > 0 ? 1 : e.deltaY < 0 ? -1 : 0;
+      const nonAccelScrollValueX = e.deltaX > 0 ? 1 : e.deltaX < 0 ? -1 : 0;
 
       // Get actual scroll value
-      const scrollValue = isAccel ? accelScrollValue : nonAccelScrollValue;
+      const scrollValueY = isAccelY ? accelScrollValueY : nonAccelScrollValueY;
+      const scrollValueX = isAccelX ? accelScrollValueX : nonAccelScrollValueX;
 
       // Apply clamping (i.e. min and max mouse wheel hardware value)
-      const clampedScrollValue = Math.max(-128, Math.min(127, scrollValue));
+      const clampedScrollValueY = Math.max(-127, Math.min(127, scrollValueY));
+      const clampedScrollValueX = Math.max(-127, Math.min(127, scrollValueX));
 
-      send("wheelReport", { wheelY: clampedScrollValue });      
+      send("wheelReport", { wheelY: clampedScrollValueY, wheelX : clampedScrollValueX });      
 
       // Apply blocking delay
       setBlockWheelEvent(true);

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -259,25 +259,22 @@ export default function WebRTCVideo() {
     (e: WheelEvent) => {
       if (blockWheelEvent) return;
 
-      // Determine if the wheel event is from a trackpad or a mouse wheel
-      const isTrackpad = Math.abs(e.deltaY) < trackpadThreshold;
+      // Determine if the wheel event is an accelerable scroll value
+      const isAccel = Math.abs(e.deltaY) >= 100;
 
-      // Apply appropriate sensitivity based on input device
-      const scrollSensitivity = isTrackpad ? trackpadSensitivity : mouseSensitivity;
+      // Calculate the accelerable scroll value
+      const accelScrollValue = e.deltaY / 100;
 
-      // Calculate the scroll value
-      const scroll = e.deltaY * scrollSensitivity;
+      // Calculate the non-accelerable scroll value
+      const nonAccelScrollValue = e.deltaY > 0 ? 1: -1;
 
-      // Apply clamping
-      const clampedScroll = Math.max(clampMin, Math.min(clampMax, scroll));
+      // Get actual scroll value
+      const scrollValue = isAccel ? accelScrollValue : nonAccelScrollValue;
 
-      // Round to the nearest integer
-      const roundedScroll = Math.round(clampedScroll);
+      // Apply clamping (i.e. min and max mouse wheel hardware value)
+      const clampedScrollValue = Math.max(-128, Math.min(127, scrollValue));
 
-      // Invert the scroll value to match expected behavior
-      const invertedScroll = -roundedScroll;
-
-      send("wheelReport", { wheelY: invertedScroll });
+      send("wheelReport", { wheelY: clampedScrollValue });      
 
       // Apply blocking delay
       setBlockWheelEvent(true);

--- a/usb.go
+++ b/usb.go
@@ -38,8 +38,8 @@ func rpcRelMouseReport(dx, dy int8, buttons uint8) error {
 	return gadget.RelMouseReport(dx, dy, buttons)
 }
 
-func rpcWheelReport(wheelY int8) error {
-	return gadget.AbsMouseWheelReport(wheelY)
+func rpcWheelReport(wheelY, wheelX int8) error {
+	return gadget.AbsMouseWheelReport(wheelY, wheelX)
 }
 
 var usbState = "unknown"


### PR DESCRIPTION
This pull request makes several small but significant changes to the mouse wheel scroll behavior. In addition to guaranteeing that every mouse wheel click produces a scroll, these changes also maintain most if not all of the acceleration scroll values provided by many popular browsers. These changes simplify the code and make the various user scroll sensitivity settings completely unnecessary. However, these settings were *not* removed in this request.

These changes have been tested under the following environments. Unless otherwise noted, the scrolling behavior seems to work perfectly fine in these environments.

1. Windows 10 - Chrome 136 - Mouse (Delta = 100)
2. Windows 10  - Edge  136 - Mouse (Delta = 100)
3. Windows 10  - Firefox 138 - Mouse (Delta = 108)
4. Windows 10  - Opera 119 - Mouse (Delta = 8)

5. Linux Ubuntu 24.04.2 - Chrome 136 - Mouse (Delta = 120) + Trackpad
6. Linux Ubuntu 24.04.2 - Edge 136 - Mouse (Delta = 120) + Trackpad
7. Linux Ubuntu 24.04.2 - Firefox 138 - Mouse (Delta = 138) + Trackpad
8. Linux Ubuntu 24.04.2 - Opera 119 - THIS BROWSER CANNOT START JETKVM!

9. Android 15 - Chrome 136 - Mouse (Delta = 64)
10. Android 15 - Edge 136 - Mouse (Delta = 64)
11. Android 15 - Firefox 138 - Mouse (Delta = 63) - SCROLLING IS BACKWARDS!
12. Android 15 - Opera 89 - THIS BROWSER CANNOT START JETKVM!

Thank you very much for your consideration!
