### PR TITLE
chore / Fix go lint error

### DIFF
--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -17,7 +17,7 @@ var keyboardConfig = gadgetConfigItem{
 		"protocol":        "1",
 		"subclass":        "1",
 		"report_length":   "8",
-		"no_out_endpoint": "0",		
+		"no_out_endpoint": "0",
 	},
 	reportDesc: keyboardReportDesc,
 }


### PR DESCRIPTION
Looks like a couple trailing tabs crept into the hid_keyboard.go during a recent USB HID fix