### PR TITLE
feat(dc-power-extension) Power restore mode in DCPowerControl component

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -681,10 +681,11 @@ func rpcResetConfig() error {
 }
 
 type DCPowerState struct {
-	IsOn    bool    `json:"isOn"`
-	Voltage float64 `json:"voltage"`
-	Current float64 `json:"current"`
-	Power   float64 `json:"power"`
+	IsOn         bool    `json:"isOn"`
+	Voltage      float64 `json:"voltage"`
+	Current      float64 `json:"current"`
+	Power        float64 `json:"power"`
+	RestoreState int     `json:"restoreState"`
 }
 
 func rpcGetDCPowerState() (DCPowerState, error) {
@@ -696,6 +697,15 @@ func rpcSetDCPowerState(enabled bool) error {
 	err := setDCPowerState(enabled)
 	if err != nil {
 		return fmt.Errorf("failed to set DC power state: %w", err)
+	}
+	return nil
+}
+
+func rpcSetDCRestoreState(state int) error {
+	logger.Info().Int("state", state).Msg("Setting DC restore state")
+	err := setDCRestoreState(state)
+	if err != nil {
+		return fmt.Errorf("failed to set DC restore state: %w", err)
 	}
 	return nil
 }
@@ -1088,6 +1098,7 @@ var rpcHandlers = map[string]RPCHandler{
 	"getBacklightSettings":   {Func: rpcGetBacklightSettings},
 	"getDCPowerState":        {Func: rpcGetDCPowerState},
 	"setDCPowerState":        {Func: rpcSetDCPowerState, Params: []string{"enabled"}},
+	"setDCRestoreState":      {Func: rpcSetDCRestoreState, Params: []string{"state"}},
 	"getActiveExtension":     {Func: rpcGetActiveExtension},
 	"setActiveExtension":     {Func: rpcSetActiveExtension, Params: []string{"extensionId"}},
 	"getATXState":            {Func: rpcGetATXState},

--- a/serial.go
+++ b/serial.go
@@ -142,6 +142,7 @@ var dcState DCPowerState
 func runDCControl() {
 	scopedLogger := serialLogger.With().Str("service", "dc_control").Logger()
 	reader := bufio.NewReader(port)
+	hasRestoreFeature := false
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
@@ -151,7 +152,13 @@ func runDCControl() {
 
 		// Split the line by semicolon
 		parts := strings.Split(strings.TrimSpace(line), ";")
-		if len(parts) != 4 {
+		if len(parts) == 5 {
+			scopedLogger.Debug().Str("line", line).Msg("Detected DC extension with restore feature")
+			hasRestoreFeature = true
+		} else if len(parts) == 4 {
+			scopedLogger.Debug().Str("line", line).Msg("Detected DC extension without restore feature")
+			hasRestoreFeature = false
+		} else {
 			scopedLogger.Warn().Str("line", line).Msg("Invalid line")
 			continue
 		}
@@ -163,6 +170,17 @@ func runDCControl() {
 			continue
 		}
 		dcState.IsOn = powerState == 1
+		if hasRestoreFeature {
+			restoreState, err := strconv.Atoi(parts[4])
+			if err != nil {
+				scopedLogger.Warn().Err(err).Msg("Invalid restore state")
+				continue
+			}
+			dcState.RestoreState = restoreState
+		} else {
+			// -1 means not supported
+			dcState.RestoreState = -1
+		}
 		milliVolts, err := strconv.ParseFloat(parts[1], 64)
 		if err != nil {
 			scopedLogger.Warn().Err(err).Msg("Invalid voltage")
@@ -202,6 +220,24 @@ func setDCPowerState(on bool) error {
 	command := "PWR_OFF\n"
 	if on {
 		command = "PWR_ON\n"
+	}
+	_, err = port.Write([]byte(command))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func setDCRestoreState(state int) error {
+	_, err := port.Write([]byte("\n"))
+	if err != nil {
+		return err
+	}
+	command := "RESTORE_MODE_OFF\n"
+	if state == 1 {
+		command = "RESTORE_MODE_ON\n"
+	} else if state == 2 {
+		command = "RESTORE_MODE_LAST_STATE\n"
 	}
 	_, err = port.Write([]byte(command))
 	if err != nil {

--- a/serial.go
+++ b/serial.go
@@ -234,9 +234,10 @@ func setDCRestoreState(state int) error {
 		return err
 	}
 	command := "RESTORE_MODE_OFF\n"
-	if state == 1 {
+	switch state {
+	case 1:
 		command = "RESTORE_MODE_ON\n"
-	} else if state == 2 {
+	case 2:
 		command = "RESTORE_MODE_LAST_STATE\n"
 	}
 	_, err = port.Write([]byte(command))

--- a/ui/src/components/extensions/DCPowerControl.tsx
+++ b/ui/src/components/extensions/DCPowerControl.tsx
@@ -8,12 +8,14 @@ import { useJsonRpc } from "@/hooks/useJsonRpc";
 import notifications from "@/notifications";
 import FieldLabel from "@components/FieldLabel";
 import LoadingSpinner from "@components/LoadingSpinner";
+import {SelectMenuBasic} from "@components/SelectMenuBasic";
 
 interface DCPowerState {
   isOn: boolean;
   voltage: number;
   current: number;
   power: number;
+  restoreState: number;
 }
 
 export function DCPowerControl() {
@@ -43,6 +45,20 @@ export function DCPowerControl() {
       getDCPowerState(); // Refresh state after change
     });
   };
+  const handleRestoreChange = (state: number) => {
+    // const state = powerState?.restoreState === 0 ? 1 : powerState?.restoreState === 1 ? 2 : 0;
+    send("setDCRestoreState", { state }, resp => {
+      if ("error" in resp) {
+        notifications.error(
+          `Failed to set DC power state: ${resp.error.data || "Unknown error"}`,
+        );
+        return;
+      }
+      getDCPowerState(); // Refresh state after change
+    });
+  };
+
+
 
   useEffect(() => {
     getDCPowerState();
@@ -63,7 +79,7 @@ export function DCPowerControl() {
           <LoadingSpinner className="h-6 w-6 text-blue-500 dark:text-blue-400" />
         </Card>
       ) : (
-        <Card className="h-[160px] animate-fadeIn opacity-0">
+        <Card className="animate-fadeIn opacity-0">
           <div className="space-y-4 p-3">
             {/* Power Controls */}
             <div className="flex items-center space-x-2">
@@ -84,6 +100,21 @@ export function DCPowerControl() {
                 onClick={() => handlePowerToggle(false)}
               />
             </div>
+            {powerState.restoreState > -1 ? (
+              <div className="flex items-center">
+                <SelectMenuBasic
+                    size="SM"
+                    label="Restore Power Loss"
+                    value={powerState.restoreState}
+                    onChange={e => handleRestoreChange(parseInt(e.target.value))}
+                    options={[
+                      { value: '0', label: "Power OFF" },
+                      { value: '1', label: "Power ON" },
+                      { value: '2', label: "Last State" },
+                    ]}
+                />
+              </div>
+            ) : null}
             <hr className="border-slate-700/30 dark:border-slate-600/30" />
 
             {/* Status Display */}


### PR DESCRIPTION
With this feature its possible to set a power restore mode for the DC Power extension module. 
There are three options that can be applied by the module in case the device comes back after a power loss:

1. **Power OFF:** which is the default and leaves the DC output turned off. 
2. **Power ON:** which turns the DC output always on.
3. **Last state:** which restores the state that the DC output was before the power loss took place.

To make this work, there is a firmware update for the DC module necessary. See https://github.com/jetkvm/dc-extension-firmware/pull/3  

**This is how its look like:**
![DC Restore on Power Loss](https://github.com/user-attachments/assets/34f518b2-4bec-453e-909c-587e81b7d421)


Feedback always welcome