### PR TITLE
Update hid_mouse_absolute.go

### DIFF
--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -12,7 +12,7 @@ var absoluteMouseConfig = gadgetConfigItem{
 	configPath: []string{"hid.usb1"},
 	attrs: gadgetAttributes{
 		"protocol":      "2",
-		"subclass":      "1",
+		"subclass":      "0",
 		"report_length": "6",
 	},
 	reportDesc: absoluteMouseCombinedReportDesc,


### PR DESCRIPTION
Changed absolute mouse usb interface descriptor's subclass field to zero. If a usb mouse advertises itself as a boot device, it is *required* to reports its Button Status Value in Byte 0, its X Displacement Value in Byte 1, and its Y Displacement Value in Byte 2 when it is configured to operate in boot mode.

Although JetKVM's absolute mouse does always report its Button Status Value in Byte 0, it always reports its X Absolute Value in Byte 1 and Byte 2, and its Y Absolute Value in Byte 3 and Byte 4. As such, this incorrect code will definitely cause problems for operating environments that attempt to configure the absolute mouse to operate in boot mode.

P.S. I believe it is acceptable for the relative mouse to advertise itself as as boot device because it does indeed always report its Button Status Value in Byte 0, its X Displacement Value in Byte 1, and its Y Displacement Value in Byte 2 under all conditions at least in the current code.
