### PR TITLE
Static IP in Settings

### DIFF
--- a/internal/confparser/confparser.go
+++ b/internal/confparser/confparser.go
@@ -346,6 +346,17 @@ func (f *FieldConfig) validateField() error {
 		return nil
 	}
 
+	// Handle []string types, like dns servers, time sync ntp servers, etc.
+	if slice, ok := f.CurrentValue.([]string); ok {
+		for i, item := range slice {
+			if err := f.validateSingleValue(item, i); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Handle single string types
 	val, err := toString(f.CurrentValue)
 	if err != nil {
 		return fmt.Errorf("field `%s` cannot use validate_type: %s", f.Name, err)
@@ -355,27 +366,46 @@ func (f *FieldConfig) validateField() error {
 		return nil
 	}
 
+	return f.validateSingleValue(val, -1)
+}
+
+func (f *FieldConfig) validateSingleValue(val string, index int) error {
 	for _, validateType := range f.ValidateTypes {
+		var fieldRef string
+		if index >= 0 {
+			fieldRef = fmt.Sprintf("field `%s[%d]`", f.Name, index)
+		} else {
+			fieldRef = fmt.Sprintf("field `%s`", f.Name)
+		}
+
 		switch validateType {
 		case "ipv4":
 			if net.ParseIP(val).To4() == nil {
-				return fmt.Errorf("field `%s` is not a valid IPv4 address: %s", f.Name, val)
+				return fmt.Errorf("%s is not a valid IPv4 address: %s", fieldRef, val)
 			}
 		case "ipv6":
 			if net.ParseIP(val).To16() == nil {
-				return fmt.Errorf("field `%s` is not a valid IPv6 address: %s", f.Name, val)
+				return fmt.Errorf("%s is not a valid IPv6 address: %s", fieldRef, val)
+			}
+		case "ipv4_or_ipv6":
+			if net.ParseIP(val) == nil {
+				return fmt.Errorf("%s is not a valid IPv4 or IPv6 address: %s", fieldRef, val)
 			}
 		case "hwaddr":
 			if _, err := net.ParseMAC(val); err != nil {
-				return fmt.Errorf("field `%s` is not a valid MAC address: %s", f.Name, val)
+				return fmt.Errorf("%s is not a valid MAC address: %s", fieldRef, val)
 			}
 		case "hostname":
 			if _, err := idna.Lookup.ToASCII(val); err != nil {
-				return fmt.Errorf("field `%s` is not a valid hostname: %s", f.Name, val)
+				return fmt.Errorf("%s is not a valid hostname: %s", fieldRef, val)
 			}
 		case "proxy":
 			if url, err := url.Parse(val); err != nil || (url.Scheme != "http" && url.Scheme != "https") || url.Host == "" {
-				return fmt.Errorf("field `%s` is not a valid HTTP proxy URL: %s", f.Name, val)
+				return fmt.Errorf("%s is not a valid HTTP proxy URL: %s", fieldRef, val)
+			}
+		case "url":
+			if _, err := url.Parse(val); err != nil {
+				return fmt.Errorf("%s is not a valid URL: %s", fieldRef, val)
 			}
 		default:
 			return fmt.Errorf("field `%s` cannot use validate_type: unsupported validator: %s", f.Name, validateType)

--- a/internal/confparser/confparser.go
+++ b/internal/confparser/confparser.go
@@ -407,6 +407,10 @@ func (f *FieldConfig) validateSingleValue(val string, index int) error {
 			if _, err := url.Parse(val); err != nil {
 				return fmt.Errorf("%s is not a valid URL: %s", fieldRef, val)
 			}
+		case "cidr":
+			if _, _, err := net.ParseCIDR(val); err != nil {
+				return fmt.Errorf("%s is not a valid CIDR notation: %s", fieldRef, val)
+			}
 		default:
 			return fmt.Errorf("field `%s` cannot use validate_type: unsupported validator: %s", f.Name, validateType)
 		}

--- a/internal/network/config.go
+++ b/internal/network/config.go
@@ -28,8 +28,7 @@ type IPv4StaticConfig struct {
 }
 
 type IPv6StaticConfig struct {
-	Address null.String `json:"address,omitempty" validate_type:"ipv6" required:"true"`
-	Prefix  null.String `json:"prefix,omitempty" required:"true"`
+	Address null.String `json:"address,omitempty" validate_type:"cidr" required:"true"`
 	Gateway null.String `json:"gateway,omitempty" validate_type:"ipv6" required:"true"`
 	DNS     []string    `json:"dns,omitempty" validate_type:"ipv6" required:"true"`
 }

--- a/internal/network/config.go
+++ b/internal/network/config.go
@@ -29,7 +29,7 @@ type IPv4StaticConfig struct {
 
 type IPv6StaticConfig struct {
 	Address null.String `json:"address,omitempty" validate_type:"ipv6" required:"true"`
-	Prefix  null.String `json:"prefix,omitempty" validate_type:"ipv6" required:"true"`
+	Prefix  null.String `json:"prefix,omitempty" required:"true"`
 	Gateway null.String `json:"gateway,omitempty" validate_type:"ipv6" required:"true"`
 	DNS     []string    `json:"dns,omitempty" validate_type:"ipv6" required:"true"`
 }

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -28,6 +28,7 @@
         "react": "^19.1.0",
         "react-animate-height": "^3.2.3",
         "react-dom": "^19.1.0",
+        "react-hook-form": "^7.62.0",
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.22.3",
@@ -5795,6 +5796,22 @@
       },
       "peerDependencies": {
         "react": "^19.1.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.62.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.62.0.tgz",
+      "integrity": "sha512-7KWFejc98xqG/F4bAxpL41NB3o1nnvQO1RWZT3TqRZYL8RryQETGfEdVnJN2fy1crCiBLLjkRBVK05j24FxJGA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/react-hot-toast": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -39,6 +39,7 @@
     "react": "^19.1.0",
     "react-animate-height": "^3.2.3",
     "react-dom": "^19.1.0",
+    "react-hook-form": "^7.62.0",
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.22.3",

--- a/ui/src/components/ConfirmDialog.tsx
+++ b/ui/src/components/ConfirmDialog.tsx
@@ -1,13 +1,10 @@
-import {
-  CheckCircleIcon,
-  ExclamationTriangleIcon,
-  InformationCircleIcon,
-} from "@heroicons/react/24/outline";
+import { CheckCircleIcon } from "@heroicons/react/24/outline";
+import { CloseButton } from "@headlessui/react";
+import { LuInfo, LuOctagonAlert, LuTriangleAlert } from "react-icons/lu";
 
 import { Button } from "@/components/Button";
 import Modal from "@/components/Modal";
 import { cx } from "@/cva.config";
-
 type Variant = "danger" | "success" | "warning" | "info";
 
 interface ConfirmDialogProps {
@@ -24,27 +21,27 @@ interface ConfirmDialogProps {
 
 const variantConfig = {
   danger: {
-    icon: ExclamationTriangleIcon,
+    icon: LuOctagonAlert,
     iconClass: "text-red-600",
-    iconBgClass: "bg-red-100",
+    iconBgClass: "bg-red-100 border border-red-500/90",
     buttonTheme: "danger",
   },
   success: {
     icon: CheckCircleIcon,
     iconClass: "text-green-600",
-    iconBgClass: "bg-green-100",
+    iconBgClass: "bg-green-100 border border-green-500/90",
     buttonTheme: "primary",
   },
   warning: {
-    icon: ExclamationTriangleIcon,
+    icon: LuTriangleAlert,
     iconClass: "text-yellow-600",
-    iconBgClass: "bg-yellow-100",
-    buttonTheme: "lightDanger",
+    iconBgClass: "bg-yellow-100 border border-yellow-500/90",
+    buttonTheme: "primary",
   },
   info: {
-    icon: InformationCircleIcon,
+    icon: LuInfo,
     iconClass: "text-blue-600",
-    iconBgClass: "bg-blue-100",
+    iconBgClass: "bg-blue-100 border border-blue-500/90",
     buttonTheme: "primary",
   },
 } as Record<
@@ -94,9 +91,9 @@ export function ConfirmDialog({
               </div>
             </div>
 
-            <div className="flex justify-end gap-x-2">
+            <div className="flex justify-end gap-x-2" autoFocus>
               {cancelText && (
-                <Button size="SM" theme="blank" text={cancelText} onClick={onClose} />
+                <CloseButton as={Button} size="SM" theme="blank" text={cancelText} />
               )}
               <Button
                 size="SM"

--- a/ui/src/components/ConfirmDialog.tsx
+++ b/ui/src/components/ConfirmDialog.tsx
@@ -97,6 +97,7 @@ export function ConfirmDialog({
               )}
               <Button
                 size="SM"
+                type="button"
                 theme={buttonTheme}
                 text={isConfirming ? `${confirmText}...` : confirmText}
                 onClick={onConfirm}

--- a/ui/src/components/DhcpLeaseCard.tsx
+++ b/ui/src/components/DhcpLeaseCard.tsx
@@ -29,9 +29,23 @@ export default function DhcpLeaseCard({
     <GridCard>
       <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">
         <div className="space-y-3">
-          <h3 className="text-base font-bold text-slate-900 dark:text-white">
-            DHCP Lease Information
-          </h3>
+          <div className="flex items-center justify-between">
+            <h3 className="text-base font-bold text-slate-900 dark:text-white">
+              DHCP Lease Information
+            </h3>
+
+            <div>
+              <Button
+                size="XS"
+                theme="light"
+                type="button"
+                className="text-red-500"
+                text="Renew DHCP Lease"
+                LeadingIcon={LuRefreshCcw}
+                onClick={() => setShowRenewLeaseConfirm(true)}
+              />
+            </div>
+          </div>
 
           <div className="flex gap-x-6 gap-y-2">
             <div className="flex-1 space-y-2">
@@ -208,17 +222,6 @@ export default function DhcpLeaseCard({
                 </div>
               )}
             </div>
-          </div>
-
-          <div>
-            <Button
-              size="SM"
-              theme="light"
-              className="text-red-500"
-              text="Renew DHCP Lease"
-              LeadingIcon={LuRefreshCcw}
-              onClick={() => setShowRenewLeaseConfirm(true)}
-            />
           </div>
         </div>
       </div>

--- a/ui/src/components/DhcpLeaseCard.tsx
+++ b/ui/src/components/DhcpLeaseCard.tsx
@@ -5,6 +5,8 @@ import { GridCard } from "@/components/Card";
 import { LifeTimeLabel } from "@/routes/devices.$id.settings.network";
 import { NetworkState } from "@/hooks/stores";
 
+import EmptyCard from "./EmptyCard";
+
 export default function DhcpLeaseCard({
   networkState,
   setShowRenewLeaseConfirm,
@@ -12,6 +14,17 @@ export default function DhcpLeaseCard({
   networkState: NetworkState | null;
   setShowRenewLeaseConfirm: (show: boolean) => void;
 }) {
+  const isDhcpLeaseEmpty = Object.keys(networkState?.dhcp_lease || {}).length === 0;
+
+  if (isDhcpLeaseEmpty) {
+    return (
+      <EmptyCard
+        headline="No DHCP Lease information"
+        description="We haven't received any DHCP lease information from the device yet."
+      />
+    );
+  }
+
   return (
     <GridCard>
       <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">

--- a/ui/src/components/DhcpLeaseCard.tsx
+++ b/ui/src/components/DhcpLeaseCard.tsx
@@ -9,12 +9,12 @@ export default function DhcpLeaseCard({
   networkState,
   setShowRenewLeaseConfirm,
 }: {
-  networkState: NetworkState;
+  networkState: NetworkState | null;
   setShowRenewLeaseConfirm: (show: boolean) => void;
 }) {
   return (
     <GridCard>
-      <div className="animate-fadeIn p-4 opacity-0 animation-duration-500 text-black dark:text-white">
+      <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">
         <div className="space-y-3">
           <h3 className="text-base font-bold text-slate-900 dark:text-white">
             DHCP Lease Information
@@ -44,24 +44,15 @@ export default function DhcpLeaseCard({
                 </div>
               )}
 
-              {networkState?.dhcp_lease?.dns && (
+              {networkState?.dhcp_lease?.dns_servers && (
                 <div className="flex justify-between border-t border-slate-800/10 pt-2 dark:border-slate-300/20">
                   <span className="text-sm text-slate-600 dark:text-slate-400">
                     DNS Servers
                   </span>
                   <span className="text-right text-sm font-medium">
-                    {networkState?.dhcp_lease?.dns.map(dns => <div key={dns}>{dns}</div>)}
-                  </span>
-                </div>
-              )}
-
-              {networkState?.dhcp_lease?.broadcast && (
-                <div className="flex justify-between border-t border-slate-800/10 pt-2 dark:border-slate-300/20">
-                  <span className="text-sm text-slate-600 dark:text-slate-400">
-                    Broadcast
-                  </span>
-                  <span className="text-sm font-medium">
-                    {networkState?.dhcp_lease?.broadcast}
+                    {networkState?.dhcp_lease?.dns_servers.map(dns => (
+                      <div key={dns}>{dns}</div>
+                    ))}
                   </span>
                 </div>
               )}
@@ -138,6 +129,17 @@ export default function DhcpLeaseCard({
                     <LifeTimeLabel
                       lifetime={`${networkState?.dhcp_lease?.lease_expiry}`}
                     />
+                  </span>
+                </div>
+              )}
+
+              {networkState?.dhcp_lease?.broadcast && (
+                <div className="flex justify-between border-t border-slate-800/10 pt-2 dark:border-slate-300/20">
+                  <span className="text-sm text-slate-600 dark:text-slate-400">
+                    Broadcast
+                  </span>
+                  <span className="text-sm font-medium">
+                    {networkState?.dhcp_lease?.broadcast}
                   </span>
                 </div>
               )}

--- a/ui/src/components/Ipv6NetworkCard.tsx
+++ b/ui/src/components/Ipv6NetworkCard.tsx
@@ -33,56 +33,54 @@ export default function Ipv6NetworkCard({
             {networkState?.ipv6_addresses && networkState?.ipv6_addresses.length > 0 && (
               <div className="space-y-3">
                 <h4 className="text-sm font-semibold">IPv6 Addresses</h4>
-                {networkState.ipv6_addresses.map(
-                  addr => (
-                    <div
-                      key={addr.address}
-                      className="rounded-md rounded-l-none border border-slate-500/10 border-l-blue-700/50 bg-white p-4 pl-4 backdrop-blur-sm dark:bg-transparent"
-                    >
-                      <div className="grid grid-cols-2 gap-x-8 gap-y-4">
-                        <div className="col-span-2 flex flex-col justify-between">
-                          <span className="text-sm text-slate-600 dark:text-slate-400">
-                            Address
-                          </span>
-                          <span className="text-sm font-medium">{addr.address}</span>
-                        </div>
-
-                        {addr.valid_lifetime && (
-                          <div className="flex flex-col justify-between">
-                            <span className="text-sm text-slate-600 dark:text-slate-400">
-                              Valid Lifetime
-                            </span>
-                            <span className="text-sm font-medium">
-                              {addr.valid_lifetime === "" ? (
-                                <span className="text-slate-400 dark:text-slate-600">
-                                  N/A
-                                </span>
-                              ) : (
-                                <LifeTimeLabel lifetime={`${addr.valid_lifetime}`} />
-                              )}
-                            </span>
-                          </div>
-                        )}
-                        {addr.preferred_lifetime && (
-                          <div className="flex flex-col justify-between">
-                            <span className="text-sm text-slate-600 dark:text-slate-400">
-                              Preferred Lifetime
-                            </span>
-                            <span className="text-sm font-medium">
-                              {addr.preferred_lifetime === "" ? (
-                                <span className="text-slate-400 dark:text-slate-600">
-                                  N/A
-                                </span>
-                              ) : (
-                                <LifeTimeLabel lifetime={`${addr.preferred_lifetime}`} />
-                              )}
-                            </span>
-                          </div>
-                        )}
+                {networkState.ipv6_addresses.map(addr => (
+                  <div
+                    key={addr.address}
+                    className="rounded-md rounded-l-none border border-slate-500/10 border-l-blue-700/50 bg-white p-4 pl-4 backdrop-blur-sm dark:bg-transparent"
+                  >
+                    <div className="grid grid-cols-2 gap-x-8 gap-y-4">
+                      <div className="col-span-2 flex flex-col justify-between">
+                        <span className="text-sm text-slate-600 dark:text-slate-400">
+                          Address
+                        </span>
+                        <span className="text-sm font-medium">{addr.address}</span>
                       </div>
+
+                      {addr.valid_lifetime && (
+                        <div className="flex flex-col justify-between">
+                          <span className="text-sm text-slate-600 dark:text-slate-400">
+                            Valid Lifetime
+                          </span>
+                          <span className="text-sm font-medium">
+                            {addr.valid_lifetime === "" ? (
+                              <span className="text-slate-400 dark:text-slate-600">
+                                N/A
+                              </span>
+                            ) : (
+                              <LifeTimeLabel lifetime={`${addr.valid_lifetime}`} />
+                            )}
+                          </span>
+                        </div>
+                      )}
+                      {addr.preferred_lifetime && (
+                        <div className="flex flex-col justify-between">
+                          <span className="text-sm text-slate-600 dark:text-slate-400">
+                            Preferred Lifetime
+                          </span>
+                          <span className="text-sm font-medium">
+                            {addr.preferred_lifetime === "" ? (
+                              <span className="text-slate-400 dark:text-slate-600">
+                                N/A
+                              </span>
+                            ) : (
+                              <LifeTimeLabel lifetime={`${addr.preferred_lifetime}`} />
+                            )}
+                          </span>
+                        </div>
+                      )}
                     </div>
-                  ),
-                )}
+                  </div>
+                ))}
               </div>
             )}
           </div>

--- a/ui/src/components/Ipv6NetworkCard.tsx
+++ b/ui/src/components/Ipv6NetworkCard.tsx
@@ -6,7 +6,7 @@ import { GridCard } from "./Card";
 export default function Ipv6NetworkCard({
   networkState,
 }: {
-  networkState: NetworkState;
+  networkState: NetworkState | undefined;
 }) {
   return (
     <GridCard>

--- a/ui/src/components/SettingsPageheader.tsx
+++ b/ui/src/components/SettingsPageheader.tsx
@@ -3,14 +3,19 @@ import { ReactNode } from "react";
 export function SettingsPageHeader({
   title,
   description,
+  action,
 }: {
   title: string | ReactNode;
   description: string | ReactNode;
+  action?: ReactNode;
 }) {
   return (
-    <div className="select-none">
-      <h2 className=" text-xl font-extrabold text-black dark:text-white">{title}</h2>
-      <div className="text-sm text-black dark:text-slate-300">{description}</div>
+    <div className="flex items-center justify-between gap-x-2 select-none">
+      <div className="flex flex-col gap-y-1">
+        <h2 className="text-xl font-extrabold text-black dark:text-white">{title}</h2>
+        <div className="text-sm text-black dark:text-slate-300">{description}</div>
+      </div>
+      {action && <div className="">{action}</div>}
     </div>
   );
 }

--- a/ui/src/components/StaticIpv4Card.tsx
+++ b/ui/src/components/StaticIpv4Card.tsx
@@ -1,0 +1,237 @@
+import { useState, useEffect } from "react";
+import { LuPlus, LuX } from "react-icons/lu";
+import isIP from "validator/es/lib/isIP";
+
+import { GridCard } from "@/components/Card";
+import { Button } from "@/components/Button";
+import { InputFieldWithLabel } from "@/components/InputField";
+import { IPv4StaticConfig, NetworkSettings, NetworkState } from "@/hooks/stores";
+
+interface StaticIpv4CardProps {
+  networkSettings: NetworkSettings;
+  onUpdate: (settings: NetworkSettings) => void;
+  networkState?: NetworkState;
+  onApply: () => void;
+}
+
+export default function StaticIpv4Card({
+  networkSettings,
+  onUpdate,
+  networkState,
+  onApply,
+}: StaticIpv4CardProps) {
+  const [staticConfig, setStaticConfig] = useState<IPv4StaticConfig>({
+    address: "",
+    netmask: "",
+    gateway: "",
+    dns: [],
+  });
+
+  // Validation errors
+  const addressError =
+    staticConfig.address && !isIP(staticConfig.address, "4") ? "Invalid IP address" : "";
+  const netmaskError =
+    staticConfig.netmask && !isIP(staticConfig.netmask, "4") ? "Invalid subnet mask" : "";
+  const gatewayError =
+    staticConfig.gateway && !isIP(staticConfig.gateway, "4")
+      ? "Invalid gateway address"
+      : "";
+  const dnsErrors = staticConfig.dns.map(dns =>
+    dns && !isIP(dns, "4") ? "Invalid DNS server" : "",
+  );
+
+  // Check if any field has an error or if required fields are empty
+  const hasValidationErrors = !!(
+    addressError ||
+    netmaskError ||
+    gatewayError ||
+    dnsErrors.some(error => error)
+  );
+  const hasEmptyRequiredFields =
+    !staticConfig.address ||
+    !staticConfig.netmask ||
+    !staticConfig.gateway ||
+    staticConfig.dns.length === 0;
+  const isFormValid = !hasValidationErrors && !hasEmptyRequiredFields;
+
+  // Initialize from existing settings or use current network state as defaults
+  useEffect(() => {
+    if (networkSettings.ipv4_static) {
+      setStaticConfig(networkSettings.ipv4_static);
+    } else if (networkState?.dhcp_lease) {
+      // Use current DHCP values as defaults
+      const defaults: IPv4StaticConfig = {
+        address: networkState.dhcp_lease.ip || "",
+        netmask: networkState.dhcp_lease.netmask || "",
+        gateway: networkState.dhcp_lease.routers?.[0] || "",
+        dns: networkState.dhcp_lease.dns_servers || [],
+      };
+      setStaticConfig(defaults);
+      // Update the parent with these default values
+      onUpdate({ ...networkSettings, ipv4_static: defaults });
+    }
+  }, [networkSettings.ipv4_static, networkState?.dhcp_lease, networkSettings, onUpdate]);
+
+  const handleConfigChange = (
+    field: keyof Omit<IPv4StaticConfig, "dns">,
+    value: string,
+  ) => {
+    const updatedConfig = { ...staticConfig, [field]: value };
+    setStaticConfig(updatedConfig);
+    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
+  };
+
+  const handleDnsChange = (index: number, value: string) => {
+    const updatedDns = [...staticConfig.dns];
+    updatedDns[index] = value;
+    const updatedConfig = { ...staticConfig, dns: updatedDns };
+    setStaticConfig(updatedConfig);
+    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
+  };
+
+  const handleAddDnsField = () => {
+    const updatedConfig = {
+      ...staticConfig,
+      dns: [...staticConfig.dns, ""],
+    };
+    setStaticConfig(updatedConfig);
+    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
+  };
+
+  const handleRemoveDnsServer = (index: number) => {
+    const updatedConfig = {
+      ...staticConfig,
+      dns: staticConfig.dns.filter((_, i) => i !== index),
+    };
+    setStaticConfig(updatedConfig);
+    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
+  };
+
+  return (
+    <GridCard>
+      <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">
+        <div className="space-y-4">
+          <h3 className="text-base font-bold text-slate-900 dark:text-white">
+            Static IPv4 Configuration
+          </h3>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <InputFieldWithLabel
+              label="IP Address"
+              type="text"
+              size="SM"
+              placeholder="192.168.1.100"
+              value={staticConfig.address}
+              onChange={e => handleConfigChange("address", e.target.value)}
+              error={addressError}
+            />
+
+            <InputFieldWithLabel
+              label="Subnet Mask"
+              type="text"
+              size="SM"
+              placeholder="255.255.255.0"
+              value={staticConfig.netmask}
+              onChange={e => handleConfigChange("netmask", e.target.value)}
+              error={netmaskError}
+            />
+          </div>
+
+          <InputFieldWithLabel
+            label="Gateway"
+            type="text"
+            size="SM"
+            placeholder="192.168.1.1"
+            value={staticConfig.gateway}
+            onChange={e => handleConfigChange("gateway", e.target.value)}
+            error={gatewayError}
+          />
+
+          {/* DNS server fields */}
+          <div className="space-y-2">
+            {staticConfig.dns.length === 0 && (
+              <div className="flex items-center gap-2">
+                <div className="flex-1">
+                  <InputFieldWithLabel
+                    label="Primary DNS Server"
+                    type="text"
+                    size="SM"
+                    placeholder="8.8.8.8"
+                    value=""
+                    onChange={e => {
+                      const updatedConfig = { ...staticConfig, dns: [e.target.value] };
+                      setStaticConfig(updatedConfig);
+                      onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
+                    }}
+                  />
+                </div>
+              </div>
+            )}
+
+            {staticConfig.dns.map((dns, index) => (
+              <StaticIpv4DnsField
+                key={index}
+                value={dns}
+                index={index}
+                isLast={index === staticConfig.dns.length - 1}
+                onChange={e => handleDnsChange(index, e)}
+                onAdd={handleAddDnsField}
+                onRemove={handleRemoveDnsServer}
+                error={dnsErrors[index]}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </GridCard>
+  );
+}
+
+export function StaticIpv4DnsField({
+  value,
+  index,
+  isLast,
+  onChange,
+  onAdd,
+  onRemove,
+  error,
+}: {
+  value: string;
+  index: number;
+  isLast: boolean;
+  onChange: (dns: string) => void;
+  onAdd: () => void;
+  onRemove: (index: number) => void;
+  error?: string;
+}) {
+  return (
+    <div key={index} className="flex items-center gap-2">
+      <div className="flex-1">
+        <InputFieldWithLabel
+          label={index === 0 ? "Primary DNS Server" : `DNS Server ${index + 1}`}
+          type="text"
+          size="SM"
+          placeholder="8.8.8.8"
+          value={value}
+          onChange={e => onChange(e.target.value)}
+          error={error || ""}
+        />
+      </div>
+      <div className="mt-[21.875px] flex-shrink-0">
+        {
+          // if last item, show add button
+          isLast ? (
+            <Button size="SM" theme="light" onClick={onAdd} LeadingIcon={LuPlus} />
+          ) : (
+            <Button
+              size="SM"
+              theme="danger"
+              onClick={() => onRemove(index)}
+              LeadingIcon={LuX}
+            />
+          )
+        }
+      </div>
+    </div>
+  );
+}

--- a/ui/src/components/StaticIpv4Card.tsx
+++ b/ui/src/components/StaticIpv4Card.tsx
@@ -1,111 +1,16 @@
-import { useState, useEffect } from "react";
 import { LuPlus, LuX } from "react-icons/lu";
-import isIP from "validator/es/lib/isIP";
+import { useFieldArray, useFormContext } from "react-hook-form";
+import validator from "validator";
 
 import { GridCard } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { InputFieldWithLabel } from "@/components/InputField";
-import { IPv4StaticConfig, NetworkSettings, NetworkState } from "@/hooks/stores";
 
-interface StaticIpv4CardProps {
-  networkSettings: NetworkSettings;
-  onUpdate: (settings: NetworkSettings) => void;
-  networkState?: NetworkState;
-  onApply: () => void;
-}
+export default function StaticIpv4Card() {
+  const formMethods = useFormContext();
+  const { register, formState } = formMethods;
 
-export default function StaticIpv4Card({
-  networkSettings,
-  onUpdate,
-  networkState,
-  onApply,
-}: StaticIpv4CardProps) {
-  const [staticConfig, setStaticConfig] = useState<IPv4StaticConfig>({
-    address: "",
-    netmask: "",
-    gateway: "",
-    dns: [],
-  });
-
-  // Validation errors
-  const addressError =
-    staticConfig.address && !isIP(staticConfig.address, "4") ? "Invalid IP address" : "";
-  const netmaskError =
-    staticConfig.netmask && !isIP(staticConfig.netmask, "4") ? "Invalid subnet mask" : "";
-  const gatewayError =
-    staticConfig.gateway && !isIP(staticConfig.gateway, "4")
-      ? "Invalid gateway address"
-      : "";
-  const dnsErrors = staticConfig.dns.map(dns =>
-    dns && !isIP(dns, "4") ? "Invalid DNS server" : "",
-  );
-
-  // Check if any field has an error or if required fields are empty
-  const hasValidationErrors = !!(
-    addressError ||
-    netmaskError ||
-    gatewayError ||
-    dnsErrors.some(error => error)
-  );
-  const hasEmptyRequiredFields =
-    !staticConfig.address ||
-    !staticConfig.netmask ||
-    !staticConfig.gateway ||
-    staticConfig.dns.length === 0;
-  const isFormValid = !hasValidationErrors && !hasEmptyRequiredFields;
-
-  // Initialize from existing settings or use current network state as defaults
-  useEffect(() => {
-    if (networkSettings.ipv4_static) {
-      setStaticConfig(networkSettings.ipv4_static);
-    } else if (networkState?.dhcp_lease) {
-      // Use current DHCP values as defaults
-      const defaults: IPv4StaticConfig = {
-        address: networkState.dhcp_lease.ip || "",
-        netmask: networkState.dhcp_lease.netmask || "",
-        gateway: networkState.dhcp_lease.routers?.[0] || "",
-        dns: networkState.dhcp_lease.dns_servers || [],
-      };
-      setStaticConfig(defaults);
-      // Update the parent with these default values
-      onUpdate({ ...networkSettings, ipv4_static: defaults });
-    }
-  }, [networkSettings.ipv4_static, networkState?.dhcp_lease, networkSettings, onUpdate]);
-
-  const handleConfigChange = (
-    field: keyof Omit<IPv4StaticConfig, "dns">,
-    value: string,
-  ) => {
-    const updatedConfig = { ...staticConfig, [field]: value };
-    setStaticConfig(updatedConfig);
-    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
-  };
-
-  const handleDnsChange = (index: number, value: string) => {
-    const updatedDns = [...staticConfig.dns];
-    updatedDns[index] = value;
-    const updatedConfig = { ...staticConfig, dns: updatedDns };
-    setStaticConfig(updatedConfig);
-    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
-  };
-
-  const handleAddDnsField = () => {
-    const updatedConfig = {
-      ...staticConfig,
-      dns: [...staticConfig.dns, ""],
-    };
-    setStaticConfig(updatedConfig);
-    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
-  };
-
-  const handleRemoveDnsServer = (index: number) => {
-    const updatedConfig = {
-      ...staticConfig,
-      dns: staticConfig.dns.filter((_, i) => i !== index),
-    };
-    setStaticConfig(updatedConfig);
-    onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
-  };
+  const { fields, append, remove } = useFieldArray({ name: "ipv4_static.dns" });
 
   return (
     <GridCard>
@@ -121,9 +26,7 @@ export default function StaticIpv4Card({
               type="text"
               size="SM"
               placeholder="192.168.1.100"
-              value={staticConfig.address}
-              onChange={e => handleConfigChange("address", e.target.value)}
-              error={addressError}
+              {...register("ipv4_static.address")}
             />
 
             <InputFieldWithLabel
@@ -131,9 +34,7 @@ export default function StaticIpv4Card({
               type="text"
               size="SM"
               placeholder="255.255.255.0"
-              value={staticConfig.netmask}
-              onChange={e => handleConfigChange("netmask", e.target.value)}
-              error={netmaskError}
+              {...register("ipv4_static.netmask")}
             />
           </div>
 
@@ -142,96 +43,58 @@ export default function StaticIpv4Card({
             type="text"
             size="SM"
             placeholder="192.168.1.1"
-            value={staticConfig.gateway}
-            onChange={e => handleConfigChange("gateway", e.target.value)}
-            error={gatewayError}
+            {...register("ipv4_static.gateway")}
           />
 
           {/* DNS server fields */}
-          <div className="space-y-2">
-            {staticConfig.dns.length === 0 && (
-              <div className="flex items-center gap-2">
-                <div className="flex-1">
-                  <InputFieldWithLabel
-                    label="Primary DNS Server"
-                    type="text"
-                    size="SM"
-                    placeholder="8.8.8.8"
-                    value=""
-                    onChange={e => {
-                      const updatedConfig = { ...staticConfig, dns: [e.target.value] };
-                      setStaticConfig(updatedConfig);
-                      onUpdate({ ...networkSettings, ipv4_static: updatedConfig });
-                    }}
-                  />
+          <div className="space-y-4">
+            {fields.map((dns, index) => {
+              return (
+                <div key={dns.id}>
+                  <div className="flex items-start gap-x-2">
+                    <div className="flex-1">
+                      <InputFieldWithLabel
+                        label={index === 0 ? "DNS Server" : null}
+                        type="text"
+                        size="SM"
+                        placeholder="1.1.1.1"
+                        {...register(`ipv4_static.dns.${index}`, {
+                          validate: (value: string) => {
+                            if (value === "") return true;
+                            if (!validator.isIP(value)) return "Invalid IP address";
+                            return true;
+                          },
+                        })}
+                        error={formState.errors.ipv4_static?.dns?.[index]?.message}
+                      />
+                    </div>
+                    {index > 0 && (
+                      <div className="flex-shrink-0">
+                        <Button
+                          size="SM"
+                          theme="light"
+                          type="button"
+                          onClick={() => remove(index)}
+                          LeadingIcon={LuX}
+                        />
+                      </div>
+                    )}
+                  </div>
                 </div>
-              </div>
-            )}
-
-            {staticConfig.dns.map((dns, index) => (
-              <StaticIpv4DnsField
-                key={index}
-                value={dns}
-                index={index}
-                isLast={index === staticConfig.dns.length - 1}
-                onChange={e => handleDnsChange(index, e)}
-                onAdd={handleAddDnsField}
-                onRemove={handleRemoveDnsServer}
-                error={dnsErrors[index]}
-              />
-            ))}
+              );
+            })}
           </div>
+
+          <Button
+            size="SM"
+            theme="light"
+            onClick={() => append("", { shouldFocus: true })}
+            LeadingIcon={LuPlus}
+            type="button"
+            text="Add DNS Server"
+          />
         </div>
       </div>
     </GridCard>
-  );
-}
-
-export function StaticIpv4DnsField({
-  value,
-  index,
-  isLast,
-  onChange,
-  onAdd,
-  onRemove,
-  error,
-}: {
-  value: string;
-  index: number;
-  isLast: boolean;
-  onChange: (dns: string) => void;
-  onAdd: () => void;
-  onRemove: (index: number) => void;
-  error?: string;
-}) {
-  return (
-    <div key={index} className="flex items-center gap-2">
-      <div className="flex-1">
-        <InputFieldWithLabel
-          label={index === 0 ? "Primary DNS Server" : `DNS Server ${index + 1}`}
-          type="text"
-          size="SM"
-          placeholder="8.8.8.8"
-          value={value}
-          onChange={e => onChange(e.target.value)}
-          error={error || ""}
-        />
-      </div>
-      <div className="mt-[21.875px] flex-shrink-0">
-        {
-          // if last item, show add button
-          isLast ? (
-            <Button size="SM" theme="light" onClick={onAdd} LeadingIcon={LuPlus} />
-          ) : (
-            <Button
-              size="SM"
-              theme="danger"
-              onClick={() => onRemove(index)}
-              LeadingIcon={LuX}
-            />
-          )
-        }
-      </div>
-    </div>
   );
 }

--- a/ui/src/components/StaticIpv4Card.tsx
+++ b/ui/src/components/StaticIpv4Card.tsx
@@ -1,13 +1,15 @@
 import { LuPlus, LuX } from "react-icons/lu";
 import { useFieldArray, useFormContext } from "react-hook-form";
 import { useEffect } from "react";
+import validator from "validator";
 
 import { GridCard } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { InputFieldWithLabel } from "@/components/InputField";
+import { NetworkSettings } from "@/hooks/stores";
 
 export default function StaticIpv4Card() {
-  const formMethods = useFormContext();
+  const formMethods = useFormContext<NetworkSettings>();
   const { register, formState, watch } = formMethods;
 
   const { fields, append, remove } = useFieldArray({ name: "ipv4_static.dns" });
@@ -17,6 +19,12 @@ export default function StaticIpv4Card() {
   }, [append, fields.length]);
 
   const dns = watch("ipv4_static.dns");
+
+  const validate = (value: string) => {
+    if (!validator.isIP(value)) return "Invalid IP address";
+    return true;
+  };
+
   return (
     <GridCard>
       <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">
@@ -31,7 +39,8 @@ export default function StaticIpv4Card() {
               type="text"
               size="SM"
               placeholder="192.168.1.100"
-              {...register("ipv4_static.address")}
+              {...register("ipv4_static.address", { validate })}
+              error={formState.errors.ipv4_static?.address?.message}
             />
 
             <InputFieldWithLabel
@@ -39,7 +48,8 @@ export default function StaticIpv4Card() {
               type="text"
               size="SM"
               placeholder="255.255.255.0"
-              {...register("ipv4_static.netmask")}
+              {...register("ipv4_static.netmask", { validate })}
+              error={formState.errors.ipv4_static?.netmask?.message}
             />
           </div>
 
@@ -48,7 +58,8 @@ export default function StaticIpv4Card() {
             type="text"
             size="SM"
             placeholder="192.168.1.1"
-            {...register("ipv4_static.gateway")}
+            {...register("ipv4_static.gateway", { validate })}
+            error={formState.errors.ipv4_static?.gateway?.message}
           />
 
           {/* DNS server fields */}
@@ -63,14 +74,7 @@ export default function StaticIpv4Card() {
                         type="text"
                         size="SM"
                         placeholder="1.1.1.1"
-                        {...register(`ipv4_static.dns.${index}`, {
-                          // validate: (value: string) => {
-                          //   if (value === "") return true;
-                          //   if (!validator.isIP(value)) return "Invalid IP address";
-                          //   return true;
-                          // },
-                        })}
-                        // @ts-expect-error - dns is not a field in the form
+                        {...register(`ipv4_static.dns.${index}`, { validate })}
                         error={formState.errors.ipv4_static?.dns?.[index]?.message}
                       />
                     </div>

--- a/ui/src/components/StaticIpv4Card.tsx
+++ b/ui/src/components/StaticIpv4Card.tsx
@@ -70,6 +70,7 @@ export default function StaticIpv4Card() {
                           //   return true;
                           // },
                         })}
+                        // @ts-expect-error - dns is not a field in the form
                         error={formState.errors.ipv4_static?.dns?.[index]?.message}
                       />
                     </div>

--- a/ui/src/components/StaticIpv6Card.tsx
+++ b/ui/src/components/StaticIpv6Card.tsx
@@ -47,6 +47,7 @@ export default function StaticIpv6Card() {
                 return true;
               },
             })}
+            // @ts-expect-error - address is not a field in the form
             error={formState.errors.ipv6_static?.address?.message}
           />
 
@@ -77,6 +78,7 @@ export default function StaticIpv6Card() {
                             return true;
                           },
                         })}
+                        // @ts-expect-error - dns is not a field in the form
                         error={formState.errors.ipv6_static?.dns?.[index]?.message}
                       />
                     </div>

--- a/ui/src/components/StaticIpv6Card.tsx
+++ b/ui/src/components/StaticIpv6Card.tsx
@@ -6,9 +6,10 @@ import { useEffect } from "react";
 import { GridCard } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { InputFieldWithLabel } from "@/components/InputField";
+import { NetworkSettings } from "@/hooks/stores";
 
 export default function StaticIpv6Card() {
-  const formMethods = useFormContext();
+  const formMethods = useFormContext<NetworkSettings>();
   const { register, formState, watch } = formMethods;
 
   const { fields, append, remove } = useFieldArray({ name: "ipv6_static.dns" });
@@ -18,6 +19,29 @@ export default function StaticIpv6Card() {
   }, [append, fields.length]);
 
   const dns = watch("ipv6_static.dns");
+
+  const cidrValidation = (value: string) => {
+    if (value === "") return true;
+
+    // Check if it's a valid IPv6 address with CIDR notation
+    const parts = value.split("/");
+    if (parts.length !== 2) return "Please use CIDR notation (e.g., 2001:db8::1/64)";
+
+    const [address, prefix] = parts;
+    if (!validator.isIP(address, 6)) return "Invalid IPv6 address";
+    const prefixNum = parseInt(prefix);
+    if (isNaN(prefixNum) || prefixNum < 0 || prefixNum > 128) {
+      return "Prefix must be between 0 and 128";
+    }
+
+    return true;
+  };
+
+  const ipv6Validation = (value: string) => {
+    if (!validator.isIP(value, 6)) return "Invalid IPv6 address";
+    return true;
+  };
+
   return (
     <GridCard>
       <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">
@@ -31,23 +55,7 @@ export default function StaticIpv6Card() {
             type="text"
             size="SM"
             placeholder="2001:db8::1/64"
-            {...register("ipv6_static.address", {
-              validate: (value: string) => {
-                if (value === "") return true;
-                // Check if it's a valid IPv6 address with CIDR notation
-                const parts = value.split("/");
-                if (parts.length !== 2)
-                  return "Please use CIDR notation (e.g., 2001:db8::1/64)";
-                const [address, prefix] = parts;
-                if (!validator.isIP(address, 6)) return "Invalid IPv6 address";
-                const prefixNum = parseInt(prefix);
-                if (isNaN(prefixNum) || prefixNum < 0 || prefixNum > 128) {
-                  return "Prefix must be between 0 and 128";
-                }
-                return true;
-              },
-            })}
-            // @ts-expect-error - address is not a field in the form
+            {...register("ipv6_static.address", { validate: cidrValidation })}
             error={formState.errors.ipv6_static?.address?.message}
           />
 
@@ -56,7 +64,8 @@ export default function StaticIpv6Card() {
             type="text"
             size="SM"
             placeholder="2001:db8::1"
-            {...register("ipv6_static.gateway")}
+            {...register("ipv6_static.gateway", { validate: ipv6Validation })}
+            error={formState.errors.ipv6_static?.gateway?.message}
           />
 
           {/* DNS server fields */}
@@ -72,13 +81,8 @@ export default function StaticIpv6Card() {
                         size="SM"
                         placeholder="2001:4860:4860::8888"
                         {...register(`ipv6_static.dns.${index}`, {
-                          validate: (value: string) => {
-                            if (value === "") return true;
-                            if (!validator.isIP(value)) return "Invalid IP address";
-                            return true;
-                          },
+                          validate: ipv6Validation,
                         })}
-                        // @ts-expect-error - dns is not a field in the form
                         error={formState.errors.ipv6_static?.dns?.[index]?.message}
                       />
                     </div>

--- a/ui/src/components/StaticIpv6Card.tsx
+++ b/ui/src/components/StaticIpv6Card.tsx
@@ -1,28 +1,29 @@
 import { LuPlus, LuX } from "react-icons/lu";
 import { useFieldArray, useFormContext } from "react-hook-form";
+import validator from "validator";
 import { useEffect } from "react";
 
 import { GridCard } from "@/components/Card";
 import { Button } from "@/components/Button";
 import { InputFieldWithLabel } from "@/components/InputField";
 
-export default function StaticIpv4Card() {
+export default function StaticIpv6Card() {
   const formMethods = useFormContext();
   const { register, formState, watch } = formMethods;
 
-  const { fields, append, remove } = useFieldArray({ name: "ipv4_static.dns" });
+  const { fields, append, remove } = useFieldArray({ name: "ipv6_static.dns" });
 
   useEffect(() => {
     if (fields.length === 0) append("");
   }, [append, fields.length]);
 
-  const dns = watch("ipv4_static.dns");
+  const dns = watch("ipv6_static.dns");
   return (
     <GridCard>
       <div className="animate-fadeIn p-4 text-black opacity-0 animation-duration-500 dark:text-white">
         <div className="space-y-4">
           <h3 className="text-base font-bold text-slate-900 dark:text-white">
-            Static IPv4 Configuration
+            Static IPv6 Configuration
           </h3>
 
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
@@ -30,16 +31,16 @@ export default function StaticIpv4Card() {
               label="IP Address"
               type="text"
               size="SM"
-              placeholder="192.168.1.100"
-              {...register("ipv4_static.address")}
+              placeholder="2001:db8::1"
+              {...register("ipv6_static.address")}
             />
 
             <InputFieldWithLabel
-              label="Subnet Mask"
+              label="Prefix"
               type="text"
               size="SM"
-              placeholder="255.255.255.0"
-              {...register("ipv4_static.netmask")}
+              placeholder="64"
+              {...register("ipv6_static.prefix")}
             />
           </div>
 
@@ -47,8 +48,8 @@ export default function StaticIpv4Card() {
             label="Gateway"
             type="text"
             size="SM"
-            placeholder="192.168.1.1"
-            {...register("ipv4_static.gateway")}
+            placeholder="2001:db8::1"
+            {...register("ipv6_static.gateway")}
           />
 
           {/* DNS server fields */}
@@ -63,14 +64,14 @@ export default function StaticIpv4Card() {
                         type="text"
                         size="SM"
                         placeholder="1.1.1.1"
-                        {...register(`ipv4_static.dns.${index}`, {
-                          // validate: (value: string) => {
-                          //   if (value === "") return true;
-                          //   if (!validator.isIP(value)) return "Invalid IP address";
-                          //   return true;
-                          // },
+                        {...register(`ipv6_static.dns.${index}`, {
+                          validate: (value: string) => {
+                            if (value === "") return true;
+                            if (!validator.isIP(value)) return "Invalid IP address";
+                            return true;
+                          },
                         })}
-                        error={formState.errors.ipv4_static?.dns?.[index]?.message}
+                        error={formState.errors.ipv6_static?.dns?.[index]?.message}
                       />
                     </div>
                     {index > 0 && (

--- a/ui/src/components/StaticIpv6Card.tsx
+++ b/ui/src/components/StaticIpv6Card.tsx
@@ -26,23 +26,29 @@ export default function StaticIpv6Card() {
             Static IPv6 Configuration
           </h3>
 
-          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <InputFieldWithLabel
-              label="IP Address"
-              type="text"
-              size="SM"
-              placeholder="2001:db8::1"
-              {...register("ipv6_static.address")}
-            />
-
-            <InputFieldWithLabel
-              label="Prefix"
-              type="text"
-              size="SM"
-              placeholder="64"
-              {...register("ipv6_static.prefix")}
-            />
-          </div>
+          <InputFieldWithLabel
+            label="IP Address/Prefix"
+            type="text"
+            size="SM"
+            placeholder="2001:db8::1/64"
+            {...register("ipv6_static.address", {
+              validate: (value: string) => {
+                if (value === "") return true;
+                // Check if it's a valid IPv6 address with CIDR notation
+                const parts = value.split("/");
+                if (parts.length !== 2)
+                  return "Please use CIDR notation (e.g., 2001:db8::1/64)";
+                const [address, prefix] = parts;
+                if (!validator.isIP(address, 6)) return "Invalid IPv6 address";
+                const prefixNum = parseInt(prefix);
+                if (isNaN(prefixNum) || prefixNum < 0 || prefixNum > 128) {
+                  return "Prefix must be between 0 and 128";
+                }
+                return true;
+              },
+            })}
+            error={formState.errors.ipv6_static?.address?.message}
+          />
 
           <InputFieldWithLabel
             label="Gateway"
@@ -63,7 +69,7 @@ export default function StaticIpv6Card() {
                         label={index === 0 ? "DNS Server" : null}
                         type="text"
                         size="SM"
-                        placeholder="1.1.1.1"
+                        placeholder="2001:4860:4860::8888"
                         {...register(`ipv6_static.dns.${index}`, {
                           validate: (value: string) => {
                             if (value === "") return true;

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -683,7 +683,7 @@ export interface DhcpLease {
   bootp_file?: string;
   timezone?: string;
   routers?: string[];
-  dns?: string[];
+  dns_servers?: string[];
   ntp_servers?: string[];
   lpr_servers?: string[];
   _time_servers?: string[];
@@ -744,11 +744,19 @@ export type TimeSyncMode =
   | "custom"
   | "unknown";
 
+export interface IPv4StaticConfig {
+  address: string;
+  netmask: string;
+  gateway: string;
+  dns: string[];
+}
+
 export interface NetworkSettings {
   hostname: string;
   domain: string;
   http_proxy: string;
   ipv4_mode: IPv4Mode;
+  ipv4_static?: IPv4StaticConfig;
   ipv6_mode: IPv6Mode;
   lldp_mode: LLDPMode;
   lldp_tx_tlvs: string[];

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -436,7 +436,7 @@ export interface KeyboardLedState {
   scroll_lock: boolean;
   compose: boolean;
   kana: boolean;
-};
+}
 const defaultKeyboardLedState: KeyboardLedState = {
   num_lock: false,
   caps_lock: false,
@@ -516,7 +516,8 @@ export const useHidStore = create<HidState>((set, get) => ({
   },
 
   keyboardLedStateSyncAvailable: false,
-  setKeyboardLedStateSyncAvailable: available => set({ keyboardLedStateSyncAvailable: available }),
+  setKeyboardLedStateSyncAvailable: available =>
+    set({ keyboardLedStateSyncAvailable: available }),
 
   isVirtualKeyboardEnabled: false,
   setVirtualKeyboardEnabled: enabled => set({ isVirtualKeyboardEnabled: enabled }),
@@ -752,9 +753,9 @@ export interface IPv4StaticConfig {
 }
 
 export interface NetworkSettings {
-  hostname: string;
-  domain: string;
-  http_proxy: string;
+  hostname: string | null;
+  domain: string | null;
+  http_proxy: string | null;
   ipv4_mode: IPv4Mode;
   ipv4_static?: IPv4StaticConfig;
   ipv6_mode: IPv6Mode;
@@ -944,5 +945,5 @@ export const useMacrosStore = create<MacrosState>((set, get) => ({
     } finally {
       set({ loading: false });
     }
-  }
+  },
 }));

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -752,6 +752,13 @@ export interface IPv4StaticConfig {
   dns: string[];
 }
 
+export interface IPv6StaticConfig {
+  address: string;
+  prefix: string;
+  gateway: string;
+  dns: string[];
+}
+
 export interface NetworkSettings {
   hostname: string | null;
   domain: string | null;
@@ -759,6 +766,7 @@ export interface NetworkSettings {
   ipv4_mode: IPv4Mode;
   ipv4_static?: IPv4StaticConfig;
   ipv6_mode: IPv6Mode;
+  ipv6_static?: IPv6StaticConfig;
   lldp_mode: LLDPMode;
   lldp_tx_tlvs: string[];
   mdns_mode: mDNSMode;

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -32,6 +32,7 @@
   --animate-fadeInScaleFloat:
     fadeInScaleFloat 1s ease-out forwards, float 3s ease-in-out infinite;
   --animate-fadeIn: fadeIn 1s ease-out forwards;
+  --animate-fadeInStill: fadeInStill 1s ease-out forwards;
   --animate-slideUpFade: slideUpFade 1s ease-out forwards;
 
   --container-8xl: 88rem;
@@ -107,6 +108,15 @@
     100% {
       opacity: 1;
       transform: translateY(0);
+    }
+  }
+
+  @keyframes fadeInStill {
+    0% {
+      opacity: 0;
+    }
+    100% {
+      opacity: 1;
     }
   }
 

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -27,6 +27,7 @@ import Ipv6NetworkCard from "../components/Ipv6NetworkCard";
 import EmptyCard from "../components/EmptyCard";
 import AutoHeight from "../components/AutoHeight";
 import DhcpLeaseCard from "../components/DhcpLeaseCard";
+import StaticIpv4Card from "../components/StaticIpv4Card";
 
 import { SettingsItem } from "./devices.$id.settings";
 
@@ -37,6 +38,7 @@ const defaultNetworkSettings: NetworkSettings = {
   http_proxy: "",
   domain: "",
   ipv4_mode: "unknown",
+  ipv4_static: undefined,
   ipv6_mode: "unknown",
   lldp_mode: "unknown",
   lldp_tx_tlvs: [],
@@ -127,7 +129,17 @@ export default function SettingsNetworkRoute() {
   const setNetworkSettingsRemote = useCallback(
     (settings: NetworkSettings) => {
       setNetworkSettingsLoaded(false);
-      send("setNetworkSettings", { settings }, resp => {
+
+      // Filter out empty DNS strings from static IP config before sending
+      const filteredSettings = { ...settings };
+      if (filteredSettings.ipv4_static?.dns) {
+        filteredSettings.ipv4_static = {
+          ...filteredSettings.ipv4_static,
+          dns: filteredSettings.ipv4_static.dns.filter(dns => dns.trim() !== "")
+        };
+      }
+
+      send("setNetworkSettings", { settings: filteredSettings }, resp => {
         if ("error" in resp) {
           notifications.error(
             "Failed to save network settings: " +
@@ -375,7 +387,7 @@ export default function SettingsNetworkRoute() {
               onChange={e => handleIpv4ModeChange(e.target.value)}
               options={filterUnknown([
                 { value: "dhcp", label: "DHCP" },
-                // { value: "static", label: "Static" },
+                { value: "static", label: "Static" },
               ])}
             />
           </SettingsItem>
@@ -390,12 +402,21 @@ export default function SettingsNetworkRoute() {
                     <div className="animate-pulse space-y-3">
                       <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
                       <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
-                      <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-                    </div>
+                      <div classNa
+                onApply={() => setNetworkSettingsRemote(networkSettings)}   </div>
                   </div>
                 </div>
               </GridCard>
-            ) : networkState?.dhcp_lease && networkState.dhcp_lease.ip ? (
+            ) : networkSettings.ipv4_mode === "static" ? (
+              <StaticIpv4Card
+                networkSettings={networkSettings}
+                onUpdate={setNetworkSettings}
+                networkState={networkState}
+                onApply={() => setNetworkSettingsRemote(networkSettings)}
+              />
+            ) : networkSettings.ipv4_mode === "dhcp" &&
+              networkState?.dhcp_lease &&
+              networkState.dhcp_lease.ip ? (
               <DhcpLeaseCard
                 networkState={networkState}
                 setShowRenewLeaseConfirm={setShowRenewLeaseConfirm}
@@ -403,8 +424,8 @@ export default function SettingsNetworkRoute() {
             ) : (
               <EmptyCard
                 IconElm={LuEthernetPort}
-                headline="DHCP Information"
-                description="No DHCP lease information available"
+                headline="Network Information"
+                description="No network configuration available"
               />
             )}
           </AutoHeight>

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -206,6 +206,16 @@ export default function SettingsNetworkRoute() {
   const ipv4mode = watch("ipv4_mode");
   const ipv6mode = watch("ipv6_mode");
 
+  const onDhcpLeaseRenew = () => {
+    send("renewDHCPLease", {}, resp => {
+      if ("error" in resp) {
+        notifications.error("Failed to renew lease: " + resp.error.message);
+      } else {
+        notifications.success("DHCP lease renewed");
+      }
+    });
+  };
+
   return (
     <>
       <FormProvider {...formMethods}>
@@ -496,15 +506,24 @@ export default function SettingsNetworkRoute() {
           </div>
         }
       />
-
       <ConfirmDialog
         open={showRenewLeaseConfirm}
-        title="Renew DHCP lease"
+        title="Renew DHCP Lease"
         variant="warning"
-        confirmText="Renew lease"
-        description="The device may briefly disconnect while requesting a new lease."
+        confirmText="Renew Lease"
+        description={
+          <p>
+            This will request a new IP address from your router. The device may briefly
+            disconnect during the renewal process.
+            <br />
+            <br />
+            If you receive a new IP address,{" "}
+            <strong>you may need to reconnect using the new address</strong>.
+          </p>
+        }
         onConfirm={() => {
           setShowRenewLeaseConfirm(false);
+          onDhcpLeaseRenew();
         }}
         onClose={() => setShowRenewLeaseConfirm(false)}
       />

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -1,49 +1,48 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { LuEthernetPort } from "react-icons/lu";
+import { useForm, FormProvider, FieldValues } from "react-hook-form";
+import validator from "validator";
 
-import {
-  IPv4Mode,
-  IPv6Mode,
-  LLDPMode,
-  mDNSMode,
-  NetworkSettings,
-  NetworkState,
-  TimeSyncMode,
-  useNetworkStateStore,
-} from "@/hooks/stores";
-import { useJsonRpc } from "@/hooks/useJsonRpc";
+import { NetworkSettings, NetworkState, useRTCStore } from "@/hooks/stores";
 import { Button } from "@components/Button";
 import { GridCard } from "@components/Card";
 import InputField, { InputFieldWithLabel } from "@components/InputField";
 import { SelectMenuBasic } from "@/components/SelectMenuBasic";
 import { SettingsPageHeader } from "@/components/SettingsPageheader";
-import Fieldset from "@/components/Fieldset";
 import { ConfirmDialog } from "@/components/ConfirmDialog";
 import notifications from "@/notifications";
+import { getNetworkSettings, getNetworkState } from "@/utils/jsonrpc";
 
 import Ipv6NetworkCard from "../components/Ipv6NetworkCard";
 import EmptyCard from "../components/EmptyCard";
 import AutoHeight from "../components/AutoHeight";
 import DhcpLeaseCard from "../components/DhcpLeaseCard";
 import StaticIpv4Card from "../components/StaticIpv4Card";
+import { useJsonRpc } from "../hooks/useJsonRpc";
 
 import { SettingsItem } from "./devices.$id.settings";
 
 dayjs.extend(relativeTime);
 
-const defaultNetworkSettings: NetworkSettings = {
-  hostname: "",
-  http_proxy: "",
-  domain: "",
-  ipv4_mode: "unknown",
-  ipv4_static: undefined,
-  ipv6_mode: "unknown",
-  lldp_mode: "unknown",
-  lldp_tx_tlvs: [],
-  mdns_mode: "unknown",
-  time_sync_mode: "unknown",
+const resolveOnRtcReady = () => {
+  return new Promise(resolve => {
+    // Check if RTC is already connected
+    const currentState = useRTCStore.getState();
+    if (currentState.rpcDataChannel?.readyState === "open") {
+      // Already connected, fetch data immediately
+      return resolve(void 0);
+    }
+
+    // Not connected yet, subscribe to state changes
+    const unsubscribe = useRTCStore.subscribe(state => {
+      if (state.rpcDataChannel?.readyState === "open") {
+        unsubscribe(); // Clean up subscription
+        return resolve(void 0);
+      }
+    });
+  });
 };
 
 export function LifeTimeLabel({ lifetime }: { lifetime: string }) {
@@ -75,434 +74,311 @@ export function LifeTimeLabel({ lifetime }: { lifetime: string }) {
 
 export default function SettingsNetworkRoute() {
   const [send] = useJsonRpc();
-  const [networkState, setNetworkState] = useNetworkStateStore(state => [
-    state,
-    state.setNetworkState,
-  ]);
 
-  const [networkSettings, setNetworkSettings] =
-    useState<NetworkSettings>(defaultNetworkSettings);
+  const [networkState, setNetworkState] = useState<NetworkState | null>(null);
 
-  // We use this to determine whether the settings have changed
-  const firstNetworkSettings = useRef<NetworkSettings | undefined>(undefined);
-
-  const [networkSettingsLoaded, setNetworkSettingsLoaded] = useState(false);
-
+  // Some input needs direct state management. Mostly options that open more details
   const [customDomain, setCustomDomain] = useState<string>("");
-  const [selectedDomainOption, setSelectedDomainOption] = useState<string>("dhcp");
 
-  useEffect(() => {
-    if (networkSettings.domain && networkSettingsLoaded) {
-      // Check if the domain is one of the predefined options
-      const predefinedOptions = ["dhcp", "local"];
-      if (predefinedOptions.includes(networkSettings.domain)) {
-        setSelectedDomainOption(networkSettings.domain);
-      } else {
-        setSelectedDomainOption("custom");
-        setCustomDomain(networkSettings.domain);
-      }
-    }
-  }, [networkSettings.domain, networkSettingsLoaded]);
-
-  const getNetworkSettings = useCallback(() => {
-    setNetworkSettingsLoaded(false);
-    send("getNetworkSettings", {}, resp => {
-      if ("error" in resp) return;
-      console.log(resp.result);
-      setNetworkSettings(resp.result as NetworkSettings);
-
-      if (!firstNetworkSettings.current) {
-        firstNetworkSettings.current = resp.result as NetworkSettings;
-      }
-      setNetworkSettingsLoaded(true);
-    });
-  }, [send]);
-
-  const getNetworkState = useCallback(() => {
-    send("getNetworkState", {}, resp => {
-      if ("error" in resp) return;
-      console.log(resp.result);
-      setNetworkState(resp.result as NetworkState);
-    });
-  }, [send, setNetworkState]);
-
-  const setNetworkSettingsRemote = useCallback(
-    (settings: NetworkSettings) => {
-      setNetworkSettingsLoaded(false);
-
-      // Filter out empty DNS strings from static IP config before sending
-      const filteredSettings = { ...settings };
-      if (filteredSettings.ipv4_static?.dns) {
-        filteredSettings.ipv4_static = {
-          ...filteredSettings.ipv4_static,
-          dns: filteredSettings.ipv4_static.dns.filter(dns => dns.trim() !== "")
-        };
-      }
-
-      send("setNetworkSettings", { settings: filteredSettings }, resp => {
-        if ("error" in resp) {
-          notifications.error(
-            "Failed to save network settings: " +
-              (resp.error.data ? resp.error.data : resp.error.message),
-          );
-          setNetworkSettingsLoaded(true);
-          return;
-        }
-        // We need to update the firstNetworkSettings ref to the new settings so we can use it to determine if the settings have changed
-        firstNetworkSettings.current = resp.result as NetworkSettings;
-        setNetworkSettings(resp.result as NetworkSettings);
-        getNetworkState();
-        setNetworkSettingsLoaded(true);
-        notifications.success("Network settings saved");
-      });
-    },
-    [getNetworkState, send],
-  );
-
-  const handleRenewLease = useCallback(() => {
-    send("renewDHCPLease", {}, resp => {
-      if ("error" in resp) {
-        notifications.error("Failed to renew lease: " + resp.error.message);
-      } else {
-        notifications.success("DHCP lease renewed");
-      }
-    });
-  }, [send]);
-
-  useEffect(() => {
-    getNetworkState();
-    getNetworkSettings();
-  }, [getNetworkState, getNetworkSettings]);
-
-  const handleIpv4ModeChange = (value: IPv4Mode | string) => {
-    setNetworkSettings({ ...networkSettings, ipv4_mode: value as IPv4Mode });
-  };
-
-  const handleIpv6ModeChange = (value: IPv6Mode | string) => {
-    setNetworkSettings({ ...networkSettings, ipv6_mode: value as IPv6Mode });
-  };
-
-  const handleLldpModeChange = (value: LLDPMode | string) => {
-    setNetworkSettings({ ...networkSettings, lldp_mode: value as LLDPMode });
-  };
-
-  const handleMdnsModeChange = (value: mDNSMode | string) => {
-    setNetworkSettings({ ...networkSettings, mdns_mode: value as mDNSMode });
-  };
-
-  const handleTimeSyncModeChange = (value: TimeSyncMode | string) => {
-    setNetworkSettings({ ...networkSettings, time_sync_mode: value as TimeSyncMode });
-  };
-
-  const handleHostnameChange = (value: string) => {
-    setNetworkSettings({ ...networkSettings, hostname: value });
-  };
-
-  const handleProxyChange = (value: string) => {
-    setNetworkSettings({ ...networkSettings, http_proxy: value });
-  };
-
-  const handleDomainChange = (value: string) => {
-    setNetworkSettings({ ...networkSettings, domain: value });
-  };
-
-  const handleDomainOptionChange = (value: string) => {
-    setSelectedDomainOption(value);
-    if (value !== "custom") {
-      handleDomainChange(value);
-    }
-  };
-
-  const handleCustomDomainChange = (value: string) => {
-    setCustomDomain(value);
-    handleDomainChange(value);
-  };
-
-  const filterUnknown = useCallback(
-    (options: { value: string; label: string }[]) => {
-      if (!networkSettingsLoaded) return options;
-      return options.filter(option => option.value !== "unknown");
-    },
-    [networkSettingsLoaded],
-  );
-
+  // Confirm dialog
   const [showRenewLeaseConfirm, setShowRenewLeaseConfirm] = useState(false);
 
+  const fetchNetworkData = useCallback(async () => {
+    try {
+      console.log("Fetching network data...");
+
+      const [settings, state] = (await Promise.all([
+        getNetworkSettings(),
+        getNetworkState(),
+      ])) as [NetworkSettings, NetworkState];
+
+      setNetworkState(state as NetworkState);
+
+      const settingsWithDefaults = {
+        ...settings,
+
+        domain: settings.domain || "local", // TODO: null means local domain TRUE?????
+        mdns_mode: settings.mdns_mode || "disabled",
+        time_sync_mode: settings.time_sync_mode || "ntp_only",
+        ipv4_static: {
+          address: settings.ipv4_static?.address || state.dhcp_lease?.ip || "",
+          netmask: settings.ipv4_static?.netmask || state.dhcp_lease?.netmask || "",
+          gateway: settings.ipv4_static?.gateway || state.dhcp_lease?.routers?.[0] || "",
+          dns: settings.ipv4_static?.dns || state.dhcp_lease?.dns_servers || [],
+        },
+      };
+
+      return { settings: settingsWithDefaults, state };
+    } catch (err) {
+      notifications.error(err instanceof Error ? err.message : "Unknown error");
+      throw err;
+    }
+  }, []);
+
+  const formMethods = useForm<NetworkSettings>({
+    mode: "onBlur",
+
+    defaultValues: async () => {
+      console.log("Preparing form default values...");
+
+      // Ensure data channel is ready, before fetching network data from the device
+      await resolveOnRtcReady();
+
+      const { settings } = await fetchNetworkData();
+      return settings;
+    },
+  });
+
+  const { register, handleSubmit, watch, formState, reset } = formMethods;
+
+  const onSubmit = async (data: FieldValues) => {
+    const settings = {
+      ...data,
+
+      // If custom domain option is selected, use the custom domain as value
+      domain: data.domain === "custom" ? customDomain : data.domain,
+      ipv4_static: {
+        ...data.ipv4_static,
+
+        // Remove empty DNS entries
+        dns: data.ipv4_static?.dns.filter((dns: string) => dns.trim() !== ""),
+      },
+    };
+
+    send("setNetworkSettings", { settings }, async resp => {
+      if ("error" in resp) {
+        return notifications.error(
+          resp.error.data ? resp.error.data : resp.error.message,
+        );
+      } else {
+        // If the settings are saved successfully, fetch the latest network data and reset the form
+        // We do this so we get all the form state values, for stuff like is the form dirty, etc...
+        const networkData = await fetchNetworkData();
+        reset(networkData.settings);
+        notifications.success("Network settings saved");
+      }
+    });
+  };
+
+  const isIPv4Mode = watch("ipv4_mode");
   return (
     <>
-      <Fieldset disabled={!networkSettingsLoaded} className="space-y-4">
-        <SettingsPageHeader
-          title="Network"
-          description="Configure your network settings"
-        />
-        <div className="space-y-4">
-          <SettingsItem
-            title="MAC Address"
-            description="Hardware identifier for the network interface"
-          >
-            <InputField
-              type="text"
-              size="SM"
-              value={networkState?.mac_address}
-              error={""}
-              readOnly={true}
-              className="dark:!text-opacity-60"
-            />
-          </SettingsItem>
-        </div>
-        <div className="space-y-4">
-          <SettingsItem
-            title="Hostname"
-            description="Device identifier on the network. Blank for system default"
-          >
-            <div className="relative">
-              <div>
-                <InputField
-                  size="SM"
-                  type="text"
-                  placeholder="jetkvm"
-                  defaultValue={networkSettings.hostname}
-                  onChange={e => {
-                    handleHostnameChange(e.target.value);
-                  }}
-                />
-              </div>
-            </div>
-          </SettingsItem>
-        </div>
-        <div className="space-y-4">
-          <SettingsItem
-            title="HTTP Proxy"
-            description="Proxy server for outgoing HTTP(S) requests from the device. Blank for none."
-          >
-            <div className="relative">
-              <div>
-                <InputField
-                  size="SM"
-                  type="text"
-                  placeholder="http://proxy.example.com:8080/"
-                  defaultValue={networkSettings.http_proxy}
-                  onChange={e => {
-                    handleProxyChange(e.target.value);
-                  }}
-                />
-              </div>
-            </div>
-          </SettingsItem>
-        </div>
-
-        <div className="space-y-4">
-          <div className="space-y-1">
-            <SettingsItem
-              title="Domain"
-              description="Network domain suffix for the device"
-            >
-              <div className="space-y-2">
-                <SelectMenuBasic
-                  size="SM"
-                  value={selectedDomainOption}
-                  onChange={e => handleDomainOptionChange(e.target.value)}
-                  options={[
-                    { value: "dhcp", label: "DHCP provided" },
-                    { value: "local", label: ".local" },
-                    { value: "custom", label: "Custom" },
-                  ]}
-                />
-              </div>
-            </SettingsItem>
-            {selectedDomainOption === "custom" && (
-              <div className="mt-2 w-1/3 border-l border-slate-800/10 pl-4 dark:border-slate-300/20">
-                <InputFieldWithLabel
-                  size="SM"
-                  type="text"
-                  label="Custom Domain"
-                  placeholder="home"
-                  value={customDomain}
-                  onChange={e => {
-                    setCustomDomain(e.target.value);
-                    handleCustomDomainChange(e.target.value);
-                  }}
-                />
-              </div>
-            )}
-          </div>
+      <FormProvider {...formMethods}>
+        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+          <SettingsPageHeader
+            title="Network"
+            description="Configure the network settings for the device"
+            action={
+              <>
+                {(formState.isDirty || formState.isSubmitting) && (
+                  <div className="animate-fadeInStill opacity-0 animation-duration-300">
+                    <Button
+                      size="SM"
+                      theme="primary"
+                      disabled={formState.isSubmitting}
+                      loading={formState.isSubmitting}
+                      type="submit"
+                      text={formState.isSubmitting ? "Saving..." : "Save Settings"}
+                    />
+                  </div>
+                )}
+              </>
+            }
+          />
           <div className="space-y-4">
             <SettingsItem
-              title="mDNS"
-              description="Control mDNS (multicast DNS) operational mode"
+              title="MAC Address"
+              description="Hardware identifier for the network interface"
             >
+              <InputField
+                type="text"
+                size="SM"
+                value={networkState?.mac_address}
+                error={""}
+                readOnly={true}
+                className="dark:!text-opacity-60"
+              />
+            </SettingsItem>
+            <SettingsItem title="Hostname" description="Set the device hostname">
+              <InputField
+                size="SM"
+                {...register("hostname")}
+                error={formState.errors.hostname?.message}
+              />
+            </SettingsItem>
+            <SettingsItem title="HTTP Proxy" description="Configure HTTP proxy settings">
+              <InputField
+                size="SM"
+                placeholder="http://proxy.example.com:8080"
+                {...register("http_proxy", {
+                  validate: (value: string | null) => {
+                    if (value === "") return true;
+                    if (!validator.isURL(value || "", { protocols: ["http", "https"] })) {
+                      return "Invalid HTTP proxy URL";
+                    }
+                    return true;
+                  },
+                })}
+                error={formState.errors.http_proxy?.message}
+              />
+            </SettingsItem>
+            <div className="space-y-1">
+              <SettingsItem
+                title="Domain"
+                description="Network domain suffix for the device"
+              >
+                <div className="space-y-2">
+                  <SelectMenuBasic
+                    size="SM"
+                    options={[
+                      { value: "dhcp", label: "DHCP provided" },
+                      { value: "local", label: ".local" },
+                      { value: "custom", label: "Custom" },
+                    ]}
+                    {...register("domain")}
+                    error={formState.errors.domain?.message}
+                  />
+                </div>
+              </SettingsItem>
+              {watch("domain") === "custom" && (
+                <div className="mt-2 w-1/3 border-l border-slate-800/10 pl-4 dark:border-slate-300/20">
+                  <InputFieldWithLabel
+                    size="SM"
+                    type="text"
+                    label="Custom Domain"
+                    placeholder="home"
+                    onChange={e => {
+                      setCustomDomain(e.target.value);
+                    }}
+                  />
+                </div>
+              )}
+            </div>
+
+            <SettingsItem title="mDNS Mode" description="Configure mDNS settings">
               <SelectMenuBasic
                 size="SM"
-                value={networkSettings.mdns_mode}
-                onChange={e => handleMdnsModeChange(e.target.value)}
-                options={filterUnknown([
+                options={[
                   { value: "disabled", label: "Disabled" },
                   { value: "auto", label: "Auto" },
                   { value: "ipv4_only", label: "IPv4 only" },
                   { value: "ipv6_only", label: "IPv6 only" },
-                ])}
+                ]}
+                {...register("mdns_mode")}
               />
             </SettingsItem>
-          </div>
-
-          <div className="space-y-4">
             <SettingsItem
               title="Time synchronization"
               description="Configure time synchronization settings"
             >
               <SelectMenuBasic
                 size="SM"
-                value={networkSettings.time_sync_mode}
-                onChange={e => {
-                  handleTimeSyncModeChange(e.target.value);
-                }}
-                options={filterUnknown([
-                  { value: "unknown", label: "..." },
-                  // { value: "auto", label: "Auto" },
+                options={[
                   { value: "ntp_only", label: "NTP only" },
                   { value: "ntp_and_http", label: "NTP and HTTP" },
                   { value: "http_only", label: "HTTP only" },
-                  // { value: "custom", label: "Custom" },
-                ])}
+                ]}
+                {...register("time_sync_mode")}
               />
             </SettingsItem>
-          </div>
 
-          <Button
-            size="SM"
-            theme="primary"
-            disabled={firstNetworkSettings.current === networkSettings}
-            text="Save Settings"
-            onClick={() => setNetworkSettingsRemote(networkSettings)}
-          />
-        </div>
-
-        <div className="h-px w-full bg-slate-800/10 dark:bg-slate-300/20" />
-
-        <div className="space-y-4">
-          <SettingsItem title="IPv4 Mode" description="Configure the IPv4 mode">
-            <SelectMenuBasic
-              size="SM"
-              value={networkSettings.ipv4_mode}
-              onChange={e => handleIpv4ModeChange(e.target.value)}
-              options={filterUnknown([
-                { value: "dhcp", label: "DHCP" },
-                { value: "static", label: "Static" },
-              ])}
-            />
-          </SettingsItem>
-          <AutoHeight>
-            {!networkSettingsLoaded && !networkState?.dhcp_lease ? (
-              <GridCard>
-                <div className="p-4">
-                  <div className="space-y-4">
-                    <h3 className="text-base font-bold text-slate-900 dark:text-white">
-                      DHCP Lease Information
-                    </h3>
-                    <div className="animate-pulse space-y-3">
-                      <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-                      <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
-                      <div classNa
-                onApply={() => setNetworkSettingsRemote(networkSettings)}   </div>
-                  </div>
-                </div>
-              </GridCard>
-            ) : networkSettings.ipv4_mode === "static" ? (
-              <StaticIpv4Card
-                networkSettings={networkSettings}
-                onUpdate={setNetworkSettings}
-                networkState={networkState}
-                onApply={() => setNetworkSettingsRemote(networkSettings)}
+            <SettingsItem title="IPv4 Mode" description="Configure the IPv4 mode">
+              <SelectMenuBasic
+                size="SM"
+                options={[
+                  { value: "dhcp", label: "DHCP" },
+                  { value: "static", label: "Static" },
+                ]}
+                {...register("ipv4_mode")}
               />
-            ) : networkSettings.ipv4_mode === "dhcp" &&
-              networkState?.dhcp_lease &&
-              networkState.dhcp_lease.ip ? (
-              <DhcpLeaseCard
-                networkState={networkState}
-                setShowRenewLeaseConfirm={setShowRenewLeaseConfirm}
-              />
-            ) : (
-              <EmptyCard
-                IconElm={LuEthernetPort}
-                headline="Network Information"
-                description="No network configuration available"
-              />
-            )}
-          </AutoHeight>
-        </div>
-        <div className="space-y-4">
-          <SettingsItem title="IPv6 Mode" description="Configure the IPv6 mode">
-            <SelectMenuBasic
-              size="SM"
-              value={networkSettings.ipv6_mode}
-              onChange={e => handleIpv6ModeChange(e.target.value)}
-              options={filterUnknown([
-                // { value: "disabled", label: "Disabled" },
-                { value: "slaac", label: "SLAAC" },
-                // { value: "dhcpv6", label: "DHCPv6" },
-                // { value: "slaac_and_dhcpv6", label: "SLAAC and DHCPv6" },
-                // { value: "static", label: "Static" },
-                // { value: "link_local", label: "Link-local only" },
-              ])}
-            />
-          </SettingsItem>
-          <AutoHeight>
-            {!networkSettingsLoaded &&
-            !(networkState?.ipv6_addresses && networkState.ipv6_addresses.length > 0) ? (
-              <GridCard>
-                <div className="p-4">
-                  <div className="space-y-4">
-                    <h3 className="text-base font-bold text-slate-900 dark:text-white">
-                      IPv6 Information
-                    </h3>
-                    <div className="animate-pulse space-y-3">
-                      <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
-                      <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
-                      <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
+            </SettingsItem>
+            <div>
+              <AutoHeight>
+                {formState.isLoading ? (
+                  <GridCard>
+                    <div className="p-4">
+                      <div className="space-y-4">
+                        <div className="h-6 w-1/3 animate-pulse rounded bg-slate-200 dark:bg-slate-700" />
+                        <div className="animate-pulse space-y-2">
+                          <div className="h-4 w-1/4 rounded bg-slate-200 dark:bg-slate-700" />
+                          <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
+                          <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
+                          <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
+                          <div className="h-4 w-1/4 rounded bg-slate-200 dark:bg-slate-700" />
+                        </div>
+                      </div>
                     </div>
-                  </div>
-                </div>
-              </GridCard>
-            ) : networkState?.ipv6_addresses && networkState.ipv6_addresses.length > 0 ? (
-              <Ipv6NetworkCard networkState={networkState} />
-            ) : (
-              <EmptyCard
-                IconElm={LuEthernetPort}
-                headline="IPv6 Information"
-                description="No IPv6 addresses configured"
+                  </GridCard>
+                ) : isIPv4Mode === "static" ? (
+                  <StaticIpv4Card />
+                ) : isIPv4Mode === "dhcp" ? (
+                  <DhcpLeaseCard
+                    networkState={networkState}
+                    setShowRenewLeaseConfirm={setShowRenewLeaseConfirm}
+                  />
+                ) : (
+                  <EmptyCard
+                    IconElm={LuEthernetPort}
+                    headline="Network Information"
+                    description="No network configuration available"
+                  />
+                )}
+              </AutoHeight>
+            </div>
+
+            <SettingsItem title="IPv6 Mode" description="Configure the IPv6 mode">
+              <SelectMenuBasic
+                size="SM"
+                options={[{ value: "slaac", label: "SLAAC" }]}
+                {...register("ipv6_mode")}
               />
+            </SettingsItem>
+            <div className="space-y-4">
+              <AutoHeight>
+                {!networkState?.ipv6_addresses ? (
+                  <GridCard>
+                    <div className="p-4">
+                      <div className="space-y-4">
+                        <h3 className="text-base font-bold text-slate-900 dark:text-white">
+                          IPv6 Network Information
+                        </h3>
+                        <div className="animate-pulse space-y-3">
+                          <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
+                          <div className="h-4 w-1/2 rounded bg-slate-200 dark:bg-slate-700" />
+                          <div className="h-4 w-1/3 rounded bg-slate-200 dark:bg-slate-700" />
+                        </div>
+                      </div>
+                    </div>
+                  </GridCard>
+                ) : (
+                  <Ipv6NetworkCard networkState={networkState || undefined} />
+                )}
+              </AutoHeight>
+            </div>
+            <div className="h-px w-full bg-slate-800/10 dark:bg-slate-300/20" />
+            {(formState.isDirty || formState.isSubmitting) && (
+              <div className="animate-fadeInStill opacity-0 animation-duration-300">
+                <Button
+                  size="SM"
+                  theme="primary"
+                  disabled={formState.isSubmitting}
+                  loading={formState.isSubmitting}
+                  type="submit"
+                  text={formState.isSubmitting ? "Saving..." : "Save Settings"}
+                />
+              </div>
             )}
-          </AutoHeight>
-        </div>
-        <div className="hidden space-y-4">
-          <SettingsItem
-            title="LLDP"
-            description="Control which TLVs will be sent over Link Layer Discovery Protocol"
-          >
-            <SelectMenuBasic
-              size="SM"
-              value={networkSettings.lldp_mode}
-              onChange={e => handleLldpModeChange(e.target.value)}
-              options={filterUnknown([
-                { value: "disabled", label: "Disabled" },
-                { value: "basic", label: "Basic" },
-                { value: "all", label: "All" },
-              ])}
-            />
-          </SettingsItem>
-        </div>
-      </Fieldset>
+          </div>
+        </form>
+      </FormProvider>
       <ConfirmDialog
         open={showRenewLeaseConfirm}
-        onClose={() => setShowRenewLeaseConfirm(false)}
         title="Renew DHCP Lease"
-        description="This will request a new IP address from your DHCP server. Your device may temporarily lose network connectivity during this process."
-        variant="danger"
-        confirmText="Renew Lease"
+        description="Are you sure you want to renew the DHCP lease? This may temporarily disconnect the device."
         onConfirm={() => {
-          handleRenewLease();
           setShowRenewLeaseConfirm(false);
         }}
+        onClose={() => setShowRenewLeaseConfirm(false)}
       />
     </>
   );

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 import { LuEthernetPort } from "react-icons/lu";
@@ -83,6 +83,13 @@ export default function SettingsNetworkRoute() {
 
   // Confirm dialog
   const [showRenewLeaseConfirm, setShowRenewLeaseConfirm] = useState(false);
+  const initialSettingsRef = useRef<NetworkSettings | null>(null);
+
+  const [showCriticalSettingsConfirm, setShowCriticalSettingsConfirm] = useState(false);
+  const [stagedSettings, setStagedSettings] = useState<NetworkSettings | null>(null);
+  const [criticalChanges, setCriticalChanges] = useState<
+    { label: string; from: string; to: string }[]
+  >([]);
 
   const fetchNetworkData = useCallback(async () => {
     try {
@@ -116,6 +123,7 @@ export default function SettingsNetworkRoute() {
         },
       };
 
+      initialSettingsRef.current = settingsWithDefaults;
       return { settings: settingsWithDefaults, state };
     } catch (err) {
       notifications.error(err instanceof Error ? err.message : "Unknown error");
@@ -137,10 +145,8 @@ export default function SettingsNetworkRoute() {
     },
   });
 
-  const { register, handleSubmit, watch, formState, reset } = formMethods;
-
-  const onSubmit = async (data: FieldValues) => {
-    const settings = {
+  const prepareSettings = (data: FieldValues) => {
+    return {
       ...data,
 
       // If custom domain option is selected, use the custom domain as value
@@ -157,8 +163,12 @@ export default function SettingsNetworkRoute() {
         // Remove empty DNS entries
         dns: data.ipv6_static?.dns.filter((dns: string) => dns.trim() !== ""),
       },
-    };
+    } as NetworkSettings;
+  };
 
+  const { register, handleSubmit, watch, formState, reset } = formMethods;
+
+  const onSubmit = async (settings: NetworkSettings) => {
     send("setNetworkSettings", { settings }, async resp => {
       if ("error" in resp) {
         return notifications.error(
@@ -174,12 +184,44 @@ export default function SettingsNetworkRoute() {
     });
   };
 
+  const onSubmitGate = async (data: FieldValues) => {
+    const settings = prepareSettings(data);
+    const dirty = formState.dirtyFields;
+
+    // These fields will prompt a confirm dialog, all else save immediately
+    const criticalFields = [
+      // Label is for the UI, key is the internal key of the field
+      { label: "IPv4 mode", key: "ipv4_mode" },
+      { label: "IPv6 mode", key: "ipv6_mode" },
+    ] as { label: string; key: keyof NetworkSettings }[];
+
+    const criticalChanged = criticalFields.some(field => dirty[field.key]);
+
+    // If no critical fields are changed, save immediately
+    if (!criticalChanged) return onSubmit(settings);
+
+    const changes = new Set<{ label: string; from: string; to: string }>();
+    criticalFields.forEach(field => {
+      const { key, label } = field;
+      if (dirty[key]) {
+        const from = initialSettingsRef?.current?.[key] as string;
+        const to = data[key] as string;
+        changes.add({ label, from, to });
+      }
+    });
+
+    setStagedSettings(settings);
+    setCriticalChanges(Array.from(changes));
+    setShowCriticalSettingsConfirm(true);
+  };
+
   const ipv4mode = watch("ipv4_mode");
   const ipv6mode = watch("ipv6_mode");
+
   return (
     <>
       <FormProvider {...formMethods}>
-        <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
+        <form onSubmit={handleSubmit(onSubmitGate)} className="space-y-4">
           <SettingsPageHeader
             title="Network"
             description="Configure the network settings for the device"
@@ -326,6 +368,12 @@ export default function SettingsNetworkRoute() {
                   </GridCard>
                 ) : ipv4mode === "static" ? (
                   <StaticIpv4Card />
+                ) : ipv4mode === "dhcp" && !!formState.dirtyFields.ipv4_mode ? (
+                  <EmptyCard
+                    IconElm={LuEthernetPort}
+                    headline="Pending DHCP IPv4 mode change"
+                    description="Save settings to enable DHCP mode and view lease information"
+                  />
                 ) : ipv4mode === "dhcp" ? (
                   <DhcpLeaseCard
                     networkState={networkState}
@@ -393,10 +441,80 @@ export default function SettingsNetworkRoute() {
           </div>
         </form>
       </FormProvider>
+
+      {/* Critical change confirm */}
+      <ConfirmDialog
+        open={showCriticalSettingsConfirm}
+        title="Apply network settings"
+        variant="warning"
+        confirmText="Apply changes"
+        onConfirm={() => {
+          setShowCriticalSettingsConfirm(false);
+          if (stagedSettings) onSubmit(stagedSettings);
+
+          // Wait for the close animation to finish before resetting the staged settings
+          setTimeout(() => {
+            setStagedSettings(null);
+            setCriticalChanges([]);
+          }, 500);
+        }}
+        onClose={() => {
+          // close();
+          setShowCriticalSettingsConfirm(false);
+        }}
+        isConfirming={formState.isSubmitting}
+        description={
+          <div className="space-y-4">
+            <p>
+              This will update the device&apos;s network configuration and may briefly
+              disconnect your session.
+            </p>
+
+            <div className="rounded-md border border-slate-200 bg-slate-50 p-3 dark:border-slate-700 dark:bg-slate-900/40">
+              <div className="mb-2 text-xs font-semibold tracking-wide text-slate-500 uppercase dark:text-slate-400">
+                Pending changes
+              </div>
+              <dl className="grid grid-cols-1 gap-y-2">
+                {criticalChanges.map((c, idx) => (
+                  <div key={idx} className="w-full not-last:pb-2">
+                    <div className="flex items-center gap-2 gap-x-8">
+                      <dt className="text-sm text-slate-500 dark:text-slate-400">
+                        {c.label}
+                      </dt>
+                      <div className="flex items-center gap-2">
+                        <span className="rounded-sm bg-slate-200 px-1.5 py-0.5 text-sm font-medium text-slate-900 dark:bg-slate-700 dark:text-slate-100">
+                          {c.from || "—"}
+                        </span>
+
+                        <span className="text-sm text-slate-500 dark:text-slate-400">
+                          →
+                        </span>
+
+                        <span className="rounded-sm bg-slate-200 px-1.5 py-0.5 text-sm font-medium text-slate-900 dark:bg-slate-700 dark:text-slate-100">
+                          {c.to}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                ))}
+              </dl>
+            </div>
+
+            <p className="text-sm">
+              If the network settings are invalid,{" "}
+              <strong>the device may become unreachable</strong> and require a factory
+              reset to restore connectivity.
+            </p>
+          </div>
+        }
+      />
+
       <ConfirmDialog
         open={showRenewLeaseConfirm}
-        title="Renew DHCP Lease"
-        description="Are you sure you want to renew the DHCP lease? This may temporarily disconnect the device."
+        title="Renew DHCP lease"
+        variant="warning"
+        confirmText="Renew lease"
+        description="The device may briefly disconnect while requesting a new lease."
         onConfirm={() => {
           setShowRenewLeaseConfirm(false);
         }}

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -21,6 +21,7 @@ import AutoHeight from "../components/AutoHeight";
 import DhcpLeaseCard from "../components/DhcpLeaseCard";
 import StaticIpv4Card from "../components/StaticIpv4Card";
 import { useJsonRpc } from "../hooks/useJsonRpc";
+import StaticIpv6Card from "../components/StaticIpv6Card";
 
 import { SettingsItem } from "./devices.$id.settings";
 
@@ -106,6 +107,13 @@ export default function SettingsNetworkRoute() {
           gateway: settings.ipv4_static?.gateway || state.dhcp_lease?.routers?.[0] || "",
           dns: settings.ipv4_static?.dns || state.dhcp_lease?.dns_servers || [],
         },
+        ipv6_static: {
+          address:
+            settings.ipv6_static?.address || state.ipv6_addresses?.[0]?.address || "",
+          prefix: settings.ipv6_static?.prefix || state.ipv6_addresses?.[0]?.prefix || "",
+          gateway: settings.ipv6_static?.gateway || "",
+          dns: settings.ipv6_static?.dns || [],
+        },
       };
 
       return { settings: settingsWithDefaults, state };
@@ -143,6 +151,12 @@ export default function SettingsNetworkRoute() {
         // Remove empty DNS entries
         dns: data.ipv4_static?.dns.filter((dns: string) => dns.trim() !== ""),
       },
+      ipv6_static: {
+        ...data.ipv6_static,
+
+        // Remove empty DNS entries
+        dns: data.ipv6_static?.dns.filter((dns: string) => dns.trim() !== ""),
+      },
     };
 
     send("setNetworkSettings", { settings }, async resp => {
@@ -160,7 +174,8 @@ export default function SettingsNetworkRoute() {
     });
   };
 
-  const isIPv4Mode = watch("ipv4_mode");
+  const ipv4mode = watch("ipv4_mode");
+  const ipv6mode = watch("ipv6_mode");
   return (
     <>
       <FormProvider {...formMethods}>
@@ -309,9 +324,9 @@ export default function SettingsNetworkRoute() {
                       </div>
                     </div>
                   </GridCard>
-                ) : isIPv4Mode === "static" ? (
+                ) : ipv4mode === "static" ? (
                   <StaticIpv4Card />
-                ) : isIPv4Mode === "dhcp" ? (
+                ) : ipv4mode === "dhcp" ? (
                   <DhcpLeaseCard
                     networkState={networkState}
                     setShowRenewLeaseConfirm={setShowRenewLeaseConfirm}
@@ -329,7 +344,10 @@ export default function SettingsNetworkRoute() {
             <SettingsItem title="IPv6 Mode" description="Configure the IPv6 mode">
               <SelectMenuBasic
                 size="SM"
-                options={[{ value: "slaac", label: "SLAAC" }]}
+                options={[
+                  { value: "slaac", label: "SLAAC" },
+                  { value: "static", label: "Static" },
+                ]}
                 {...register("ipv6_mode")}
               />
             </SettingsItem>
@@ -350,23 +368,27 @@ export default function SettingsNetworkRoute() {
                       </div>
                     </div>
                   </GridCard>
+                ) : ipv6mode === "static" ? (
+                  <StaticIpv6Card />
                 ) : (
                   <Ipv6NetworkCard networkState={networkState || undefined} />
                 )}
               </AutoHeight>
             </div>
-            <div className="h-px w-full bg-slate-800/10 dark:bg-slate-300/20" />
             {(formState.isDirty || formState.isSubmitting) && (
-              <div className="animate-fadeInStill opacity-0 animation-duration-300">
-                <Button
-                  size="SM"
-                  theme="primary"
-                  disabled={formState.isSubmitting}
-                  loading={formState.isSubmitting}
-                  type="submit"
-                  text={formState.isSubmitting ? "Saving..." : "Save Settings"}
-                />
-              </div>
+              <>
+                <div className="h-px w-full bg-slate-800/10 dark:bg-slate-300/20" />
+                <div className="animate-fadeInStill opacity-0 animation-duration-300">
+                  <Button
+                    size="SM"
+                    theme="primary"
+                    disabled={formState.isSubmitting}
+                    loading={formState.isSubmitting}
+                    type="submit"
+                    text={formState.isSubmitting ? "Saving..." : "Save Settings"}
+                  />
+                </div>
+              </>
             )}
           </div>
         </form>

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -151,18 +151,6 @@ export default function SettingsNetworkRoute() {
 
       // If custom domain option is selected, use the custom domain as value
       domain: data.domain === "custom" ? customDomain : data.domain,
-      ipv4_static: {
-        ...data.ipv4_static,
-
-        // Remove empty DNS entries
-        dns: data.ipv4_static?.dns.filter((dns: string) => dns.trim() !== ""),
-      },
-      ipv6_static: {
-        ...data.ipv6_static,
-
-        // Remove empty DNS entries
-        dns: data.ipv6_static?.dns.filter((dns: string) => dns.trim() !== ""),
-      },
     } as NetworkSettings;
   };
 

--- a/ui/src/utils/jsonrpc.ts
+++ b/ui/src/utils/jsonrpc.ts
@@ -1,0 +1,103 @@
+import { useRTCStore } from "@/hooks/stores";
+
+// JSON-RPC utility for use outside of React components
+export interface JsonRpcCallOptions {
+  method: string;
+  params?: unknown;
+  timeout?: number;
+}
+
+export interface JsonRpcCallResponse {
+  jsonrpc: string;
+  result?: unknown;
+  error?: {
+    code: number;
+    message: string;
+    data?: unknown;
+  };
+  id: number | string | null;
+}
+
+let rpcCallCounter = 0;
+
+export function callJsonRpc(options: JsonRpcCallOptions): Promise<JsonRpcCallResponse> {
+  return new Promise((resolve, reject) => {
+    // Access the RTC store directly outside of React context
+    const rpcDataChannel = useRTCStore.getState().rpcDataChannel;
+
+    if (!rpcDataChannel || rpcDataChannel.readyState !== "open") {
+      reject(new Error("RPC data channel not available"));
+      return;
+    }
+
+    rpcCallCounter++;
+    const requestId = `rpc_${Date.now()}_${rpcCallCounter}`;
+
+    const request = {
+      jsonrpc: "2.0",
+      method: options.method,
+      params: options.params || {},
+      id: requestId,
+    };
+
+    const timeout = options.timeout || 5000;
+    let timeoutId: number | undefined;
+
+    const messageHandler = (event: MessageEvent) => {
+      try {
+        const response = JSON.parse(event.data) as JsonRpcCallResponse;
+        if (response.id === requestId) {
+          clearTimeout(timeoutId);
+          rpcDataChannel.removeEventListener("message", messageHandler);
+          resolve(response);
+        }
+      } catch (error) {
+        // Ignore parse errors from other messages
+      }
+    };
+
+    timeoutId = setTimeout(() => {
+      rpcDataChannel.removeEventListener("message", messageHandler);
+      reject(new Error(`JSON-RPC call timed out after ${timeout}ms`));
+    }, timeout);
+
+    rpcDataChannel.addEventListener("message", messageHandler);
+    rpcDataChannel.send(JSON.stringify(request));
+  });
+}
+
+// Specific network settings API calls
+export async function getNetworkSettings() {
+  const response = await callJsonRpc({ method: "getNetworkSettings" });
+  if (response.error) {
+    throw new Error(response.error.message);
+  }
+  return response.result;
+}
+
+export async function setNetworkSettings(settings: unknown) {
+  const response = await callJsonRpc({
+    method: "setNetworkSettings",
+    params: { settings },
+  });
+  if (response.error) {
+    throw new Error(response.error.message);
+  }
+  return response.result;
+}
+
+export async function getNetworkState() {
+  const response = await callJsonRpc({ method: "getNetworkState" });
+  if (response.error) {
+    throw new Error(response.error.message);
+  }
+  return response.result;
+}
+
+export async function renewDHCPLease() {
+  const response = await callJsonRpc({ method: "renewDHCPLease" });
+  if (response.error) {
+    throw new Error(response.error.message);
+  }
+  return response.result;
+}


### PR DESCRIPTION
Until this PR, we haven't had a dedicated way to manage forms. All form state & data loading was handled with React. Not having a proper form solution and relying on React was the right decision given we only had simple forms. 

In this PR, I introduce `react-hook-form`, which simplifies form management and is starting to become needed in our settings. The network settings are now the only form that uses it, but we should migrate more of the forms to `react-hook-form`, so new contributions know what to do.

In terms of static IP features, as tracked here https://github.com/jetkvm/kvm/issues/37, consists of two parts: UI and touchscreen. This PR implements the UI part; the touchscreen part will come later.

This PR enabled settings for both static IPv4 and IPv6. As the wrong static configuration can render the device unreachable, there are config validations on both the client and device. Additionally, we prompt the user with a confirm dialog , with pending changes , to make sure they know what they're doing.

- [x] UI settings
- [ ] Real on device IPv4 & IPv6 mode changes cc @ym 