### PR TITLE
Remove Out Endpoint Descriptors from Keyboard, Absolute Mouse, and Relative Mouse

### DIFF
--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -14,9 +14,10 @@ var keyboardConfig = gadgetConfigItem{
 	path:       []string{"functions", "hid.usb0"},
 	configPath: []string{"hid.usb0"},
 	attrs: gadgetAttributes{
-		"protocol":      "1",
-		"subclass":      "1",
-		"report_length": "8",
+		"protocol":        "1",
+		"subclass":        "1",
+		"report_length":   "8",
+		"no_out_endpoint": "1",
 	},
 	reportDesc: keyboardReportDesc,
 }

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -11,9 +11,10 @@ var absoluteMouseConfig = gadgetConfigItem{
 	path:       []string{"functions", "hid.usb1"},
 	configPath: []string{"hid.usb1"},
 	attrs: gadgetAttributes{
-		"protocol":      "2",
-		"subclass":      "1",
-		"report_length": "6",
+		"protocol":        "2",
+		"subclass":        "1",
+		"report_length":   "6",
+		"no_out_endpoint": "1",
 	},
 	reportDesc: absoluteMouseCombinedReportDesc,
 }

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -11,9 +11,10 @@ var relativeMouseConfig = gadgetConfigItem{
 	path:       []string{"functions", "hid.usb2"},
 	configPath: []string{"hid.usb2"},
 	attrs: gadgetAttributes{
-		"protocol":      "2",
-		"subclass":      "1",
-		"report_length": "4",
+		"protocol":        "2",
+		"subclass":        "1",
+		"report_length":   "4",
+		"no_out_endpoint": "1",
 	},
 	reportDesc: relativeMouseCombinedReportDesc,
 }


### PR DESCRIPTION
Added attribute to remove unnecessary and potentially confusing out endpoint descriptors from the keyboard, absolute mouse, and relative mouse.