### PR TITLE
chore: Update devcontainer.json to match ui's package.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
 	"features": {
 		"ghcr.io/devcontainers/features/node:1": {
 			// Should match what is defined in ui/package.json
-			"version": "21.1.0"
+			"version": "22.15.0"
 		}
 	},
 	"mounts": [


### PR DESCRIPTION
Missed that we upgraded the ui's package.json, need to _also_ update the devcontainer.json to matching verison 22.15.0
