### PR TITLE
Allow the versions in the makefile to be overwritten with ENV variables

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@ BRANCH    ?= $(shell git rev-parse --abbrev-ref HEAD)
 BUILDDATE ?= $(shell date -u +%FT%T%z)
 BUILDTS   ?= $(shell date -u +%s)
 REVISION  ?= $(shell git rev-parse HEAD)
-VERSION_DEV := 0.4.5-dev$(shell date +%Y%m%d%H%M)
-VERSION := 0.4.4
+VERSION_DEV ?= 0.4.5-dev$(shell date +%Y%m%d%H%M)
+VERSION ?= 0.4.4
 
 PROMETHEUS_TAG := github.com/prometheus/common/version
 KVM_PKG_NAME := github.com/jetkvm/kvm


### PR DESCRIPTION
Goes well with https://github.com/jetkvm/kvm/pull/527

`VERSION=0.4.5-local ./dev_deploy.sh -i -r <jetkvm_ip>`

![image](https://github.com/user-attachments/assets/2943112e-5c11-4649-b4dd-b3184ca7ff33)
