### PR TITLE
Improve/Simplify Mouse Wheel Scroll Behavior

### DIFF
--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -113,7 +113,7 @@ func (u *UsbGadget) AbsMouseWheelReport(wheelY int8) error {
 	}
 
 	err := u.absMouseWriteHidFile([]byte{
-		2,                  // Report ID 2
+		2,            // Report ID 2
 		byte(wheelY), // Wheel Y (signed)
 	})
 

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -107,23 +107,15 @@ func (u *UsbGadget) AbsMouseWheelReport(wheelY int8) error {
 	u.absMouseLock.Lock()
 	defer u.absMouseLock.Unlock()
 
-	// Accumulate the wheelY value
-	u.absMouseAccumulatedWheelY += float64(wheelY) / 8.0
-
-	// Only send a report if the accumulated value is significant
-	if abs(u.absMouseAccumulatedWheelY) < 1.0 {
+	// Only send a report if the value is non-zero
+	if wheelY == 0 {
 		return nil
 	}
 
-	scaledWheelY := int8(u.absMouseAccumulatedWheelY)
-
 	err := u.absMouseWriteHidFile([]byte{
 		2,                  // Report ID 2
-		byte(scaledWheelY), // Scaled Wheel Y (signed)
+		byte(wheelY), // Wheel Y (signed)
 	})
-
-	// Reset the accumulator, keeping any remainder
-	u.absMouseAccumulatedWheelY -= float64(scaledWheelY)
 
 	u.resetUserInputTime()
 	return err

--- a/internal/usbgadget/utils.go
+++ b/internal/usbgadget/utils.go
@@ -7,14 +7,6 @@ import (
 	"path/filepath"
 )
 
-// Helper function to get absolute value of float64
-func abs(x float64) float64 {
-	if x < 0 {
-		return -x
-	}
-	return x
-}
-
 func joinPath(basePath string, paths []string) string {
 	pathArr := append([]string{basePath}, paths...)
 	return filepath.Join(pathArr...)

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -259,25 +259,25 @@ export default function WebRTCVideo() {
     (e: WheelEvent) => {
       if (blockWheelEvent) return;
 
-      // Determine if the wheel event is from a trackpad or a mouse wheel
-      const isTrackpad = Math.abs(e.deltaY) < trackpadThreshold;
+      // Determine if the wheel event is an accel scroll value
+      const isAccel = Math.abs(e.deltaY) >= 100;
 
-      // Apply appropriate sensitivity based on input device
-      const scrollSensitivity = isTrackpad ? trackpadSensitivity : mouseSensitivity;
+      // Calculate the accel scroll value
+      const accelScrollValue = e.deltaY / 100;
 
-      // Calculate the scroll value
-      const scroll = e.deltaY * scrollSensitivity;
+      // Calculate the no accel scroll value
+      const noAccelScrollValue = e.deltaY > 0 ? 1 : (e.deltaY < 0 ? -1 : 0);
 
-      // Apply clamping
-      const clampedScroll = Math.max(clampMin, Math.min(clampMax, scroll));
+      // Get scroll value
+      const scrollValue = isAccel ? accelScrollValue : noAccelScrollValue;
 
-      // Round to the nearest integer
-      const roundedScroll = Math.round(clampedScroll);
+      // Apply clamping (i.e. min and max mouse wheel hardware value)
+      const clampedScrollValue = Math.max(-127, Math.min(127, scrollValue));
 
-      // Invert the scroll value to match expected behavior
-      const invertedScroll = -roundedScroll;
+      // Invert the clamped scroll value to match expected behavior
+      const invertedScrollValue = -clampedScrollValue;
 
-      send("wheelReport", { wheelY: invertedScroll });
+      send("wheelReport", { wheelY : invertedScrollValue });
 
       // Apply blocking delay
       setBlockWheelEvent(true);


### PR DESCRIPTION
This pull request makes several small but significant changes to the mouse wheel scroll behavior. In addition to guaranteeing that every mouse wheel click produces a scroll, these changes also maintain most if not all of the acceleration scroll values provided by many popular browsers. These changes simplify the code and make the various user scroll sensitivity settings completely unnecessary. However, these settings were not removed in this request.

These changes have been tested under the following environments. Unless otherwise noted, the scrolling behavior seems to work perfectly fine in these environments.

1. Windows 10 - Chrome 136 - Mouse (Delta = 100)
2. Windows 10 - Edge 136 - Mouse (Delta = 100)
3. Windows 10 - Firefox 138 - Mouse (Delta = 108)
4. Windows 10 - Opera 119 - Mouse (Delta = 8)
5. Linux Ubuntu 24.04.2 - Chrome 136 - Mouse (Delta = 120) + Trackpad
6. Linux Ubuntu 24.04.2 - Edge 136 - Mouse (Delta = 120) + Trackpad
7. Linux Ubuntu 24.04.2 - Firefox 138 - Mouse (Delta = 138) + Trackpad
8. Linux Ubuntu 24.04.2 - Opera 119 - THIS BROWSER CANNOT START JETKVM!
9. Android 15 - Chrome 136 - Mouse (Delta = 64)
10. Android 15 - Edge 136 - Mouse (Delta = 64)
11. Android 15 - Firefox 138 - Mouse (Delta = 63) - SCROLLING IS BACKWARDS!
12. Android 15 - Opera 89 - THIS BROWSER CANNOT START JETKVM!

This pull request corrects a scrolling polarity issue and fixes some invalid scrolling values not properly handled by my previous closed pull request on this issue.

Thank you very much for your consideration!
