### PR TITLE
fix(ui): Fix regression on Shift-Backspace not being handled

### DIFF
--- a/ui/src/keyboardMappings.ts
+++ b/ui/src/keyboardMappings.ts
@@ -243,6 +243,7 @@ export const keyDisplayMap: Record<string, string> = {
   Escape: "esc",
   Tab: "tab",
   Backspace: "backspace",
+  "(Backspace)": "backspace",
   Enter: "enter",
   CapsLock: "caps lock",
   ShiftLeft: "shift",


### PR DESCRIPTION
This keystroke is valid and means "delete to the right" on MacOS.
