### PR TITLE
Fix for #531 - The screen doesn't dim or turn off

### DIFF
--- a/display.go
+++ b/display.go
@@ -343,7 +343,7 @@ func startBacklightTickers() {
 		dimTicker.Stop()
 	}
 
-	if offticker != nil {
+	if offTicker != nil {
 		offTicker.Stop()
 	}
 

--- a/display.go
+++ b/display.go
@@ -339,10 +339,17 @@ func startBacklightTickers() {
 		return
 	}
 
-	if dimTicker == nil && config.DisplayDimAfterSec != 0 {
+	if dimTicker != nil {
+		dimTicker.Stop()
+	}
+
+	if offticker != nil {
+		offTicker.Stop()
+	}
+
+	if config.DisplayDimAfterSec != 0 {
 		displayLogger.Info().Msg("dim_ticker has started")
 		dimTicker = time.NewTicker(time.Duration(config.DisplayDimAfterSec) * time.Second)
-		defer dimTicker.Stop()
 
 		go func() {
 			for { //nolint:staticcheck
@@ -354,10 +361,9 @@ func startBacklightTickers() {
 		}()
 	}
 
-	if offTicker == nil && config.DisplayOffAfterSec != 0 {
+	if config.DisplayOffAfterSec != 0 {
 		displayLogger.Info().Msg("off_ticker has started")
 		offTicker = time.NewTicker(time.Duration(config.DisplayOffAfterSec) * time.Second)
-		defer offTicker.Stop()
 
 		go func() {
 			for { //nolint:staticcheck

--- a/display.go
+++ b/display.go
@@ -339,6 +339,7 @@ func startBacklightTickers() {
 		return
 	}
 
+	// Stop existing tickers to prevent multiple active instances on repeated calls
 	if dimTicker != nil {
 		dimTicker.Stop()
 	}

--- a/internal/udhcpc/udhcpc.go
+++ b/internal/udhcpc/udhcpc.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"time"
 
 	"github.com/fsnotify/fsnotify"
@@ -149,6 +150,12 @@ func (c *DHCPClient) loadLeaseFile() error {
 	}
 
 	isFirstLoad := c.lease == nil
+
+	// Skip processing if lease hasn't changed to avoid unnecessary wake-ups.
+	if reflect.DeepEqual(c.lease, lease) {
+		return nil
+	}
+
 	c.lease = lease
 
 	if lease.IPAddress == nil {


### PR DESCRIPTION
Fix for #531
Remove the unnecessary defer ticker stops. Also ensure that we don't process the lease multiple times if it has not changed since it wakes the device up every time.