### PR TITLE
scroll throttling preference

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -67,6 +67,8 @@ export default function WebRTCVideo() {
   const hdmiError = ["no_lock", "no_signal", "out_of_range"].includes(hdmiState);
   const isVideoLoading = !isPlaying;
 
+  const [blockWheelEvent, setBlockWheelEvent] = useState(false);
+
   // Misc states and hooks
   const disableVideoFocusTrap = useUiStore(state => state.disableVideoFocusTrap);
   const [send] = useJsonRpc();
@@ -256,6 +258,11 @@ export default function WebRTCVideo() {
 
   const mouseWheelHandler = useCallback(
     (e: WheelEvent) => {
+
+      if (settings.scrollThrottling && blockWheelEvent) {
+        return;
+      }
+
       // Determine if the wheel event is an accel scroll value
       const isAccel = Math.abs(e.deltaY) >= 100;
 
@@ -275,8 +282,14 @@ export default function WebRTCVideo() {
       const invertedScrollValue = -clampedScrollValue;
 
       send("wheelReport", { wheelY: invertedScrollValue });
+
+      // Apply blocking delay based of throttling settings
+      if (settings.scrollThrottling && !blockWheelEvent) {
+        setBlockWheelEvent(true);
+        setTimeout(() => setBlockWheelEvent(false), settings.scrollThrottling);
+      }
     },
-    [send],
+    [send, blockWheelEvent, settings],
   );
 
   const resetMousePosition = useCallback(() => {

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -314,6 +314,9 @@ interface SettingsState {
   keyboardLedSync: KeyboardLedSync;
   setKeyboardLedSync: (sync: KeyboardLedSync) => void;
 
+  scrollThrottling: number;
+  setScrollThrottling: (value: number) => void;
+
   showPressedKeys: boolean;
   setShowPressedKeys: (show: boolean) => void;
 }
@@ -353,6 +356,9 @@ export const useSettingsStore = create(
 
       keyboardLedSync: "auto",
       setKeyboardLedSync: sync => set({ keyboardLedSync: sync }),
+
+      scrollThrottling: 0,
+      setScrollThrottling: value => set({ scrollThrottling: value }),
 
       showPressedKeys: true,
       setShowPressedKeys: show => set({ showPressedKeys: show }),

--- a/ui/src/routes/devices.$id.settings.mouse.tsx
+++ b/ui/src/routes/devices.$id.settings.mouse.tsx
@@ -14,6 +14,7 @@ import { useFeatureFlag } from "../hooks/useFeatureFlag";
 import { cx } from "../cva.config";
 
 import { SettingsItem } from "./devices.$id.settings";
+import { SelectMenuBasic } from "@components/SelectMenuBasic";
 
 export default function SettingsMouseRoute() {
   const hideCursor = useSettingsStore(state => state.isCursorHidden);
@@ -25,6 +26,19 @@ export default function SettingsMouseRoute() {
   const { isEnabled: isScrollSensitivityEnabled } = useFeatureFlag("0.3.8");
 
   const [jiggler, setJiggler] = useState(false);
+
+  const scrollThrottling = useSettingsStore(state => state.scrollThrottling);
+  const setScrollThrottling = useSettingsStore(
+    state => state.setScrollThrottling,
+  );
+
+  const scrollThrottlingOptions = [
+    { value: "0", label: "Off" },
+    { value: "10", label: "Low" },
+    { value: "25", label: "Medium" },
+    { value: "50", label: "High" },
+    { value: "100", label: "Very High" },
+  ];
 
   const [send] = useJsonRpc();
 
@@ -64,6 +78,21 @@ export default function SettingsMouseRoute() {
             onChange={e => setHideCursor(e.target.checked)}
           />
         </SettingsItem>
+
+      <SettingsItem
+        title="Scroll Throttling"
+        description="Reduce the frequency of scroll events"
+      >
+        <SelectMenuBasic
+          size="SM"
+          label=""
+          className="max-w-[292px]"
+          value={scrollThrottling}
+          fullWidth
+          onChange={e => setScrollThrottling(parseInt(e.target.value))}
+          options={scrollThrottlingOptions}
+        />
+      </SettingsItem>
 
         <SettingsItem
           title="Jiggler"


### PR DESCRIPTION
I know it's a bit of a controversial topic, but I feel as though the recently removed scroll sensitivity options were actually helpful on some devices.

Particularly as a Mac user, I think the wheel event blocking/throttling really helped tone down the scrolling speed.

This PR (re)introduces just the blocking/throttling mechanism to prevent excessive scroll events from being sent to the host system.

Given not everyone is convinced this actually makes any difference, an "Off" setting is available to maintain today's existing behaviour. This is the default setting.

For me, On my Macbook I like the "Medium" or "High" options -- depending on what I'm working on.

As always, criticism is welcome!