### PR TITLE
Allow disabling IPv6

### DIFF
--- a/internal/network/rpc.go
+++ b/internal/network/rpc.go
@@ -65,7 +65,7 @@ func (s *NetworkInterfaceState) IPv6LinkLocalAddress() string {
 func (s *NetworkInterfaceState) RpcGetNetworkState() RpcNetworkState {
 	ipv6Addresses := make([]RpcIPv6Address, 0)
 
-	if s.ipv6Addresses != nil {
+	if s.ipv6Addresses != nil && s.config.IPv6Mode.String != "disabled" {
 		for _, addr := range s.ipv6Addresses {
 			ipv6Addresses = append(ipv6Addresses, RpcIPv6Address{
 				Address:           addr.Prefix.String(),

--- a/ui/src/components/Ipv6NetworkCard.tsx
+++ b/ui/src/components/Ipv6NetworkCard.tsx
@@ -17,7 +17,7 @@ export default function Ipv6NetworkCard({
           </h3>
 
           <div className="grid grid-cols-2 gap-x-6 gap-y-2">
-            {networkState?.dhcp_lease?.ip && (
+            {networkState?.ipv6_link_local && (
               <div className="flex flex-col justify-between">
                 <span className="text-sm text-slate-600 dark:text-slate-400">
                   Link-local

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -419,7 +419,7 @@ export default function SettingsNetworkRoute() {
               value={networkSettings.ipv6_mode}
               onChange={e => handleIpv6ModeChange(e.target.value)}
               options={filterUnknown([
-                // { value: "disabled", label: "Disabled" },
+                { value: "disabled", label: "Disabled" },
                 { value: "slaac", label: "SLAAC" },
                 // { value: "dhcpv6", label: "DHCPv6" },
                 // { value: "slaac_and_dhcpv6", label: "SLAAC and DHCPv6" },


### PR DESCRIPTION
Simply ignores any IPv6 addresses in the lease and doesn't offer them to the RPC
Fixes https://github.com/orgs/jetkvm/projects/7/views/1?pane=issue&itemId=122761546&issue=jetkvm%7Ckvm%7C685
