### PR TITLE
Fix Various Absolute Mouse Coordinate Conversion Issues

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -229,16 +229,16 @@ export default function WebRTCVideo() {
       }
 
       // Clamp mouse position within the effective video boundaries
-      const clampedX = Math.min(Math.max(offsetX, e.offsetX), offsetX + effectiveWidth);
-      const clampedY = Math.min(Math.max(offsetY, e.offsetY), offsetY + effectiveHeight);
+      const clampedX = Math.min(Math.max(offsetX, e.offsetX), offsetX + effectiveWidth - 1);
+      const clampedY = Math.min(Math.max(offsetY, e.offsetY), offsetY + effectiveHeight - 1);
 
       // Map clamped mouse position to the video stream's coordinate system
       const relativeX = (clampedX - offsetX) / effectiveWidth;
       const relativeY = (clampedY - offsetY) / effectiveHeight;
 
       // Convert to HID absolute coordinate system (0-32767 range)
-      const x = Math.round(relativeX * 32767);
-      const y = Math.round(relativeY * 32767);
+      const x = Math.trunc(relativeX * 32768);
+      const y = Math.trunc(relativeY * 32768);
 
       // Send mouse movement
       const { buttons } = e;


### PR DESCRIPTION
This change fixes various absolute mouse coordinate conversion issues. It fixes 1) the video clamping range which instead of from 0 to effectiveWidth (or effectiveHeight) should instead be from 0 to effectiveWidth - 1 (or effectiveHeight - 1), 2) the mouse coordinate size which instead of 32767 should instead be 32768 since the min value is 0x0000 and the max value is 0x7FFF (32767), and 3) a rounding operation which should instead be a truncation operation.