### PR TITLE
feat: hid rpc channel

### DIFF
--- a/hidrpc.go
+++ b/hidrpc.go
@@ -2,6 +2,7 @@ package kvm
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/jetkvm/kvm/internal/hidrpc"
 	"github.com/jetkvm/kvm/internal/usbgadget"
@@ -19,9 +20,14 @@ func onHidMessage(data []byte, session *Session) {
 	)
 
 	if err := hidrpc.Unmarshal(data, &message); err != nil {
-		logger.Warn().Err(err).Msg("failed to unmarshal HID RPC message")
+		logger.Warn().Err(err).Bytes("data", data).Msg("failed to unmarshal HID RPC message")
 		return
 	}
+
+	scopedLogger := hidRpcLogger.With().Str("payload", message.String()).Logger()
+
+	scopedLogger.Debug().Msg("received HID RPC message from the queue")
+	startTime := time.Now()
 
 	switch message.Type() {
 	case hidrpc.TypeHandshake:
@@ -62,6 +68,9 @@ func onHidMessage(data []byte, session *Session) {
 	if rpcErr != nil {
 		logger.Warn().Err(rpcErr).Msg("failed to handle HID RPC message")
 	}
+
+	duration := time.Since(startTime)
+	scopedLogger.Debug().Dur("duration", duration).Msg("handled HID RPC message")
 }
 
 func handleHidRpcKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState, error) {

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jetkvm/kvm/internal/usbgadget"
 )
 
-func handleHidRpcMessage(message hidrpc.Message, session *Session) {
+func handleHidRPCMessage(message hidrpc.Message, session *Session) {
 	var rpcErr error
 
 	switch message.Type() {
@@ -22,11 +22,11 @@ func handleHidRpcMessage(message hidrpc.Message, session *Session) {
 			logger.Warn().Err(err).Msg("failed to send handshake message")
 			return
 		}
-		session.hidRpcAvailable = true
+		session.hidRPCAvailable = true
 	case hidrpc.TypeKeypressReport, hidrpc.TypeKeyboardReport:
-		keysDownState, err := handleHidRpcKeyboardInput(message)
+		keysDownState, err := handleHidRPCKeyboardInput(message)
 		if keysDownState != nil {
-			reportHidRpcKeysDownState(*keysDownState, session)
+			session.reportHidRPCKeysDownState(*keysDownState)
 		}
 		rpcErr = err
 	case hidrpc.TypePointerReport:
@@ -53,7 +53,7 @@ func handleHidRpcMessage(message hidrpc.Message, session *Session) {
 }
 
 func onHidMessage(data []byte, session *Session) {
-	scopedLogger := hidRpcLogger.With().Bytes("data", data).Logger()
+	scopedLogger := hidRPCLogger.With().Bytes("data", data).Logger()
 	scopedLogger.Debug().Msg("HID RPC message received")
 
 	if len(data) < 1 {
@@ -74,7 +74,7 @@ func onHidMessage(data []byte, session *Session) {
 
 	r := make(chan interface{})
 	go func() {
-		handleHidRpcMessage(message, session)
+		handleHidRPCMessage(message, session)
 		r <- nil
 	}()
 	select {
@@ -85,7 +85,7 @@ func onHidMessage(data []byte, session *Session) {
 	}
 }
 
-func handleHidRpcKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState, error) {
+func handleHidRPCKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState, error) {
 	switch message.Type() {
 	case hidrpc.TypeKeypressReport:
 		keypressReport, err := message.KeypressReport()
@@ -108,7 +108,7 @@ func handleHidRpcKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState
 	return nil, fmt.Errorf("unknown HID RPC message type: %d", message.Type())
 }
 
-func reportHidRpc(params any, session *Session) {
+func reportHidRPC(params any, session *Session) {
 	var (
 		message []byte
 		err     error
@@ -118,6 +118,8 @@ func reportHidRpc(params any, session *Session) {
 		message, err = hidrpc.NewKeyboardLedMessage(params).Marshal()
 	case usbgadget.KeysDownState:
 		message, err = hidrpc.NewKeydownStateMessage(params).Marshal()
+	default:
+		err = fmt.Errorf("unknown HID RPC message type: %T", params)
 	}
 
 	if err != nil {
@@ -135,16 +137,16 @@ func reportHidRpc(params any, session *Session) {
 	}
 }
 
-func reportHidRpcKeyboardLedState(state usbgadget.KeyboardState, session *Session) {
-	if !session.hidRpcAvailable {
-		writeJSONRPCEvent("keyboardLedState", state, currentSession)
+func (s *Session) reportHidRPCKeyboardLedState(state usbgadget.KeyboardState) {
+	if !s.hidRPCAvailable {
+		writeJSONRPCEvent("keyboardLedState", state, s)
 	}
-	reportHidRpc(state, session)
+	reportHidRPC(state, s)
 }
 
-func reportHidRpcKeysDownState(state usbgadget.KeysDownState, session *Session) {
-	if !session.hidRpcAvailable {
-		writeJSONRPCEvent("keysDownState", state, currentSession)
+func (s *Session) reportHidRPCKeysDownState(state usbgadget.KeysDownState) {
+	if !s.hidRPCAvailable {
+		writeJSONRPCEvent("keysDownState", state, s)
 	}
-	reportHidRpc(state, session)
+	reportHidRPC(state, s)
 }

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -109,6 +109,16 @@ func handleHidRPCKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState
 }
 
 func reportHidRPC(params any, session *Session) {
+	if session == nil {
+		logger.Warn().Msg("session is nil, skipping reportHidRPC")
+		return
+	}
+
+	if !session.hidRPCAvailable || session.HidChannel == nil {
+		logger.Warn().Msg("HID RPC is not available, skipping reportHidRPC")
+		return
+	}
+
 	var (
 		message []byte
 		err     error

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -8,26 +8,8 @@ import (
 	"github.com/jetkvm/kvm/internal/usbgadget"
 )
 
-func onHidMessage(data []byte, session *Session) {
-	if len(data) < 1 {
-		logger.Warn().Int("length", len(data)).Msg("received empty data in HID RPC message handler")
-		return
-	}
-
-	var (
-		message hidrpc.Message
-		rpcErr  error
-	)
-
-	if err := hidrpc.Unmarshal(data, &message); err != nil {
-		logger.Warn().Err(err).Bytes("data", data).Msg("failed to unmarshal HID RPC message")
-		return
-	}
-
-	scopedLogger := hidRpcLogger.With().Str("payload", message.String()).Logger()
-
-	scopedLogger.Debug().Msg("received HID RPC message from the queue")
-	startTime := time.Now()
+func handleHidRpcMessage(message hidrpc.Message, session *Session) {
+	var rpcErr error
 
 	switch message.Type() {
 	case hidrpc.TypeHandshake:
@@ -68,9 +50,39 @@ func onHidMessage(data []byte, session *Session) {
 	if rpcErr != nil {
 		logger.Warn().Err(rpcErr).Msg("failed to handle HID RPC message")
 	}
+}
 
-	duration := time.Since(startTime)
-	scopedLogger.Debug().Dur("duration", duration).Msg("handled HID RPC message")
+func onHidMessage(data []byte, session *Session) {
+	scopedLogger := hidRpcLogger.With().Bytes("data", data).Logger()
+	scopedLogger.Debug().Msg("HID RPC message received")
+
+	if len(data) < 1 {
+		scopedLogger.Warn().Int("length", len(data)).Msg("received empty data in HID RPC message handler")
+		return
+	}
+
+	var message hidrpc.Message
+
+	if err := hidrpc.Unmarshal(data, &message); err != nil {
+		scopedLogger.Warn().Err(err).Msg("failed to unmarshal HID RPC message")
+		return
+	}
+
+	scopedLogger = scopedLogger.With().Str("descr", message.String()).Logger()
+
+	t := time.Now()
+
+	r := make(chan interface{})
+	go func() {
+		handleHidRpcMessage(message, session)
+		r <- nil
+	}()
+	select {
+	case <-time.After(1 * time.Second):
+		scopedLogger.Warn().Msg("HID RPC message timed out")
+	case <-r:
+		scopedLogger.Debug().Dur("duration", time.Since(t)).Msg("HID RPC message handled")
+	}
 }
 
 func handleHidRpcKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState, error) {

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -1,0 +1,129 @@
+package kvm
+
+import (
+	"fmt"
+
+	"github.com/jetkvm/kvm/internal/hidrpc"
+	"github.com/jetkvm/kvm/internal/usbgadget"
+)
+
+func onHidMessage(data []byte, session *Session) {
+	if len(data) < 1 {
+		logger.Warn().Int("length", len(data)).Msg("received empty data in HID RPC message handler")
+		return
+	}
+
+	var (
+		message hidrpc.Message
+		rpcErr  error
+	)
+
+	if err := hidrpc.Unmarshal(data, &message); err != nil {
+		logger.Warn().Err(err).Msg("failed to unmarshal HID RPC message")
+		return
+	}
+
+	switch message.Type() {
+	case hidrpc.TypeHandshake:
+		message, err := hidrpc.NewHandshakeMessage().Marshal()
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to marshal handshake message")
+			return
+		}
+		if err := session.HidChannel.Send(message); err != nil {
+			logger.Warn().Err(err).Msg("failed to send handshake message")
+			return
+		}
+		session.hidRpcAvailable = true
+	case hidrpc.TypeKeypressReport, hidrpc.TypeKeyboardReport:
+		keysDownState, err := handleHidRpcKeyboardInput(message)
+		if keysDownState != nil {
+			reportHidRpcKeysDownState(*keysDownState, session)
+		}
+		rpcErr = err
+	case hidrpc.TypePointerReport:
+		pointerReport, err := message.PointerReport()
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to get pointer report")
+			return
+		}
+		rpcErr = rpcAbsMouseReport(pointerReport.X, pointerReport.Y, pointerReport.Button)
+	case hidrpc.TypeMouseReport:
+		mouseReport, err := message.MouseReport()
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to get mouse report")
+			return
+		}
+		rpcErr = rpcRelMouseReport(mouseReport.DX, mouseReport.DY, mouseReport.Button)
+	default:
+		logger.Warn().Uint8("type", uint8(message.Type())).Msg("unknown HID RPC message type")
+	}
+
+	if rpcErr != nil {
+		logger.Warn().Err(rpcErr).Msg("failed to handle HID RPC message")
+	}
+}
+
+func handleHidRpcKeyboardInput(message hidrpc.Message) (*usbgadget.KeysDownState, error) {
+	switch message.Type() {
+	case hidrpc.TypeKeypressReport:
+		keypressReport, err := message.KeypressReport()
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to get keypress report")
+			return nil, err
+		}
+		keysDownState, rpcError := rpcKeypressReport(keypressReport.Key, keypressReport.Press)
+		return &keysDownState, rpcError
+	case hidrpc.TypeKeyboardReport:
+		keyboardReport, err := message.KeyboardReport()
+		if err != nil {
+			logger.Warn().Err(err).Msg("failed to get keyboard report")
+			return nil, err
+		}
+		keysDownState, rpcError := rpcKeyboardReport(keyboardReport.Modifier, keyboardReport.Keys)
+		return &keysDownState, rpcError
+	}
+
+	return nil, fmt.Errorf("unknown HID RPC message type: %d", message.Type())
+}
+
+func reportHidRpc(params any, session *Session) {
+	var (
+		message []byte
+		err     error
+	)
+	switch params := params.(type) {
+	case usbgadget.KeyboardState:
+		message, err = hidrpc.NewKeyboardLedMessage(params).Marshal()
+	case usbgadget.KeysDownState:
+		message, err = hidrpc.NewKeydownStateMessage(params).Marshal()
+	}
+
+	if err != nil {
+		logger.Warn().Err(err).Msg("failed to marshal HID RPC message")
+		return
+	}
+
+	if message == nil {
+		logger.Warn().Msg("failed to marshal HID RPC message")
+		return
+	}
+
+	if err := session.HidChannel.Send(message); err != nil {
+		logger.Warn().Err(err).Msg("failed to send HID RPC message")
+	}
+}
+
+func reportHidRpcKeyboardLedState(state usbgadget.KeyboardState, session *Session) {
+	if !session.hidRpcAvailable {
+		writeJSONRPCEvent("keyboardLedState", state, currentSession)
+	}
+	reportHidRpc(state, session)
+}
+
+func reportHidRpcKeysDownState(state usbgadget.KeysDownState, session *Session) {
+	if !session.hidRpcAvailable {
+		writeJSONRPCEvent("keysDownState", state, currentSession)
+	}
+	reportHidRpc(state, session)
+}

--- a/internal/hidrpc/hidrpc.go
+++ b/internal/hidrpc/hidrpc.go
@@ -24,9 +24,18 @@ const (
 	Version byte = 0x01 // Version of the HID RPC protocol
 )
 
-// ShouldUseEnqueue returns true if the message type should be enqueued to the HID queue.
-func ShouldUseEnqueue(messageType MessageType) bool {
-	return messageType == TypeMouseReport
+// GetQueueIndex returns the index of the queue to which the message should be enqueued.
+func GetQueueIndex(messageType MessageType) int {
+	switch messageType {
+	case TypeHandshake:
+		return 0
+	case TypeKeyboardReport, TypeKeypressReport, TypeKeyboardLedState, TypeKeydownState:
+		return 1
+	case TypePointerReport, TypeMouseReport, TypeWheelReport:
+		return 2
+	default:
+		return 3
+	}
 }
 
 // Unmarshal unmarshals the HID RPC message from the data.

--- a/internal/hidrpc/hidrpc.go
+++ b/internal/hidrpc/hidrpc.go
@@ -1,0 +1,91 @@
+package hidrpc
+
+import (
+	"fmt"
+
+	"github.com/jetkvm/kvm/internal/usbgadget"
+)
+
+// HID RPC is a variable-length packet format that is used to exchange keyboard and mouse events between the client and the server.
+// The packet format is as follows:
+// 1 byte: Event Type
+
+// MessageType is the type of the HID RPC message
+type MessageType uint8
+
+const (
+	TypeHandshake        MessageType = 0x01
+	TypeKeyboardReport   MessageType = 0x02
+	TypePointerReport    MessageType = 0x03
+	TypeWheelReport      MessageType = 0x04
+	TypeKeypressReport   MessageType = 0x05
+	TypeMouseReport      MessageType = 0x06
+	TypeKeyboardLedState MessageType = 0x32
+	TypeKeydownState     MessageType = 0x33
+)
+
+// ShouldUseEnqueue returns true if the message type should be enqueued to the HID queue.
+func ShouldUseEnqueue(messageType MessageType) bool {
+	return messageType == TypeMouseReport
+}
+
+// Unmarshal unmarshals the HID RPC message from the data.
+func Unmarshal(data []byte, message *Message) error {
+	l := len(data)
+	if l < 1 {
+		return fmt.Errorf("invalid data length: %d", l)
+	}
+
+	message.t = MessageType(data[0])
+	message.d = data[1:]
+	return nil
+}
+
+// Marshal marshals the HID RPC message to the data.
+func Marshal(message *Message) ([]byte, error) {
+	if message.t == 0 {
+		return nil, fmt.Errorf("invalid message type: %d", message.t)
+	}
+
+	data := make([]byte, len(message.d)+1)
+	data[0] = byte(message.t)
+	copy(data[1:], message.d)
+
+	return data, nil
+}
+
+// NewHandshakeMessage creates a new handshake message.
+func NewHandshakeMessage() *Message {
+	return &Message{
+		t: TypeHandshake,
+		d: []byte{},
+	}
+}
+
+// NewKeyboardReportMessage creates a new keyboard report message.
+func NewKeyboardReportMessage(keys []byte, modifier uint8) *Message {
+	return &Message{
+		t: TypeKeyboardReport,
+		d: append([]byte{modifier}, keys...),
+	}
+}
+
+// NewKeyboardLedMessage creates a new keyboard LED message.
+func NewKeyboardLedMessage(state usbgadget.KeyboardState) *Message {
+	return &Message{
+		t: TypeKeyboardLedState,
+		d: []byte{state.Byte()},
+	}
+}
+
+// NewKeydownStateMessage creates a new keydown state message.
+func NewKeydownStateMessage(state usbgadget.KeysDownState) *Message {
+	data := make([]byte, len(state.Keys)+1)
+	data[0] = state.Modifier
+	copy(data[1:], state.Keys)
+
+	return &Message{
+		t: TypeKeydownState,
+		d: data,
+	}
+}

--- a/internal/hidrpc/hidrpc.go
+++ b/internal/hidrpc/hidrpc.go
@@ -6,12 +6,8 @@ import (
 	"github.com/jetkvm/kvm/internal/usbgadget"
 )
 
-// HID RPC is a variable-length packet format that is used to exchange keyboard and mouse events between the client and the server.
-// The packet format is as follows:
-// 1 byte: Event Type
-
 // MessageType is the type of the HID RPC message
-type MessageType uint8
+type MessageType byte
 
 const (
 	TypeHandshake        MessageType = 0x01
@@ -22,6 +18,10 @@ const (
 	TypeMouseReport      MessageType = 0x06
 	TypeKeyboardLedState MessageType = 0x32
 	TypeKeydownState     MessageType = 0x33
+)
+
+const (
+	Version byte = 0x01 // Version of the HID RPC protocol
 )
 
 // ShouldUseEnqueue returns true if the message type should be enqueued to the HID queue.
@@ -58,7 +58,7 @@ func Marshal(message *Message) ([]byte, error) {
 func NewHandshakeMessage() *Message {
 	return &Message{
 		t: TypeHandshake,
-		d: []byte{},
+		d: []byte{Version},
 	}
 }
 

--- a/internal/hidrpc/message.go
+++ b/internal/hidrpc/message.go
@@ -1,0 +1,104 @@
+package hidrpc
+
+import (
+	"fmt"
+)
+
+// Message ..
+type Message struct {
+	t MessageType
+	d []byte
+}
+
+// Marshal marshals the message to a byte array.
+func (m *Message) Marshal() ([]byte, error) {
+	return Marshal(m)
+}
+
+func (m *Message) Type() MessageType {
+	return m.t
+}
+
+// KeypressReport ..
+type KeypressReport struct {
+	Key   byte
+	Press bool
+}
+
+// KeypressReport returns the keypress report from the message.
+func (m *Message) KeypressReport() (KeypressReport, error) {
+	if m.t != TypeKeypressReport {
+		return KeypressReport{}, fmt.Errorf("invalid message type: %d", m.t)
+	}
+
+	return KeypressReport{
+		Key:   m.d[0],
+		Press: m.d[1] == uint8(1),
+	}, nil
+}
+
+// KeyboardReport ..
+type KeyboardReport struct {
+	Modifier byte
+	Keys     []byte
+}
+
+// KeyboardReport returns the keyboard report from the message.
+func (m *Message) KeyboardReport() (KeyboardReport, error) {
+	if m.t != TypeKeyboardReport {
+		return KeyboardReport{}, fmt.Errorf("invalid message type: %d", m.t)
+	}
+
+	return KeyboardReport{
+		Modifier: m.d[0],
+		Keys:     m.d[1:],
+	}, nil
+}
+
+// PointerReport ..
+type PointerReport struct {
+	X      int
+	Y      int
+	Button uint8
+}
+
+func toInt(b []byte) int {
+	return int(b[0])<<24 + int(b[1])<<16 + int(b[2])<<8 + int(b[3])<<0
+}
+
+// PointerReport returns the point report from the message.
+func (m *Message) PointerReport() (PointerReport, error) {
+	if m.t != TypePointerReport {
+		return PointerReport{}, fmt.Errorf("invalid message type: %d", m.t)
+	}
+
+	if len(m.d) != 9 {
+		return PointerReport{}, fmt.Errorf("invalid message length: %d", len(m.d))
+	}
+
+	return PointerReport{
+		X:      toInt(m.d[0:4]),
+		Y:      toInt(m.d[4:8]),
+		Button: uint8(m.d[8]),
+	}, nil
+}
+
+// MouseReport ..
+type MouseReport struct {
+	DX     int8
+	DY     int8
+	Button uint8
+}
+
+// MouseReport returns the mouse report from the message.
+func (m *Message) MouseReport() (MouseReport, error) {
+	if m.t != TypeMouseReport {
+		return MouseReport{}, fmt.Errorf("invalid message type: %d", m.t)
+	}
+
+	return MouseReport{
+		DX:     int8(m.d[0]),
+		DY:     int8(m.d[1]),
+		Button: uint8(m.d[2]),
+	}, nil
+}

--- a/internal/hidrpc/message.go
+++ b/internal/hidrpc/message.go
@@ -28,9 +28,9 @@ func (m *Message) String() string {
 	case TypeKeyboardReport:
 		return fmt.Sprintf("KeyboardReport{Modifier: %d, Keys: %v}", m.d[0], m.d[1:])
 	case TypePointerReport:
-		return fmt.Sprintf("PointerReport{X: %d, Y: %d, Button: %d}", m.d[0], m.d[1], m.d[2])
+		return fmt.Sprintf("PointerReport{X: %d, Y: %d, Button: %d}", m.d[0:4], m.d[4:8], m.d[8])
 	case TypeMouseReport:
-		return fmt.Sprintf("MouseReport{DX: %d, DY: %d, Button: %d}", m.d[0], m.d[1], m.d[2])
+		return fmt.Sprintf("MouseReport{DX: %d, DY: %d, Button: %d}", m.d[0:2], m.d[2:4], m.d[4])
 	default:
 		return fmt.Sprintf("Unknown{Type: %d, Data: %v}", m.t, m.d)
 	}

--- a/internal/hidrpc/message.go
+++ b/internal/hidrpc/message.go
@@ -24,13 +24,25 @@ func (m *Message) String() string {
 	case TypeHandshake:
 		return "Handshake"
 	case TypeKeypressReport:
+		if len(m.d) < 2 {
+			return fmt.Sprintf("KeypressReport{Malformed: %v}", m.d)
+		}
 		return fmt.Sprintf("KeypressReport{Key: %d, Press: %v}", m.d[0], m.d[1] == uint8(1))
 	case TypeKeyboardReport:
+		if len(m.d) < 2 {
+			return fmt.Sprintf("KeyboardReport{Malformed: %v}", m.d)
+		}
 		return fmt.Sprintf("KeyboardReport{Modifier: %d, Keys: %v}", m.d[0], m.d[1:])
 	case TypePointerReport:
+		if len(m.d) < 9 {
+			return fmt.Sprintf("PointerReport{Malformed: %v}", m.d)
+		}
 		return fmt.Sprintf("PointerReport{X: %d, Y: %d, Button: %d}", m.d[0:4], m.d[4:8], m.d[8])
 	case TypeMouseReport:
-		return fmt.Sprintf("MouseReport{DX: %d, DY: %d, Button: %d}", m.d[0:2], m.d[2:4], m.d[4])
+		if len(m.d) < 3 {
+			return fmt.Sprintf("MouseReport{Malformed: %v}", m.d)
+		}
+		return fmt.Sprintf("MouseReport{DX: %d, DY: %d, Button: %d}", m.d[0], m.d[1], m.d[2])
 	default:
 		return fmt.Sprintf("Unknown{Type: %d, Data: %v}", m.t, m.d)
 	}

--- a/internal/hidrpc/message.go
+++ b/internal/hidrpc/message.go
@@ -19,6 +19,23 @@ func (m *Message) Type() MessageType {
 	return m.t
 }
 
+func (m *Message) String() string {
+	switch m.t {
+	case TypeHandshake:
+		return "Handshake"
+	case TypeKeypressReport:
+		return fmt.Sprintf("KeypressReport{Key: %d, Press: %v}", m.d[0], m.d[1] == uint8(1))
+	case TypeKeyboardReport:
+		return fmt.Sprintf("KeyboardReport{Modifier: %d, Keys: %v}", m.d[0], m.d[1:])
+	case TypePointerReport:
+		return fmt.Sprintf("PointerReport{X: %d, Y: %d, Button: %d}", m.d[0], m.d[1], m.d[2])
+	case TypeMouseReport:
+		return fmt.Sprintf("MouseReport{DX: %d, DY: %d, Button: %d}", m.d[0], m.d[1], m.d[2])
+	default:
+		return fmt.Sprintf("Unknown{Type: %d, Data: %v}", m.t, m.d)
+	}
+}
+
 // KeypressReport ..
 type KeypressReport struct {
 	Key   byte

--- a/internal/usbgadget/consts.go
+++ b/internal/usbgadget/consts.go
@@ -1,3 +1,7 @@
 package usbgadget
 
+import "time"
+
 const dwc3Path = "/sys/bus/platform/drivers/dwc3"
+
+const hidWriteTimeout = 10 * time.Millisecond

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -103,6 +103,7 @@ func getKeyboardState(b byte) KeyboardState {
 		Compose:    b&KeyboardLedMaskCompose != 0,
 		Kana:       b&KeyboardLedMaskKana != 0,
 		Shift:      b&KeyboardLedMaskShift != 0,
+		raw:        b,
 	}
 }
 

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -148,16 +148,19 @@ func (u *UsbGadget) GetKeysDownState() KeysDownState {
 func (u *UsbGadget) updateKeyDownState(state KeysDownState) {
 	u.log.Trace().Interface("old", u.keysDownState).Interface("new", state).Msg("acquiring keyboardStateLock for updateKeyDownState")
 
-	u.keyboardStateLock.Lock()
-	defer u.keyboardStateLock.Unlock()
+	// this is intentional to unlock keyboard state lock before onKeysDownChange callback
+	{
+		u.keyboardStateLock.Lock()
+		defer u.keyboardStateLock.Unlock()
 
-	if u.keysDownState.Modifier == state.Modifier &&
-		bytes.Equal(u.keysDownState.Keys, state.Keys) {
-		return // No change in key down state
+		if u.keysDownState.Modifier == state.Modifier &&
+			bytes.Equal(u.keysDownState.Keys, state.Keys) {
+			return // No change in key down state
+		}
+
+		u.log.Trace().Interface("old", u.keysDownState).Interface("new", state).Msg("keysDownState updated")
+		u.keysDownState = state
 	}
-
-	u.log.Trace().Interface("old", u.keysDownState).Interface("new", state).Msg("keysDownState updated")
-	u.keysDownState = state
 
 	if u.onKeysDownChange != nil {
 		u.log.Trace().Interface("state", state).Msg("calling onKeysDownChange")

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -157,7 +157,9 @@ func (u *UsbGadget) updateKeyDownState(state KeysDownState) {
 	u.keysDownState = state
 
 	if u.onKeysDownChange != nil {
+		u.log.Trace().Interface("state", state).Msg("calling onKeysDownChange")
 		(*u.onKeysDownChange)(state)
+		u.log.Trace().Interface("state", state).Msg("onKeysDownChange called")
 	}
 }
 
@@ -239,7 +241,7 @@ func (u *UsbGadget) keyboardWriteHidFile(modifier byte, keys []byte) error {
 		return err
 	}
 
-	_, err := u.keyboardHidFile.Write(append([]byte{modifier, 0x00}, keys[:hidKeyBufferSize]...))
+	_, err := writeWithTimeout(u.keyboardHidFile, append([]byte{modifier, 0x00}, keys[:hidKeyBufferSize]...))
 	if err != nil {
 		u.logWithSuppression("keyboardWriteHidFile", 100, u.log, err, "failed to write to hidg0")
 		u.keyboardHidFile.Close()

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -146,6 +146,8 @@ func (u *UsbGadget) GetKeysDownState() KeysDownState {
 }
 
 func (u *UsbGadget) updateKeyDownState(state KeysDownState) {
+	u.log.Trace().Interface("old", u.keysDownState).Interface("new", state).Msg("acquiring keyboardStateLock for updateKeyDownState")
+
 	u.keyboardStateLock.Lock()
 	defer u.keyboardStateLock.Unlock()
 
@@ -242,7 +244,7 @@ func (u *UsbGadget) keyboardWriteHidFile(modifier byte, keys []byte) error {
 		return err
 	}
 
-	_, err := writeWithTimeout(u.keyboardHidFile, append([]byte{modifier, 0x00}, keys[:hidKeyBufferSize]...))
+	_, err := u.writeWithTimeout(u.keyboardHidFile, append([]byte{modifier, 0x00}, keys[:hidKeyBufferSize]...))
 	if err != nil {
 		u.logWithSuppression("keyboardWriteHidFile", 100, u.log, err, "failed to write to hidg0")
 		u.keyboardHidFile.Close()

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -86,6 +86,12 @@ type KeyboardState struct {
 	Compose    bool `json:"compose"`
 	Kana       bool `json:"kana"`
 	Shift      bool `json:"shift"` // This is not part of the main USB HID spec
+	raw        byte
+}
+
+// Byte returns the raw byte representation of the keyboard state.
+func (k *KeyboardState) Byte() byte {
+	return k.raw
 }
 
 func getKeyboardState(b byte) KeyboardState {

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -74,7 +74,7 @@ func (u *UsbGadget) absMouseWriteHidFile(data []byte) error {
 		}
 	}
 
-	_, err := u.absMouseHidFile.Write(data)
+	_, err := writeWithTimeout(u.absMouseHidFile, data)
 	if err != nil {
 		u.logWithSuppression("absMouseWriteHidFile", 100, u.log, err, "failed to write to hidg1")
 		u.absMouseHidFile.Close()

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -74,7 +74,7 @@ func (u *UsbGadget) absMouseWriteHidFile(data []byte) error {
 		}
 	}
 
-	_, err := writeWithTimeout(u.absMouseHidFile, data)
+	_, err := u.writeWithTimeout(u.absMouseHidFile, data)
 	if err != nil {
 		u.logWithSuppression("absMouseWriteHidFile", 100, u.log, err, "failed to write to hidg1")
 		u.absMouseHidFile.Close()

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -64,7 +64,7 @@ func (u *UsbGadget) relMouseWriteHidFile(data []byte) error {
 		}
 	}
 
-	_, err := u.relMouseHidFile.Write(data)
+	_, err := writeWithTimeout(u.relMouseHidFile, data)
 	if err != nil {
 		u.logWithSuppression("relMouseWriteHidFile", 100, u.log, err, "failed to write to hidg2")
 		u.relMouseHidFile.Close()

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -64,7 +64,7 @@ func (u *UsbGadget) relMouseWriteHidFile(data []byte) error {
 		}
 	}
 
-	_, err := writeWithTimeout(u.relMouseHidFile, data)
+	_, err := u.writeWithTimeout(u.relMouseHidFile, data)
 	if err != nil {
 		u.logWithSuppression("relMouseWriteHidFile", 100, u.log, err, "failed to write to hidg2")
 		u.relMouseHidFile.Close()

--- a/internal/usbgadget/utils.go
+++ b/internal/usbgadget/utils.go
@@ -110,7 +110,7 @@ func compareFileContent(oldContent []byte, newContent []byte, looserMatch bool) 
 	return false
 }
 
-func writeWithTimeout(file *os.File, data []byte) (n int, err error) {
+func (u *UsbGadget) writeWithTimeout(file *os.File, data []byte) (n int, err error) {
 	if err := file.SetWriteDeadline(time.Now().Add(hidWriteTimeout)); err != nil {
 		return -1, err
 	}
@@ -121,6 +121,14 @@ func writeWithTimeout(file *os.File, data []byte) (n int, err error) {
 	}
 
 	if errors.Is(err, os.ErrDeadlineExceeded) {
+		u.logWithSuppression(
+			fmt.Sprintf("writeWithTimeout_%s", file.Name()),
+			1000,
+			u.log,
+			err,
+			"write timed out: %s",
+			file.Name(),
+		)
 		err = nil
 	}
 

--- a/internal/usbgadget/utils.go
+++ b/internal/usbgadget/utils.go
@@ -3,10 +3,13 @@ package usbgadget
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/rs/zerolog"
 )
@@ -105,6 +108,23 @@ func compareFileContent(oldContent []byte, newContent []byte, looserMatch bool) 
 	}
 
 	return false
+}
+
+func writeWithTimeout(file *os.File, data []byte) (n int, err error) {
+	if err := file.SetWriteDeadline(time.Now().Add(hidWriteTimeout)); err != nil {
+		return -1, err
+	}
+
+	n, err = file.Write(data)
+	if err == nil {
+		return
+	}
+
+	if errors.Is(err, os.ErrDeadlineExceeded) {
+		err = nil
+	}
+
+	return
 }
 
 func (u *UsbGadget) logWithSuppression(counterName string, every int, logger *zerolog.Logger, err error, msg string, args ...any) {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -83,7 +83,7 @@ func writeJSONRPCEvent(event string, params any, session *Session) {
 		Str("data", requestString).
 		Logger()
 
-	scopedLogger.Info().Msg("sending JSONRPC event")
+	scopedLogger.Trace().Msg("sending JSONRPC event")
 
 	err = session.RPCChannel.SendText(requestString)
 	if err != nil {

--- a/log.go
+++ b/log.go
@@ -19,7 +19,7 @@ var (
 	nbdLogger       = logging.GetSubsystemLogger("nbd")
 	timesyncLogger  = logging.GetSubsystemLogger("timesync")
 	jsonRpcLogger   = logging.GetSubsystemLogger("jsonrpc")
-	hidRpcLogger    = logging.GetSubsystemLogger("hidrpc")
+	hidRPCLogger    = logging.GetSubsystemLogger("hidrpc")
 	watchdogLogger  = logging.GetSubsystemLogger("watchdog")
 	websecureLogger = logging.GetSubsystemLogger("websecure")
 	otaLogger       = logging.GetSubsystemLogger("ota")

--- a/log.go
+++ b/log.go
@@ -19,6 +19,7 @@ var (
 	nbdLogger       = logging.GetSubsystemLogger("nbd")
 	timesyncLogger  = logging.GetSubsystemLogger("timesync")
 	jsonRpcLogger   = logging.GetSubsystemLogger("jsonrpc")
+	hidRpcLogger    = logging.GetSubsystemLogger("hidrpc")
 	watchdogLogger  = logging.GetSubsystemLogger("watchdog")
 	websecureLogger = logging.GetSubsystemLogger("websecure")
 	otaLogger       = logging.GetSubsystemLogger("ota")

--- a/ui/src/components/InfoBar.tsx
+++ b/ui/src/components/InfoBar.tsx
@@ -15,8 +15,8 @@ import { useHidRpc } from "@/hooks/useHidRpc";
 export default function InfoBar() {
   const { keysDownState } = useHidStore();
   const { mouseX, mouseY, mouseMove } = useMouseStore();
-  const { rpcHidReady } = useHidRpc();
-  
+  const { rpcHidStatus } = useHidRpc();
+
   const videoClientSize = useVideoStore(
     (state: VideoState) => `${Math.round(state.clientWidth)}x${Math.round(state.clientHeight)}`,
   );
@@ -48,7 +48,7 @@ export default function InfoBar() {
     const modifierNames = Object.entries(modifiers).filter(([_, mask]) => (activeModifierMask & mask) !== 0).map(([name, _]) => name);
     const keyNames = Object.entries(keys).filter(([_, value]) => keysDown.includes(value)).map(([name, _]) => name);
 
-    return [...modifierNames,...keyNames].join(", ");
+    return [...modifierNames, ...keyNames].join(", ");
   }, [keysDownState, showPressedKeys]);
 
   return (
@@ -105,7 +105,7 @@ export default function InfoBar() {
             {debugMode && (
               <div className="flex w-[156px] items-center gap-x-1">
                 <span className="text-xs font-semibold">HidRPC State:</span>
-                <span className="text-xs">{rpcHidReady ? "Ready" : "Not Ready"}</span>
+                <span className="text-xs">{rpcHidStatus}</span>
               </div>
             )}
 

--- a/ui/src/components/InfoBar.tsx
+++ b/ui/src/components/InfoBar.tsx
@@ -10,11 +10,13 @@ import {
   VideoState
 } from "@/hooks/stores";
 import { keys, modifiers } from "@/keyboardMappings";
+import { useHidRpc } from "@/hooks/useHidRpc";
 
 export default function InfoBar() {
   const { keysDownState } = useHidStore();
   const { mouseX, mouseY, mouseMove } = useMouseStore();
-
+  const { rpcHidReady } = useHidRpc();
+  
   const videoClientSize = useVideoStore(
     (state: VideoState) => `${Math.round(state.clientWidth)}x${Math.round(state.clientHeight)}`,
   );
@@ -98,6 +100,12 @@ export default function InfoBar() {
               <div className="flex w-[156px] items-center gap-x-1">
                 <span className="text-xs font-semibold">HDMI State:</span>
                 <span className="text-xs">{hdmiState}</span>
+              </div>
+            )}
+            {debugMode && (
+              <div className="flex w-[156px] items-center gap-x-1">
+                <span className="text-xs font-semibold">HidRPC State:</span>
+                <span className="text-xs">{rpcHidReady ? "Ready" : "Not Ready"}</span>
               </div>
             )}
 

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -61,7 +61,7 @@ export default function WebRTCVideo() {
 
   // Misc states and hooks
   const { send } = useJsonRpc();
-  const { reportAbsMouseEvent, reportRelMouseEvent, handshakeCompleted } = useHidRpc();
+  const { reportAbsMouseEvent, reportRelMouseEvent, rpcHidReady } = useHidRpc();
 
   // Video-related
   const handleResize = useCallback(
@@ -226,7 +226,7 @@ export default function WebRTCVideo() {
       // if (x === 0 && y === 0 && buttons === 0) return;
       const dx = calcDelta(x);
       const dy = calcDelta(y);
-      if (handshakeCompleted) {
+      if (rpcHidReady) {
         reportRelMouseEvent(dx, dy, buttons);
       } else {
         send("relMouseReport", { dx, dy, buttons });
@@ -238,7 +238,7 @@ export default function WebRTCVideo() {
       reportRelMouseEvent,
       setMouseMove,
       settings.mouseMode,
-      handshakeCompleted,
+      rpcHidReady,
     ],
   );
 
@@ -257,7 +257,7 @@ export default function WebRTCVideo() {
   const sendAbsMouseMovement = useCallback(
     (x: number, y: number, buttons: number) => {
       if (settings.mouseMode !== "absolute") return;
-      if (handshakeCompleted) {
+      if (rpcHidReady) {
         reportAbsMouseEvent(x, y, buttons);
       } else {
         send("absMouseReport", { x, y, buttons });
@@ -270,7 +270,7 @@ export default function WebRTCVideo() {
       reportAbsMouseEvent,
       setMousePosition,
       settings.mouseMode,
-      handshakeCompleted,
+      rpcHidReady,
     ],
   );
 

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -229,6 +229,7 @@ export default function WebRTCVideo() {
       if (rpcHidReady) {
         reportRelMouseEvent(dx, dy, buttons);
       } else {
+        // kept for backward compatibility
         send("relMouseReport", { dx, dy, buttons });
       }
       setMouseMove({ x, y, buttons });
@@ -260,6 +261,7 @@ export default function WebRTCVideo() {
       if (rpcHidReady) {
         reportAbsMouseEvent(x, y, buttons);
       } else {
+        // kept for backward compatibility
         send("absMouseReport", { x, y, buttons });
       }
       // We set that for the debug info bar

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -8,6 +8,7 @@ import InfoBar from "@components/InfoBar";
 import notifications from "@/notifications";
 import useKeyboard from "@/hooks/useKeyboard";
 import { useJsonRpc } from "@/hooks/useJsonRpc";
+import { useHidRpc } from "@/hooks/useHidRpc";
 import { cx } from "@/cva.config";
 import { keys } from "@/keyboardMappings";
 import {
@@ -60,10 +61,11 @@ export default function WebRTCVideo() {
 
   // Misc states and hooks
   const { send } = useJsonRpc();
+  const { reportAbsMouseEvent, reportRelMouseEvent, handshakeCompleted } = useHidRpc();
 
   // Video-related
   const handleResize = useCallback(
-    ( { width, height }: { width: number | undefined; height: number | undefined }) => {
+    ({ width, height }: { width: number | undefined; height: number | undefined }) => {
       if (!videoElm.current) return;
       // Do something with width and height, e.g.:
       setVideoClientSize(width || 0, height || 0);
@@ -222,10 +224,22 @@ export default function WebRTCVideo() {
       if (settings.mouseMode !== "relative") return;
       // if we ignore the event, double-click will not work
       // if (x === 0 && y === 0 && buttons === 0) return;
-      send("relMouseReport", { dx: calcDelta(x), dy: calcDelta(y), buttons });
+      const dx = calcDelta(x);
+      const dy = calcDelta(y);
+      if (handshakeCompleted) {
+        reportRelMouseEvent(dx, dy, buttons);
+      } else {
+        send("relMouseReport", { dx, dy, buttons });
+      }
       setMouseMove({ x, y, buttons });
     },
-    [send, setMouseMove, settings.mouseMode],
+    [
+      send,
+      reportRelMouseEvent,
+      setMouseMove,
+      settings.mouseMode,
+      handshakeCompleted,
+    ],
   );
 
   const relMouseMoveHandler = useCallback(
@@ -243,11 +257,21 @@ export default function WebRTCVideo() {
   const sendAbsMouseMovement = useCallback(
     (x: number, y: number, buttons: number) => {
       if (settings.mouseMode !== "absolute") return;
-      send("absMouseReport", { x, y, buttons });
+      if (handshakeCompleted) {
+        reportAbsMouseEvent(x, y, buttons);
+      } else {
+        send("absMouseReport", { x, y, buttons });
+      }
       // We set that for the debug info bar
       setMousePosition(x, y);
     },
-    [send, setMousePosition, settings.mouseMode],
+    [
+      send,
+      reportAbsMouseEvent,
+      setMousePosition,
+      settings.mouseMode,
+      handshakeCompleted,
+    ],
   );
 
   const absMouseMoveHandler = useCallback(
@@ -357,7 +381,7 @@ export default function WebRTCVideo() {
       }
       console.debug(`Key down: ${hidKey}`);
       handleKeyPress(hidKey, true);
-      
+
       if (!isKeyboardLockActive && hidKey === keys.MetaLeft) {
         // If the left meta key was just pressed and we're not keyboard locked
         // we'll never see the keyup event because the browser is going to lose

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -7,16 +7,14 @@ import MacroBar from "@/components/MacroBar";
 import InfoBar from "@components/InfoBar";
 import notifications from "@/notifications";
 import useKeyboard from "@/hooks/useKeyboard";
-import { useJsonRpc } from "@/hooks/useJsonRpc";
-import { useHidRpc } from "@/hooks/useHidRpc";
 import { cx } from "@/cva.config";
 import { keys } from "@/keyboardMappings";
 import {
-  useMouseStore,
   useRTCStore,
   useSettingsStore,
   useVideoStore,
 } from "@/hooks/stores";
+import useMouse from "@/hooks/useMouse";
 
 import {
   HDMIErrorOverlay,
@@ -32,10 +30,18 @@ export default function WebRTCVideo() {
   const [isPlaying, setIsPlaying] = useState(false);
   const [isPointerLockActive, setIsPointerLockActive] = useState(false);
   const [isKeyboardLockActive, setIsKeyboardLockActive] = useState(false);
+
+  const isPointerLockPossible = window.location.protocol === "https:" || window.location.hostname === "localhost";
+
   // Store hooks
   const settings = useSettingsStore();
   const { handleKeyPress, resetKeyboardState } = useKeyboard();
-  const { setMousePosition, setMouseMove } = useMouseStore();
+  const {
+    getRelMouseMoveHandler,
+    getAbsMouseMoveHandler,
+    getMouseWheelHandler,
+    resetMousePosition,
+  } = useMouse();
   const {
     setClientSize: setVideoClientSize,
     setSize: setVideoSize,
@@ -55,13 +61,6 @@ export default function WebRTCVideo() {
   // HDMI and UI states
   const hdmiError = ["no_lock", "no_signal", "out_of_range"].includes(hdmiState);
   const isVideoLoading = !isPlaying;
-
-  // Mouse wheel states
-  const [blockWheelEvent, setBlockWheelEvent] = useState(false);
-
-  // Misc states and hooks
-  const { send } = useJsonRpc();
-  const { reportAbsMouseEvent, reportRelMouseEvent, rpcHidReady } = useHidRpc();
 
   // Video-related
   const handleResize = useCallback(
@@ -101,7 +100,6 @@ export default function WebRTCVideo() {
   );
 
   // Pointer lock and keyboard lock related
-  const isPointerLockPossible = window.location.protocol === "https:" || window.location.hostname === "localhost";
   const isFullscreenEnabled = document.fullscreenEnabled;
 
   const checkNavigatorPermissions = useCallback(async (permissionName: string) => {
@@ -213,152 +211,31 @@ export default function WebRTCVideo() {
       }
     };
 
-    document.addEventListener("fullscreenchange ", handleFullscreenChange);
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
   }, [releaseKeyboardLock]);
 
-  // Mouse-related
-  const calcDelta = (pos: number) => (Math.abs(pos) < 10 ? pos * 2 : pos);
-
-  const sendRelMouseMovement = useCallback(
-    (x: number, y: number, buttons: number) => {
-      if (settings.mouseMode !== "relative") return;
-      // if we ignore the event, double-click will not work
-      // if (x === 0 && y === 0 && buttons === 0) return;
-      const dx = calcDelta(x);
-      const dy = calcDelta(y);
-      if (rpcHidReady) {
-        reportRelMouseEvent(dx, dy, buttons);
-      } else {
-        // kept for backward compatibility
-        send("relMouseReport", { dx, dy, buttons });
-      }
-      setMouseMove({ x, y, buttons });
-    },
-    [
-      send,
-      reportRelMouseEvent,
-      setMouseMove,
-      settings.mouseMode,
-      rpcHidReady,
-    ],
+  const absMouseMoveHandler = useMemo(
+    () => getAbsMouseMoveHandler({
+      videoClientWidth,
+      videoClientHeight,
+      videoWidth,
+      videoHeight,
+    }),
+    [getAbsMouseMoveHandler, videoClientWidth, videoClientHeight, videoWidth, videoHeight],
   );
 
-  const relMouseMoveHandler = useCallback(
-    (e: MouseEvent) => {
-      if (settings.mouseMode !== "relative") return;
-      if (isPointerLockActive === false && isPointerLockPossible) return;
-
-      // Send mouse movement
-      const { buttons } = e;
-      sendRelMouseMovement(e.movementX, e.movementY, buttons);
-    },
-    [isPointerLockActive, isPointerLockPossible, sendRelMouseMovement, settings.mouseMode],
+  const relMouseMoveHandler = useMemo(
+    () => getRelMouseMoveHandler({
+      isPointerLockActive,
+      isPointerLockPossible,
+    }),
+    [getRelMouseMoveHandler, isPointerLockActive, isPointerLockPossible],
   );
 
-  const sendAbsMouseMovement = useCallback(
-    (x: number, y: number, buttons: number) => {
-      if (settings.mouseMode !== "absolute") return;
-      if (rpcHidReady) {
-        reportAbsMouseEvent(x, y, buttons);
-      } else {
-        // kept for backward compatibility
-        send("absMouseReport", { x, y, buttons });
-      }
-      // We set that for the debug info bar
-      setMousePosition(x, y);
-    },
-    [
-      send,
-      reportAbsMouseEvent,
-      setMousePosition,
-      settings.mouseMode,
-      rpcHidReady,
-    ],
+  const mouseWheelHandler = useMemo(
+    () => getMouseWheelHandler(),
+    [getMouseWheelHandler],
   );
-
-  const absMouseMoveHandler = useCallback(
-    (e: MouseEvent) => {
-      if (!videoClientWidth || !videoClientHeight) return;
-      if (settings.mouseMode !== "absolute") return;
-
-      // Get the aspect ratios of the video element and the video stream
-      const videoElementAspectRatio = videoClientWidth / videoClientHeight;
-      const videoStreamAspectRatio = videoWidth / videoHeight;
-
-      // Calculate the effective video display area
-      let effectiveWidth = videoClientWidth;
-      let effectiveHeight = videoClientHeight;
-      let offsetX = 0;
-      let offsetY = 0;
-
-      if (videoElementAspectRatio > videoStreamAspectRatio) {
-        // Pillarboxing: black bars on the left and right
-        effectiveWidth = videoClientHeight * videoStreamAspectRatio;
-        offsetX = (videoClientWidth - effectiveWidth) / 2;
-      } else if (videoElementAspectRatio < videoStreamAspectRatio) {
-        // Letterboxing: black bars on the top and bottom
-        effectiveHeight = videoClientWidth / videoStreamAspectRatio;
-        offsetY = (videoClientHeight - effectiveHeight) / 2;
-      }
-
-      // Clamp mouse position within the effective video boundaries
-      const clampedX = Math.min(Math.max(offsetX, e.offsetX), offsetX + effectiveWidth);
-      const clampedY = Math.min(Math.max(offsetY, e.offsetY), offsetY + effectiveHeight);
-
-      // Map clamped mouse position to the video stream's coordinate system
-      const relativeX = (clampedX - offsetX) / effectiveWidth;
-      const relativeY = (clampedY - offsetY) / effectiveHeight;
-
-      // Convert to HID absolute coordinate system (0-32767 range)
-      const x = Math.round(relativeX * 32767);
-      const y = Math.round(relativeY * 32767);
-
-      // Send mouse movement
-      const { buttons } = e;
-      sendAbsMouseMovement(x, y, buttons);
-    },
-    [settings.mouseMode, videoClientWidth, videoClientHeight, videoWidth, videoHeight, sendAbsMouseMovement],
-  );
-
-  const mouseWheelHandler = useCallback(
-    (e: WheelEvent) => {
-
-      if (settings.scrollThrottling && blockWheelEvent) {
-        return;
-      }
-
-      // Determine if the wheel event is an accel scroll value
-      const isAccel = Math.abs(e.deltaY) >= 100;
-
-      // Calculate the accel scroll value
-      const accelScrollValue = e.deltaY / 100;
-
-      // Calculate the no accel scroll value
-      const noAccelScrollValue = Math.sign(e.deltaY);
-
-      // Get scroll value
-      const scrollValue = isAccel ? accelScrollValue : noAccelScrollValue;
-
-      // Apply clamping (i.e. min and max mouse wheel hardware value)
-      const clampedScrollValue = Math.max(-127, Math.min(127, scrollValue));
-
-      // Invert the clamped scroll value to match expected behavior
-      const invertedScrollValue = -clampedScrollValue;
-
-      send("wheelReport", { wheelY: invertedScrollValue });
-
-      // Apply blocking delay based of throttling settings
-      if (settings.scrollThrottling && !blockWheelEvent) {
-        setBlockWheelEvent(true);
-        setTimeout(() => setBlockWheelEvent(false), settings.scrollThrottling);
-      }
-    },
-    [send, blockWheelEvent, settings],
-  );
-
-  const resetMousePosition = useCallback(() => {
-    sendAbsMouseMovement(0, 0, 0);
-  }, [sendAbsMouseMovement]);
 
   const keyDownHandler = useCallback(
     (e: KeyboardEvent) => {
@@ -514,14 +391,16 @@ export default function WebRTCVideo() {
     function setMouseModeEventListeners() {
       const videoElmRefValue = videoElm.current;
       if (!videoElmRefValue) return;
+
       const isRelativeMouseMode = (settings.mouseMode === "relative");
+      const mouseHandler = isRelativeMouseMode ? relMouseMoveHandler : absMouseMoveHandler;
 
       const abortController = new AbortController();
       const signal = abortController.signal;
 
-      videoElmRefValue.addEventListener("mousemove", isRelativeMouseMode ? relMouseMoveHandler : absMouseMoveHandler, { signal });
-      videoElmRefValue.addEventListener("pointerdown", isRelativeMouseMode ? relMouseMoveHandler : absMouseMoveHandler, { signal });
-      videoElmRefValue.addEventListener("pointerup", isRelativeMouseMode ? relMouseMoveHandler : absMouseMoveHandler, { signal });
+      videoElmRefValue.addEventListener("mousemove", mouseHandler, { signal });
+      videoElmRefValue.addEventListener("pointerdown", mouseHandler, { signal });
+      videoElmRefValue.addEventListener("pointerup", mouseHandler, { signal });
       videoElmRefValue.addEventListener("wheel", mouseWheelHandler, {
         signal,
         passive: true,
@@ -549,7 +428,16 @@ export default function WebRTCVideo() {
         abortController.abort();
       };
     },
-    [absMouseMoveHandler, isPointerLockActive, isPointerLockPossible, mouseWheelHandler, relMouseMoveHandler, requestPointerLock, resetMousePosition, settings.mouseMode],
+    [
+      isPointerLockActive,
+      isPointerLockPossible,
+      requestPointerLock,
+      absMouseMoveHandler,
+      relMouseMoveHandler,
+      mouseWheelHandler,
+      resetMousePosition,
+      settings.mouseMode,
+    ],
   );
 
   const containerRef = useRef<HTMLDivElement>(null);

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -225,11 +225,8 @@ export default function WebRTCVideo() {
   );
 
   const relMouseMoveHandler = useMemo(
-    () => getRelMouseMoveHandler({
-      isPointerLockActive,
-      isPointerLockPossible,
-    }),
-    [getRelMouseMoveHandler, isPointerLockActive, isPointerLockPossible],
+    () => getRelMouseMoveHandler(),
+    [getRelMouseMoveHandler],
   );
 
   const mouseWheelHandler = useMemo(

--- a/ui/src/hooks/hidRpc.ts
+++ b/ui/src/hooks/hidRpc.ts
@@ -60,8 +60,7 @@ export class RpcMessage {
         throw new Error("Not implemented");
     }
 
-    // @ts-expect-error: this is a base class, so we don't need to implement it
-    public static unmarshal(data: Uint8Array): RpcMessage | undefined {
+    public static unmarshal(_data: Uint8Array): RpcMessage | undefined {
         throw new Error("Not implemented");
     }
 }

--- a/ui/src/hooks/hidRpc.ts
+++ b/ui/src/hooks/hidRpc.ts
@@ -1,0 +1,303 @@
+import { KeyboardLedState, KeysDownState } from "./stores";
+
+export const HID_RPC_MESSAGE_TYPES = {
+    Handshake: 0x01,
+    KeyboardReport: 0x02,
+    PointerReport: 0x03,
+    WheelReport: 0x04,
+    KeypressReport: 0x05,
+    MouseReport: 0x06,
+    KeyboardLedState: 0x32,
+    KeysDownState: 0x33,
+}
+
+export type HidRpcMessageType = typeof HID_RPC_MESSAGE_TYPES[keyof typeof HID_RPC_MESSAGE_TYPES];
+
+export const HID_RPC_VERSION = 0x01;
+
+const withinUint8Range = (value: number) => {
+    return value >= 0 && value <= 255;
+};
+
+const fromInt32toUint8 = (n: number) => {
+    if (n !== n >> 0) {
+        throw new Error(`Number ${n} is not within the int32 range`);
+    }
+
+    return new Uint8Array([
+        (n >> 24) & 0xFF,
+        (n >> 16) & 0xFF,
+        (n >> 8) & 0xFF,
+        (n >> 0) & 0xFF,
+    ]);
+};
+
+const fromInt8ToUint8 = (n: number) => {
+    if (n < -128 || n > 127) {
+        throw new Error(`Number ${n} is not within the int8 range`);
+    }
+
+    return (n >> 0) & 0xFF;
+};
+
+const keyboardLedStateMasks = {
+    num_lock: 1 << 0,
+    caps_lock: 1 << 1,
+    scroll_lock: 1 << 2,
+    compose: 1 << 3,
+    kana: 1 << 4,
+    shift: 1 << 6,
+}
+
+export class RpcMessage {
+    messageType: HidRpcMessageType;
+
+    constructor(messageType: HidRpcMessageType) {
+        this.messageType = messageType;
+    }
+
+    marshal(): Uint8Array {
+        throw new Error("Not implemented");
+    }
+
+    // @ts-expect-error: this is a base class, so we don't need to implement it
+    public static unmarshal(data: Uint8Array): RpcMessage | undefined {
+        throw new Error("Not implemented");
+    }
+}
+
+export class HandshakeMessage extends RpcMessage {
+    version: number;
+
+    constructor(version: number) {
+        super(HID_RPC_MESSAGE_TYPES.Handshake);
+        this.version = version;
+    }
+
+    marshal(): Uint8Array {
+        return new Uint8Array([this.messageType, this.version]);
+    }
+
+    public static unmarshal(data: Uint8Array): HandshakeMessage | undefined {
+        if (data.length < 1) {
+            throw new Error(`Invalid handshake message length: ${data.length}`);
+        }
+
+        return new HandshakeMessage(data[0]);
+    }
+}
+
+export class KeypressReportMessage extends RpcMessage {
+    private _key = 0;
+    private _press = false;
+
+    get key(): number {
+        return this._key;
+    }
+
+    set key(value: number) {
+        if (!withinUint8Range(value)) {
+            throw new Error(`Key ${value} is not within the uint8 range`);
+        }
+
+        this._key = value;
+    }
+
+    get press(): boolean {
+        return this._press;
+    }
+
+    set press(value: boolean) {
+        this._press = value;
+    }
+
+    constructor(key: number, press: boolean) {
+        super(HID_RPC_MESSAGE_TYPES.KeypressReport);
+        this.key = key;
+        this.press = press;
+    }
+
+    marshal(): Uint8Array {
+        return new Uint8Array([
+            this.messageType,
+            this.key,
+            this.press ? 1 : 0,
+        ]);
+    }
+
+    public static unmarshal(data: Uint8Array): KeypressReportMessage | undefined {
+        if (data.length < 1) {
+            throw new Error(`Invalid keypress report message length: ${data.length}`);
+        }
+
+        return new KeypressReportMessage(data[0], data[1] === 1);
+    }
+}
+
+export class KeyboardReportMessage extends RpcMessage {
+    private _keys: number[] = [];
+    private _modifier = 0;
+
+    get keys(): number[] {
+        return this._keys;
+    }
+
+    set keys(value: number[]) {
+        value.forEach((k) => {
+            if (!withinUint8Range(k)) {
+                throw new Error(`Key ${k} is not within the uint8 range`);
+            }
+        });
+
+        this._keys = value;
+    }
+
+    get modifier(): number {
+        return this._modifier;
+    }
+
+    set modifier(value: number) {
+        if (!withinUint8Range(value)) {
+            throw new Error(`Modifier ${value} is not within the uint8 range`);
+        }
+
+        this._modifier = value;
+    }
+
+    constructor(keys: number[], modifier: number) {
+        super(HID_RPC_MESSAGE_TYPES.KeyboardReport);
+        this.keys = keys;
+        this.modifier = modifier;
+    }
+
+    marshal(): Uint8Array {
+        return new Uint8Array([
+            this.messageType,
+            this.modifier,
+            ...this.keys,
+        ]);
+    }
+
+    public static unmarshal(data: Uint8Array): KeyboardReportMessage | undefined {
+        if (data.length < 1) {
+            throw new Error(`Invalid keyboard report message length: ${data.length}`);
+        }
+
+        return new KeyboardReportMessage(Array.from(data.slice(1)), data[0]);
+    }
+}
+
+export class KeyboardLedStateMessage extends RpcMessage {
+    keyboardLedState: KeyboardLedState;
+
+    constructor(keyboardLedState: KeyboardLedState) {
+        super(HID_RPC_MESSAGE_TYPES.KeyboardLedState);
+        this.keyboardLedState = keyboardLedState;
+    }
+
+    public static unmarshal(data: Uint8Array): KeyboardLedStateMessage | undefined {
+        if (data.length < 1) {
+            throw new Error(`Invalid keyboard led state message length: ${data.length}`);
+        }
+
+        const s = data[0];
+
+        const state = {
+            num_lock: (s & keyboardLedStateMasks.num_lock) !== 0,
+            caps_lock: (s & keyboardLedStateMasks.caps_lock) !== 0,
+            scroll_lock: (s & keyboardLedStateMasks.scroll_lock) !== 0,
+            compose: (s & keyboardLedStateMasks.compose) !== 0,
+            kana: (s & keyboardLedStateMasks.kana) !== 0,
+            shift: (s & keyboardLedStateMasks.shift) !== 0,
+        } as KeyboardLedState;
+
+        return new KeyboardLedStateMessage(state);
+    }
+}
+
+export class KeysDownStateMessage extends RpcMessage {
+    keysDownState: KeysDownState;
+
+    constructor(keysDownState: KeysDownState) {
+        super(HID_RPC_MESSAGE_TYPES.KeysDownState);
+        this.keysDownState = keysDownState;
+    }
+
+    public static unmarshal(data: Uint8Array): KeysDownStateMessage | undefined {
+        if (data.length < 1) {
+            throw new Error(`Invalid keys down state message length: ${data.length}`);
+        }
+
+        return new KeysDownStateMessage({
+            modifier: data[0],
+            keys: Array.from(data.slice(1))
+        });
+    }
+}
+
+export class PointerReportMessage extends RpcMessage {
+    x: number;
+    y: number;
+    buttons: number;
+
+    constructor(x: number, y: number, buttons: number) {
+        super(HID_RPC_MESSAGE_TYPES.PointerReport);
+        this.x = x;
+        this.y = y;
+        this.buttons = buttons;
+    }
+
+    marshal(): Uint8Array {
+        return new Uint8Array([
+            this.messageType,
+            ...fromInt32toUint8(this.x),
+            ...fromInt32toUint8(this.y),
+            this.buttons,
+        ]);
+    }
+}
+
+export class MouseReportMessage extends RpcMessage {
+    dx: number;
+    dy: number;
+    buttons: number;
+
+    constructor(dx: number, dy: number, buttons: number) {
+        super(HID_RPC_MESSAGE_TYPES.MouseReport);
+        this.dx = dx;
+        this.dy = dy;
+        this.buttons = buttons;
+    }
+
+    marshal(): Uint8Array {
+        return new Uint8Array([
+            this.messageType,
+            fromInt8ToUint8(this.dx),
+            fromInt8ToUint8(this.dy),
+            this.buttons,
+        ]);
+    }
+}
+
+export const messageRegistry = {
+    [HID_RPC_MESSAGE_TYPES.Handshake]: HandshakeMessage,
+    [HID_RPC_MESSAGE_TYPES.KeysDownState]: KeysDownStateMessage,
+    [HID_RPC_MESSAGE_TYPES.KeyboardLedState]: KeyboardLedStateMessage,
+    [HID_RPC_MESSAGE_TYPES.KeyboardReport]: KeyboardReportMessage,
+    [HID_RPC_MESSAGE_TYPES.KeypressReport]: KeypressReportMessage,
+}
+
+export const unmarshalHidRpcMessage = (data: Uint8Array): RpcMessage | undefined => {
+    if (data.length < 1) {
+        throw new Error(`Invalid HID RPC message length: ${data.length}`);
+    }
+
+    const payload = data.slice(1);
+
+    const messageType = data[0];
+    if (!(messageType in messageRegistry)) {
+        throw new Error(`Unknown HID RPC message type: ${messageType}`);
+    }
+
+    return messageRegistry[messageType].unmarshal(payload);
+};

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -461,9 +461,6 @@ export interface HidState {
   keysDownState: KeysDownState;
   setKeysDownState: (state: KeysDownState) => void;
 
-  // keyPressReportApiAvailable is no longer needed, we'll simply use hidChannel available to
-  // determine if the device supports keyPressReport
-
   isVirtualKeyboardEnabled: boolean;
   setVirtualKeyboardEnabled: (enabled: boolean) => void;
 

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -105,6 +105,9 @@ export interface RTCState {
   setRpcDataChannel: (channel: RTCDataChannel) => void;
   rpcDataChannel: RTCDataChannel | null;
 
+  rpcHidProtocolVersion: number | null;
+  setRpcHidProtocolVersion: (version: number) => void;
+
   setRpcHidChannel: (channel: RTCDataChannel) => void;
   rpcHidChannel: RTCDataChannel | null;
 
@@ -153,6 +156,9 @@ export const useRTCStore = create<RTCState>(set => ({
 
   rpcDataChannel: null,
   setRpcDataChannel: (channel: RTCDataChannel) => set({ rpcDataChannel: channel }),
+
+  rpcHidProtocolVersion: null,
+  setRpcHidProtocolVersion: (version: number) => set({ rpcHidProtocolVersion: version }),
 
   rpcHidChannel: null,
   setRpcHidChannel: (channel: RTCDataChannel) => set({ rpcHidChannel: channel }),

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -108,8 +108,8 @@ export interface RTCState {
   rpcHidProtocolVersion: number | null;
   setRpcHidProtocolVersion: (version: number) => void;
 
-  setRpcHidChannel: (channel: RTCDataChannel) => void;
   rpcHidChannel: RTCDataChannel | null;
+  setRpcHidChannel: (channel: RTCDataChannel) => void;
 
   peerConnectionState: RTCPeerConnectionState | null;
   setPeerConnectionState: (state: RTCPeerConnectionState) => void;

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -105,6 +105,9 @@ export interface RTCState {
   setRpcDataChannel: (channel: RTCDataChannel) => void;
   rpcDataChannel: RTCDataChannel | null;
 
+  setRpcHidChannel: (channel: RTCDataChannel) => void;
+  rpcHidChannel: RTCDataChannel | null;
+
   peerConnectionState: RTCPeerConnectionState | null;
   setPeerConnectionState: (state: RTCPeerConnectionState) => void;
 
@@ -150,6 +153,9 @@ export const useRTCStore = create<RTCState>(set => ({
 
   rpcDataChannel: null,
   setRpcDataChannel: (channel: RTCDataChannel) => set({ rpcDataChannel: channel }),
+
+  rpcHidChannel: null,
+  setRpcHidChannel: (channel: RTCDataChannel) => set({ rpcHidChannel: channel }),
 
   transceiver: null,
   setTransceiver: (transceiver: RTCRtpTransceiver) => set({ transceiver }),

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -461,8 +461,8 @@ export interface HidState {
   keysDownState: KeysDownState;
   setKeysDownState: (state: KeysDownState) => void;
 
-  keyPressReportApiAvailable: boolean;
-  setkeyPressReportApiAvailable: (available: boolean) => void;
+  // keyPressReportApiAvailable is no longer needed, we'll simply use hidChannel available to
+  // determine if the device supports keyPressReport
 
   isVirtualKeyboardEnabled: boolean;
   setVirtualKeyboardEnabled: (enabled: boolean) => void;
@@ -480,9 +480,6 @@ export const useHidStore = create<HidState>(set => ({
 
   keysDownState: { modifier: 0, keys: [0,0,0,0,0,0] } as KeysDownState,
   setKeysDownState: (state: KeysDownState): void => set({ keysDownState: state }),
-
-  keyPressReportApiAvailable: true,
-  setkeyPressReportApiAvailable: (available: boolean) => set({ keyPressReportApiAvailable: available }),
 
   isVirtualKeyboardEnabled: false,
   setVirtualKeyboardEnabled: (enabled: boolean): void => set({ isVirtualKeyboardEnabled: enabled }),

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -1,163 +1,19 @@
 import { useCallback, useEffect, useMemo } from "react";
 
-import { KeyboardLedState, KeysDownState, useRTCStore } from "@/hooks/stores";
+import { useRTCStore } from "@/hooks/stores";
 
-export const HID_RPC_MESSAGE_TYPES = {
-  Handshake: 0x01,
-  KeyboardReport: 0x02,
-  PointerReport: 0x03,
-  WheelReport: 0x04,
-  KeypressReport: 0x05,
-  MouseReport: 0x06,
-  KeyboardLedState: 0x32,
-  KeysDownState: 0x33,
-}
+import {
+  HID_RPC_VERSION,
+  HandshakeMessage,
+  KeyboardReportMessage,
+  KeypressReportMessage,
+  MouseReportMessage,
+  PointerReportMessage,
+  RpcMessage,
+  unmarshalHidRpcMessage,
+} from "./hidRpc";
 
-export type HidRpcMessageType = typeof HID_RPC_MESSAGE_TYPES[keyof typeof HID_RPC_MESSAGE_TYPES];
-
-export const HID_RPC_VERSION = 0x01;
-
-const withinUint8Range = (value: number) => {
-  return value >= 0 && value <= 255;
-};
-
-const fromInt32toUint8 = (n: number) => {
-  if (n !== n >> 0) {
-    throw new Error(`Number ${n} is not within the int32 range`);
-  }
-
-  return new Uint8Array([
-    (n >> 24) & 0xFF,
-    (n >> 16) & 0xFF,
-    (n >> 8) & 0xFF,
-    (n >> 0) & 0xFF,
-  ]);
-};
-
-const fromInt8ToUint8 = (n: number) => {
-  if (n < -128 || n > 127) {
-    throw new Error(`Number ${n} is not within the int8 range`);
-  }
-
-  return (n >> 0) & 0xFF;
-};
-
-const keyboardLedStateMasks = {
-  num_lock: 1 << 0,
-  caps_lock: 1 << 1,
-  scroll_lock: 1 << 2,
-  compose: 1 << 3,
-  kana: 1 << 4,
-  shift: 1 << 6,
-}
-
-export const toKeyboardLedState = (s: number): KeyboardLedState => {
-  if (!withinUint8Range(s)) {
-    throw new Error(`State ${s} is not within the uint8 range`);
-  }
-
-  return {
-    num_lock: (s & keyboardLedStateMasks.num_lock) !== 0,
-    caps_lock: (s & keyboardLedStateMasks.caps_lock) !== 0,
-    scroll_lock: (s & keyboardLedStateMasks.scroll_lock) !== 0,
-    compose: (s & keyboardLedStateMasks.compose) !== 0,
-    kana: (s & keyboardLedStateMasks.kana) !== 0,
-    shift: (s & keyboardLedStateMasks.shift) !== 0,
-  } as KeyboardLedState;
-};
-
-const toPointerReportEvent = (x: number, y: number, buttons: number) => {
-  if (!withinUint8Range(buttons)) {
-    throw new Error(`Buttons ${buttons} is not within the uint8 range`);
-  }
-
-  return new Uint8Array([
-    HID_RPC_MESSAGE_TYPES.PointerReport,
-    ...fromInt32toUint8(x),
-    ...fromInt32toUint8(y),
-    buttons,
-  ]);
-};
-
-const toMouseReportEvent = (dx: number, dy: number, buttons: number) => {
-  if (!withinUint8Range(buttons)) {
-    throw new Error(`Buttons ${buttons} is not within the uint8 range`);
-  }
-  return new Uint8Array([
-    HID_RPC_MESSAGE_TYPES.MouseReport,
-    fromInt8ToUint8(dx),
-    fromInt8ToUint8(dy),
-    buttons,
-  ]);
-};
-
-const toKeyboardReportEvent = (keys: number[], modifier: number) => {
-  if (!withinUint8Range(modifier)) {
-    throw new Error(`Modifier ${modifier} is not within the uint8 range`);
-  }
-
-  keys.forEach((k) => {
-    if (!withinUint8Range(k)) {
-      throw new Error(`Key ${k} is not within the uint8 range`);
-    }
-  });
-
-  return new Uint8Array([
-    HID_RPC_MESSAGE_TYPES.KeyboardReport,
-    modifier,
-    ...keys,
-  ]);
-};
-
-const toKeypressReportEvent = (key: number, press: boolean) => {
-  if (!withinUint8Range(key)) {
-    throw new Error(`Key ${key} is not within the uint8 range`);
-  }
-
-  return new Uint8Array([
-    HID_RPC_MESSAGE_TYPES.KeypressReport,
-    key,
-    press ? 1 : 0,
-  ]);
-};
-
-const toHandshakeMessage = () => {
-  return new Uint8Array([HID_RPC_MESSAGE_TYPES.Handshake, HID_RPC_VERSION]);
-};
-
-export interface HidRpcMessage {
-  type: HidRpcMessageType;
-  version?: number;
-  keysDownState?: KeysDownState;
-}
-
-const unmarshalHidRpcMessage = (data: Uint8Array): HidRpcMessage | undefined => {
-  if (data.length < 1) {
-    throw new Error(`Invalid HID RPC message length: ${data.length}`);
-  }
-
-  const payload = data.slice(1);
-
-  switch (data[0]) {
-    case HID_RPC_MESSAGE_TYPES.Handshake:
-      return {
-        type: HID_RPC_MESSAGE_TYPES.Handshake,
-        version: payload[0],
-      };
-    case HID_RPC_MESSAGE_TYPES.KeysDownState:
-      return {
-        type: HID_RPC_MESSAGE_TYPES.KeysDownState,
-        keysDownState: {
-          modifier: payload[0],
-          keys: Array.from(payload.slice(1))
-        },
-      };
-    default:
-      throw new Error(`Unknown HID RPC message type: ${data[0]}`);
-  }
-};
-
-export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
+export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
   const { rpcHidChannel, setRpcHidProtocolVersion, rpcHidProtocolVersion } = useRTCStore();
   const rpcHidReady = useMemo(() => {
     return rpcHidChannel?.readyState === "open" && rpcHidProtocolVersion !== null;
@@ -170,50 +26,74 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
     return `ready (v${rpcHidProtocolVersion})`;
   }, [rpcHidChannel, rpcHidProtocolVersion]);
 
+  const sendMessage = useCallback((message: RpcMessage, ignoreHandshakeState = false) => {
+    if (rpcHidChannel?.readyState !== "open") return;
+    if (!rpcHidReady && !ignoreHandshakeState) return;
+
+    let data: Uint8Array | undefined;
+    try {
+      data = message.marshal();
+    } catch (e) {
+      console.error("Failed to send HID RPC message", e);
+    }
+    if (!data) return;
+
+    rpcHidChannel?.send(data as unknown as ArrayBuffer);
+  }, [rpcHidChannel, rpcHidReady]);
+
   const reportKeyboardEvent = useCallback(
     (keys: number[], modifier: number) => {
-      if (!rpcHidReady) return;
-      rpcHidChannel?.send(toKeyboardReportEvent(keys, modifier));
-    },
-    [rpcHidChannel, rpcHidReady],
+      sendMessage(new KeyboardReportMessage(keys, modifier));
+    }, [sendMessage],
   );
 
   const reportKeypressEvent = useCallback(
     (key: number, press: boolean) => {
-      if (!rpcHidReady) return;
-      rpcHidChannel?.send(toKeypressReportEvent(key, press));
+      sendMessage(new KeypressReportMessage(key, press));
     },
-    [rpcHidChannel, rpcHidReady],
+    [sendMessage],
   );
 
   const reportAbsMouseEvent = useCallback(
     (x: number, y: number, buttons: number) => {
-      if (!rpcHidReady) return;
-      rpcHidChannel?.send(toPointerReportEvent(x, y, buttons));
+      sendMessage(new PointerReportMessage(x, y, buttons));
     },
-    [rpcHidChannel, rpcHidReady],
+    [sendMessage],
   );
 
   const reportRelMouseEvent = useCallback(
     (dx: number, dy: number, buttons: number) => {
-      if (!rpcHidReady) return;
-      rpcHidChannel?.send(toMouseReportEvent(dx, dy, buttons));
+      sendMessage(new MouseReportMessage(dx, dy, buttons));
     },
-    [rpcHidChannel, rpcHidReady],
+    [sendMessage],
   );
 
-  const doHandshake = useCallback(() => {
+  const sendHandshake = useCallback(() => {
     if (rpcHidProtocolVersion) return;
     if (!rpcHidChannel) return;
 
-    rpcHidChannel?.send(toHandshakeMessage());
-  }, [rpcHidChannel, rpcHidProtocolVersion]);
+    sendMessage(new HandshakeMessage(HID_RPC_VERSION), true);
+  }, [rpcHidChannel, rpcHidProtocolVersion, sendMessage]);
+
+  const handleHandshake = useCallback((message: HandshakeMessage) => {
+    if (!message.version) {
+      console.error("Received handshake message without version", message);
+      return;
+    }
+
+    if (message.version < HID_RPC_VERSION) {
+      console.error("Server is using an older HID RPC version than the client", message);
+      return;
+    }
+
+    setRpcHidProtocolVersion(message.version);
+  }, [setRpcHidProtocolVersion]);
 
   useEffect(() => {
     if (!rpcHidChannel) return;
 
     // send handshake message
-    doHandshake();
+    sendHandshake();
 
     const messageHandler = (e: MessageEvent) => {
       if (typeof e.data === "string") {
@@ -221,27 +101,20 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
         return;
       }
 
-      console.debug("Received HID RPC message", e.data);
-
       const message = unmarshalHidRpcMessage(new Uint8Array(e.data));
       if (!message) {
         console.warn("Received invalid HID RPC message", e.data);
         return;
       }
 
-      if (message.type === HID_RPC_MESSAGE_TYPES.Handshake) {
-        if (!message.version) {
-          console.error("Received handshake message without version", message);
-          return;
-        }
-
-        // TODO: use capabilities to determine the supported functions rather than the version
-        if (message.version < HID_RPC_VERSION) {
-          console.error("Server is using an older HID RPC version than the client", message);
-          return;
-        }
-
-        setRpcHidProtocolVersion(message.version);
+      console.debug("Received HID RPC message", message);
+      switch (message.constructor) {
+        case HandshakeMessage:
+          handleHandshake(message as HandshakeMessage);
+          break;
+        default:
+          // not all events are handled here, the rest are handled by the onHidRpcMessage callback
+          break;
       }
 
       onHidRpcMessage?.(message);
@@ -257,8 +130,8 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
       rpcHidChannel,
       onHidRpcMessage,
       setRpcHidProtocolVersion,
-      doHandshake,
-      rpcHidReady,
+      sendHandshake,
+      handleHandshake,
     ],
   );
 

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -81,8 +81,11 @@ export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
       return;
     }
 
-    if (message.version < HID_RPC_VERSION) {
-      console.error("Server is using an older HID RPC version than the client", message);
+    if (message.version > HID_RPC_VERSION) {
+      // we assume that the UI is always using the latest version of the HID RPC protocol
+      // so we can't support this
+      // TODO: use capabilities to determine rather than version number
+      console.error("Server is using a newer HID RPC version than the client", message);
       return;
     }
 

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -1,0 +1,217 @@
+import { useCallback, useEffect, useState } from "react";
+
+import { KeysDownState, useRTCStore } from "@/hooks/stores";
+
+export const HID_RPC_MESSAGE_TYPES = {
+  Handshake: 0x01,
+  KeyboardReport: 0x02,
+  PointerReport: 0x03,
+  WheelReport: 0x04,
+  KeypressReport: 0x05,
+  MouseReport: 0x06,
+  KeyboardLedState: 0x32,
+  KeysDownState: 0x33,
+}
+
+export type HidRpcMessageType = typeof HID_RPC_MESSAGE_TYPES[keyof typeof HID_RPC_MESSAGE_TYPES];
+
+const withinUint8Range = (value: number) => {
+  return value >= 0 && value <= 255;
+};
+
+const fromInt32toUint8 = (n: number) => {
+  if (n !== n >> 0) {
+    throw new Error(`Number ${n} is not within the int32 range`);
+  }
+
+  return new Uint8Array([
+    (n >> 24) & 0xFF,
+    (n >> 16) & 0xFF,
+    (n >> 8) & 0xFF,
+    (n >> 0) & 0xFF,
+  ]);
+};
+
+const fromInt8ToUint8 = (n: number) => {
+  if (n < -128 || n > 127) {
+    throw new Error(`Number ${n} is not within the int8 range`);
+  }
+
+  return (n >> 0) & 0xFF;
+};
+
+const toPointerReportEvent = (x: number, y: number, buttons: number) => {
+  if (!withinUint8Range(buttons)) {
+    throw new Error(`Buttons ${buttons} is not within the uint8 range`);
+  }
+
+  return new Uint8Array([
+    HID_RPC_MESSAGE_TYPES.PointerReport,
+    ...fromInt32toUint8(x),
+    ...fromInt32toUint8(y),
+    buttons,
+  ]);
+};
+
+const toMouseReportEvent = (dx: number, dy: number, buttons: number) => {
+  if (!withinUint8Range(buttons)) {
+    throw new Error(`Buttons ${buttons} is not within the uint8 range`);
+  }
+  return new Uint8Array([
+    HID_RPC_MESSAGE_TYPES.MouseReport,
+    fromInt8ToUint8(dx),
+    fromInt8ToUint8(dy),
+    buttons,
+  ]);
+};
+
+const toKeyboardReportEvent = (keys: number[], modifier: number) => {
+  if (!withinUint8Range(modifier)) {
+    throw new Error(`Modifier ${modifier} is not within the uint8 range`);
+  }
+
+  keys.forEach((k) => {
+    if (!withinUint8Range(k)) {
+      throw new Error(`Key ${k} is not within the uint8 range`);
+    }
+  });
+
+  return new Uint8Array([
+    HID_RPC_MESSAGE_TYPES.KeyboardReport,
+    modifier,
+    ...keys,
+  ]);
+};
+
+const toKeypressReportEvent = (key: number, press: boolean) => {
+  if (!withinUint8Range(key)) {
+    throw new Error(`Key ${key} is not within the uint8 range`);
+  }
+
+  return new Uint8Array([
+    HID_RPC_MESSAGE_TYPES.KeypressReport,
+    key,
+    press ? 1 : 0,
+  ]);
+};
+
+const toHandshakeMessage = () => {
+  return new Uint8Array([HID_RPC_MESSAGE_TYPES.Handshake]);
+};
+
+export interface HidRpcMessage {
+  type: HidRpcMessageType;
+  keysDownState?: KeysDownState;
+}
+
+const unmarshalHidRpcMessage = (data: Uint8Array): HidRpcMessage | undefined => {
+  if (data.length < 1) {
+    throw new Error(`Invalid HID RPC message length: ${data.length}`);
+  }
+
+  const payload = data.slice(1);
+
+  switch (data[0]) {
+    case HID_RPC_MESSAGE_TYPES.Handshake:
+      return {
+        type: HID_RPC_MESSAGE_TYPES.Handshake,
+      };
+    case HID_RPC_MESSAGE_TYPES.KeysDownState:
+      return {
+        type: HID_RPC_MESSAGE_TYPES.KeysDownState,
+        keysDownState: {
+          modifier: payload[0],
+          keys: Array.from(payload.slice(1))
+        },
+      };
+    default:
+      throw new Error(`Unknown HID RPC message type: ${data[0]}`);
+  }
+};
+
+export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
+  const { rpcHidChannel } = useRTCStore();
+  const [handshakeCompleted, setHandshakeCompleted] = useState(false);
+
+  const reportKeyboardEvent = useCallback(
+    (keys: number[], modifier: number) => {
+      if (rpcHidChannel?.readyState !== "open") return;
+      rpcHidChannel.send(toKeyboardReportEvent(keys, modifier));
+    },
+    [rpcHidChannel],
+  );
+
+  const reportKeypressEvent = useCallback(
+    (key: number, press: boolean) => {
+      if (rpcHidChannel?.readyState !== "open") return;
+      rpcHidChannel.send(toKeypressReportEvent(key, press));
+    },
+    [rpcHidChannel],
+  );
+
+  const reportAbsMouseEvent = useCallback(
+    (x: number, y: number, buttons: number) => {
+      if (rpcHidChannel?.readyState !== "open") return;
+      rpcHidChannel.send(toPointerReportEvent(x, y, buttons));
+    },
+    [rpcHidChannel],
+  );
+
+  const reportRelMouseEvent = useCallback(
+    (dx: number, dy: number, buttons: number) => {
+      if (rpcHidChannel?.readyState !== "open") return;
+      rpcHidChannel.send(toMouseReportEvent(dx, dy, buttons));
+    },
+    [rpcHidChannel],
+  );
+
+  const doHandshake = useCallback(() => {
+    if (handshakeCompleted) return;
+    if (!rpcHidChannel) return;
+
+    rpcHidChannel.send(toHandshakeMessage());
+  }, [rpcHidChannel, handshakeCompleted]);
+
+  useEffect(() => {
+    if (!rpcHidChannel) return;
+
+    // send handshake message
+    doHandshake();
+
+    const messageHandler = (e: MessageEvent) => {
+      if (typeof e.data === "string") {
+        console.warn("Received string data in HID RPC message handler", e.data);
+        return;
+      }
+
+      console.log("Received HID RPC message", e.data);
+
+      const message = unmarshalHidRpcMessage(new Uint8Array(e.data));
+      if (!message) {
+        console.warn("Received invalid HID RPC message", e.data);
+        return;
+      }
+
+      if (message.type === HID_RPC_MESSAGE_TYPES.Handshake) {
+        setHandshakeCompleted(true);
+      }
+
+      onHidRpcMessage?.(message);
+    };
+
+    rpcHidChannel.addEventListener("message", messageHandler);
+
+    return () => {
+      rpcHidChannel.removeEventListener("message", messageHandler);
+    };
+  },
+    [rpcHidChannel, onHidRpcMessage, setHandshakeCompleted, doHandshake]);
+
+  return {
+    reportKeyboardEvent,
+    reportKeypressEvent,
+    reportAbsMouseEvent,
+    reportRelMouseEvent,
+    handshakeCompleted,
+  };
+}

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -15,6 +15,8 @@ export const HID_RPC_MESSAGE_TYPES = {
 
 export type HidRpcMessageType = typeof HID_RPC_MESSAGE_TYPES[keyof typeof HID_RPC_MESSAGE_TYPES];
 
+export const HID_RPC_VERSION = 0x01;
+
 const withinUint8Range = (value: number) => {
   return value >= 0 && value <= 255;
 };
@@ -58,7 +60,7 @@ export const toKeyboardLedState = (s: number): KeyboardLedState => {
     num_lock: (s & keyboardLedStateMasks.num_lock) !== 0,
     caps_lock: (s & keyboardLedStateMasks.caps_lock) !== 0,
     scroll_lock: (s & keyboardLedStateMasks.scroll_lock) !== 0,
-    compose: (s & keyboardLedStateMasks.compose) !== 0, // TODO: check if this is correct
+    compose: (s & keyboardLedStateMasks.compose) !== 0,
     kana: (s & keyboardLedStateMasks.kana) !== 0,
     shift: (s & keyboardLedStateMasks.shift) !== 0,
   } as KeyboardLedState;
@@ -120,11 +122,12 @@ const toKeypressReportEvent = (key: number, press: boolean) => {
 };
 
 const toHandshakeMessage = () => {
-  return new Uint8Array([HID_RPC_MESSAGE_TYPES.Handshake]);
+  return new Uint8Array([HID_RPC_MESSAGE_TYPES.Handshake, HID_RPC_VERSION]);
 };
 
 export interface HidRpcMessage {
   type: HidRpcMessageType;
+  version?: number;
   keysDownState?: KeysDownState;
 }
 
@@ -139,6 +142,7 @@ const unmarshalHidRpcMessage = (data: Uint8Array): HidRpcMessage | undefined => 
     case HID_RPC_MESSAGE_TYPES.Handshake:
       return {
         type: HID_RPC_MESSAGE_TYPES.Handshake,
+        version: payload[0],
       };
     case HID_RPC_MESSAGE_TYPES.KeysDownState:
       return {
@@ -219,7 +223,18 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
       }
 
       if (message.type === HID_RPC_MESSAGE_TYPES.Handshake) {
-        setRpcHidProtocolVersion(1);
+        if (!message.version) {
+          console.error("Received handshake message without version", message);
+          return;
+        }
+
+        // TODO: use capabilities to determine the supported functions rather than the version
+        if (message.version < HID_RPC_VERSION) {
+          console.error("Server is using an older HID RPC version than the client", message);
+          return;
+        }
+
+        setRpcHidProtocolVersion(message.version);
       }
 
       onHidRpcMessage?.(message);

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -163,6 +163,13 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
     return rpcHidChannel?.readyState === "open" && rpcHidProtocolVersion !== null;
   }, [rpcHidChannel, rpcHidProtocolVersion]);
 
+  const rpcHidStatus = useMemo(() => {
+    if (!rpcHidChannel) return "N/A";
+    if (rpcHidChannel.readyState !== "open") return rpcHidChannel.readyState;
+    if (!rpcHidProtocolVersion) return "handshaking";
+    return `ready (v${rpcHidProtocolVersion})`;
+  }, [rpcHidChannel, rpcHidProtocolVersion]);
+
   const reportKeyboardEvent = useCallback(
     (keys: number[], modifier: number) => {
       if (!rpcHidReady) return;
@@ -262,5 +269,6 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
     reportRelMouseEvent,
     rpcHidProtocolVersion,
     rpcHidReady,
+    rpcHidStatus,
   };
 }

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 
-import { KeysDownState, useRTCStore } from "@/hooks/stores";
+import { KeyboardLedState, KeysDownState, useRTCStore } from "@/hooks/stores";
 
 export const HID_RPC_MESSAGE_TYPES = {
   Handshake: 0x01,
@@ -38,6 +38,30 @@ const fromInt8ToUint8 = (n: number) => {
   }
 
   return (n >> 0) & 0xFF;
+};
+
+const keyboardLedStateMasks = {
+  num_lock: 1 << 0,
+  caps_lock: 1 << 1,
+  scroll_lock: 1 << 2,
+  compose: 1 << 3,
+  kana: 1 << 4,
+  shift: 1 << 6,
+}
+
+export const toKeyboardLedState = (s: number): KeyboardLedState => {
+  if (!withinUint8Range(s)) {
+    throw new Error(`State ${s} is not within the uint8 range`);
+  }
+
+  return {
+    num_lock: (s & keyboardLedStateMasks.num_lock) !== 0,
+    caps_lock: (s & keyboardLedStateMasks.caps_lock) !== 0,
+    scroll_lock: (s & keyboardLedStateMasks.scroll_lock) !== 0,
+    compose: (s & keyboardLedStateMasks.compose) !== 0, // TODO: check if this is correct
+    kana: (s & keyboardLedStateMasks.kana) !== 0,
+    shift: (s & keyboardLedStateMasks.shift) !== 0,
+  } as KeyboardLedState;
 };
 
 const toPointerReportEvent = (x: number, y: number, buttons: number) => {
@@ -130,47 +154,49 @@ const unmarshalHidRpcMessage = (data: Uint8Array): HidRpcMessage | undefined => 
 };
 
 export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
-  const { rpcHidChannel } = useRTCStore();
-  const [handshakeCompleted, setHandshakeCompleted] = useState(false);
+  const { rpcHidChannel, setRpcHidProtocolVersion, rpcHidProtocolVersion } = useRTCStore();
+  const rpcHidReady = useMemo(() => {
+    return rpcHidChannel?.readyState === "open" && rpcHidProtocolVersion !== null;
+  }, [rpcHidChannel, rpcHidProtocolVersion]);
 
   const reportKeyboardEvent = useCallback(
     (keys: number[], modifier: number) => {
-      if (rpcHidChannel?.readyState !== "open") return;
-      rpcHidChannel.send(toKeyboardReportEvent(keys, modifier));
+      if (!rpcHidReady) return;
+      rpcHidChannel?.send(toKeyboardReportEvent(keys, modifier));
     },
-    [rpcHidChannel],
+    [rpcHidChannel, rpcHidReady],
   );
 
   const reportKeypressEvent = useCallback(
     (key: number, press: boolean) => {
-      if (rpcHidChannel?.readyState !== "open") return;
-      rpcHidChannel.send(toKeypressReportEvent(key, press));
+      if (!rpcHidReady) return;
+      rpcHidChannel?.send(toKeypressReportEvent(key, press));
     },
-    [rpcHidChannel],
+    [rpcHidChannel, rpcHidReady],
   );
 
   const reportAbsMouseEvent = useCallback(
     (x: number, y: number, buttons: number) => {
-      if (rpcHidChannel?.readyState !== "open") return;
-      rpcHidChannel.send(toPointerReportEvent(x, y, buttons));
+      if (!rpcHidReady) return;
+      rpcHidChannel?.send(toPointerReportEvent(x, y, buttons));
     },
-    [rpcHidChannel],
+    [rpcHidChannel, rpcHidReady],
   );
 
   const reportRelMouseEvent = useCallback(
     (dx: number, dy: number, buttons: number) => {
-      if (rpcHidChannel?.readyState !== "open") return;
-      rpcHidChannel.send(toMouseReportEvent(dx, dy, buttons));
+      if (!rpcHidReady) return;
+      rpcHidChannel?.send(toMouseReportEvent(dx, dy, buttons));
     },
-    [rpcHidChannel],
+    [rpcHidChannel, rpcHidReady],
   );
 
   const doHandshake = useCallback(() => {
-    if (handshakeCompleted) return;
+    if (rpcHidProtocolVersion) return;
     if (!rpcHidChannel) return;
 
-    rpcHidChannel.send(toHandshakeMessage());
-  }, [rpcHidChannel, handshakeCompleted]);
+    rpcHidChannel?.send(toHandshakeMessage());
+  }, [rpcHidChannel, rpcHidProtocolVersion]);
 
   useEffect(() => {
     if (!rpcHidChannel) return;
@@ -184,7 +210,7 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
         return;
       }
 
-      console.log("Received HID RPC message", e.data);
+      console.debug("Received HID RPC message", e.data);
 
       const message = unmarshalHidRpcMessage(new Uint8Array(e.data));
       if (!message) {
@@ -193,7 +219,7 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
       }
 
       if (message.type === HID_RPC_MESSAGE_TYPES.Handshake) {
-        setHandshakeCompleted(true);
+        setRpcHidProtocolVersion(1);
       }
 
       onHidRpcMessage?.(message);
@@ -205,13 +231,21 @@ export function useHidRpc(onHidRpcMessage?: (payload: HidRpcMessage) => void) {
       rpcHidChannel.removeEventListener("message", messageHandler);
     };
   },
-    [rpcHidChannel, onHidRpcMessage, setHandshakeCompleted, doHandshake]);
+    [
+      rpcHidChannel,
+      onHidRpcMessage,
+      setRpcHidProtocolVersion,
+      doHandshake,
+      rpcHidReady,
+    ],
+  );
 
   return {
     reportKeyboardEvent,
     reportKeypressEvent,
     reportAbsMouseEvent,
     reportRelMouseEvent,
-    handshakeCompleted,
+    rpcHidProtocolVersion,
+    rpcHidReady,
   };
 }

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -7,7 +7,7 @@ import { hidKeyToModifierMask, keys, modifiers } from "@/keyboardMappings";
 
 export default function useKeyboard() {
   const { send } = useJsonRpc();
-  const { rpcDataChannel, rpcHidChannel } = useRTCStore();
+  const { rpcDataChannel } = useRTCStore();
   const { keysDownState, setKeysDownState } = useHidStore();
 
   // INTRODUCTION: The earlier version of the JetKVM device shipped with all keyboard state
@@ -23,7 +23,7 @@ export default function useKeyboard() {
   const { keyPressReportApiAvailable, setkeyPressReportApiAvailable } = useHidStore();
 
   // HidRPC is a binary format for exchanging keyboard and mouse events
-  const { reportKeyboardEvent, reportKeypressEvent } = useHidRpc((message) => {
+  const { reportKeyboardEvent, reportKeypressEvent, rpcHidReady } = useHidRpc((message) => {
     if (message.type === HID_RPC_MESSAGE_TYPES.KeysDownState) {
       if (!message.keysDownState) {
         return;
@@ -40,11 +40,11 @@ export default function useKeyboard() {
   // or just accept the state if it does not support (returning no result)
   const sendKeyboardEvent = useCallback(
     async (state: KeysDownState) => {
-      if (rpcDataChannel?.readyState !== "open" && rpcHidChannel?.readyState !== "open") return;
+      if (rpcDataChannel?.readyState !== "open" && !rpcHidReady) return;
 
       console.debug(`Send keyboardReport keys: ${state.keys}, modifier: ${state.modifier}`);
 
-      if (rpcHidChannel?.readyState === "open") {
+      if (rpcHidReady) {
         console.debug("Sending keyboard report via HidRPC");
         reportKeyboardEvent(state.keys, state.modifier);
         return;
@@ -72,7 +72,7 @@ export default function useKeyboard() {
     },
     [
       rpcDataChannel?.readyState,
-      rpcHidChannel?.readyState,
+      rpcHidReady,
       send,
       reportKeyboardEvent,
       setKeysDownState,
@@ -88,11 +88,11 @@ export default function useKeyboard() {
   // in client/browser-side code using simulateDeviceSideKeyHandlingForLegacyDevices.
   const sendKeypressEvent = useCallback(
     async (key: number, press: boolean) => {
-      if (rpcDataChannel?.readyState !== "open" && rpcHidChannel?.readyState !== "open") return;
+      if (rpcDataChannel?.readyState !== "open" && !rpcHidReady) return;
 
       console.debug(`Send keypressEvent key: ${key}, press: ${press}`);
 
-      if (rpcHidChannel?.readyState === "open") {
+      if (rpcHidReady) {
         console.debug("Sending keypress event via HidRPC");
         reportKeypressEvent(key, press);
         return; 
@@ -119,7 +119,7 @@ export default function useKeyboard() {
     },
     [
       rpcDataChannel?.readyState,
-      rpcHidChannel?.readyState,
+      rpcHidReady,
       send,
       setkeyPressReportApiAvailable,
       setKeysDownState,
@@ -176,10 +176,10 @@ export default function useKeyboard() {
   // It then sends the full keyboard state to the device.
   const handleKeyPress = useCallback(
     async (key: number, press: boolean) => {
-      if (rpcDataChannel?.readyState !== "open" && rpcHidChannel?.readyState !== "open") return;
+      if (rpcDataChannel?.readyState !== "open" && !rpcHidReady) return;
       if ((key || 0) === 0) return; // ignore zero key presses (they are bad mappings)
 
-      if (rpcHidChannel?.readyState === "open") {
+      if (rpcHidReady) {
         console.debug("Sending keypress event via HidRPC");
         reportKeypressEvent(key, press);
         return;
@@ -204,7 +204,7 @@ export default function useKeyboard() {
       keysDownState,
       resetKeyboardState,
       rpcDataChannel?.readyState,
-      rpcHidChannel?.readyState,
+      rpcHidReady,
       sendKeyboardEvent,
       sendKeypressEvent,
       reportKeypressEvent,

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -2,13 +2,14 @@ import { useCallback } from "react";
 
 import { hidErrorRollOver, hidKeyBufferSize, KeysDownState, useHidStore, useRTCStore } from "@/hooks/stores";
 import { JsonRpcResponse, useJsonRpc } from "@/hooks/useJsonRpc";
-import { HID_RPC_MESSAGE_TYPES, useHidRpc } from "@/hooks/useHidRpc";
+import { useHidRpc } from "@/hooks/useHidRpc";
+import { KeyboardLedStateMessage, KeysDownStateMessage } from "@/hooks/hidRpc";
 import { hidKeyToModifierMask, keys, modifiers } from "@/keyboardMappings";
 
 export default function useKeyboard() {
   const { send } = useJsonRpc();
   const { rpcDataChannel } = useRTCStore();
-  const { keysDownState, setKeysDownState } = useHidStore();
+  const { keysDownState, setKeysDownState, setKeyboardLedState } = useHidStore();
 
   // INTRODUCTION: The earlier version of the JetKVM device shipped with all keyboard state
   // being tracked on the browser/client-side. When adding the keyPressReport API to the
@@ -24,13 +25,16 @@ export default function useKeyboard() {
 
   // HidRPC is a binary format for exchanging keyboard and mouse events
   const { reportKeyboardEvent, reportKeypressEvent, rpcHidReady } = useHidRpc((message) => {
-    if (message.type === HID_RPC_MESSAGE_TYPES.KeysDownState) {
-      if (!message.keysDownState) {
-        return;
-      }
-
-      setKeysDownState(message.keysDownState);
-      setkeyPressReportApiAvailable(true);
+    switch (message.constructor) {
+      case KeysDownStateMessage:
+        setKeysDownState((message as KeysDownStateMessage).keysDownState);
+        setkeyPressReportApiAvailable(true);
+        break;
+      case KeyboardLedStateMessage:
+        setKeyboardLedState((message as KeyboardLedStateMessage).keyboardLedState);
+        break;
+      default:
+        break;
     }
   });
 
@@ -95,7 +99,7 @@ export default function useKeyboard() {
       if (rpcHidReady) {
         console.debug("Sending keypress event via HidRPC");
         reportKeypressEvent(key, press);
-        return; 
+        return;
       }
 
       send("keypressReport", { key, press }, (resp: JsonRpcResponse) => {

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -51,26 +51,13 @@ export default function useKeyboard() {
       if (rpcHidReady) {
         console.debug("Sending keyboard report via HidRPC");
         reportKeyboardEvent(state.keys, state.modifier);
+        setkeyPressReportApiAvailable(true);
         return;
       }
 
       send("keyboardReport", { keys: state.keys, modifier: state.modifier }, (resp: JsonRpcResponse) => {
         if ("error" in resp) {
           console.error(`Failed to send keyboard report ${state}`, resp.error);
-        } else {
-          // If the device supports keyPressReport API, it will (also) return the keysDownState when we send
-          // the keyboardReport
-          const keysDownState = resp.result as KeysDownState;
-
-          if (keysDownState) {
-            setKeysDownState(keysDownState); // treat the response as the canonical state
-            setkeyPressReportApiAvailable(true); // if they returned a keysDownState, we ALSO know they also support keyPressReport
-          } else {
-            // older devices versions do not return the keyDownState
-            // so we just pretend they accepted what we sent
-            setKeysDownState(state);
-            setkeyPressReportApiAvailable(false); // we ALSO know they do not support keyPressReport
-          }
         }
       });
     },
@@ -79,7 +66,6 @@ export default function useKeyboard() {
       rpcHidReady,
       send,
       reportKeyboardEvent,
-      setKeysDownState,
       setkeyPressReportApiAvailable,
     ],
   );
@@ -92,41 +78,14 @@ export default function useKeyboard() {
   // in client/browser-side code using simulateDeviceSideKeyHandlingForLegacyDevices.
   const sendKeypressEvent = useCallback(
     async (key: number, press: boolean) => {
-      if (rpcDataChannel?.readyState !== "open" && !rpcHidReady) return;
-
       console.debug(`Send keypressEvent key: ${key}, press: ${press}`);
 
-      if (rpcHidReady) {
-        console.debug("Sending keypress event via HidRPC");
-        reportKeypressEvent(key, press);
-        return;
-      }
+      if (!rpcHidReady) return;
 
-      send("keypressReport", { key, press }, (resp: JsonRpcResponse) => {
-        if ("error" in resp) {
-          // -32601 means the method is not supported because the device is running an older version
-          if (resp.error.code === -32601) {
-            console.error("Legacy device does not support keypressReport API, switching to local key down state handling", resp.error);
-            setkeyPressReportApiAvailable(false);
-          } else {
-            console.error(`Failed to send key ${key} press: ${press}`, resp.error);
-          }
-        } else {
-          const keysDownState = resp.result as KeysDownState;
-
-          if (keysDownState) {
-            setKeysDownState(keysDownState);
-            // we don't need to set keyPressReportApiAvailable here, because it's already true or we never landed here
-          }
-        }
-      });
+      reportKeypressEvent(key, press);
     },
     [
-      rpcDataChannel?.readyState,
       rpcHidReady,
-      send,
-      setkeyPressReportApiAvailable,
-      setKeysDownState,
       reportKeypressEvent,
     ],
   );

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -23,7 +23,11 @@ export default function useKeyboard() {
   // getKeysDownState API.
 
   // HidRPC is a binary format for exchanging keyboard and mouse events
-  const { reportKeyboardEvent, reportKeypressEvent, rpcHidReady } = useHidRpc((message) => {
+  const {
+    reportKeyboardEvent: sendKeyboardEventHidRpc,
+    reportKeypressEvent: sendKeypressEventHidRpc,
+    rpcHidReady,
+  } = useHidRpc((message) => {
     switch (message.constructor) {
       case KeysDownStateMessage:
         setKeysDownState((message as KeysDownStateMessage).keysDownState);
@@ -48,7 +52,7 @@ export default function useKeyboard() {
 
       if (rpcHidReady) {
         console.debug("Sending keyboard report via HidRPC");
-        reportKeyboardEvent(state.keys, state.modifier);
+        sendKeyboardEventHidRpc(state.keys, state.modifier);
         return;
       }
 
@@ -62,27 +66,7 @@ export default function useKeyboard() {
       rpcDataChannel?.readyState,
       rpcHidReady,
       send,
-      reportKeyboardEvent,
-    ],
-  );
-
-  // sendKeypressEvent is used to send a single key press/release event to the device.
-  // It sends the key and whether it is pressed or released.
-  // Older device version will not understand this request and will respond with
-  // an error with code -32601, which means that the RPC method name was not recognized.
-  // In that case we will switch to local key handling and update the keysDownState
-  // in client/browser-side code using simulateDeviceSideKeyHandlingForLegacyDevices.
-  const sendKeypressEvent = useCallback(
-    async (key: number, press: boolean) => {
-      console.debug(`Send keypressEvent key: ${key}, press: ${press}`);
-
-      if (!rpcHidReady) return;
-
-      reportKeypressEvent(key, press);
-    },
-    [
-      rpcHidReady,
-      reportKeypressEvent,
+      sendKeyboardEventHidRpc,
     ],
   );
 
@@ -139,14 +123,13 @@ export default function useKeyboard() {
       if ((key || 0) === 0) return; // ignore zero key presses (they are bad mappings)
 
       if (rpcHidReady) {
-        console.debug("Sending keypress event via HidRPC");
-        reportKeypressEvent(key, press);
-        return;
-      }
-
-      if (rpcHidReady) {
         // if the keyPress api is available, we can just send the key press event
-        sendKeypressEvent(key, press);
+        // sendKeypressEvent is used to send a single key press/release event to the device.
+        // It sends the key and whether it is pressed or released.
+        // Older device version doesn't support this API, so we will switch to local key handling
+        // In that case we will switch to local key handling and update the keysDownState
+        // in client/browser-side code using simulateDeviceSideKeyHandlingForLegacyDevices.
+        sendKeypressEventHidRpc(key, press);
       } else {
         // if the keyPress api is not available, we need to handle the key locally
         const downState = simulateDeviceSideKeyHandlingForLegacyDevices(keysDownState, key, press);
@@ -164,8 +147,7 @@ export default function useKeyboard() {
       resetKeyboardState,
       rpcDataChannel?.readyState,
       sendKeyboardEvent,
-      sendKeypressEvent,
-      reportKeypressEvent,
+      sendKeypressEventHidRpc,
     ],
   );
 

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -1,12 +1,13 @@
 import { useCallback } from "react";
 
-import { KeysDownState, useHidStore, useRTCStore, hidKeyBufferSize, hidErrorRollOver } from "@/hooks/stores";
+import { hidErrorRollOver, hidKeyBufferSize, KeysDownState, useHidStore, useRTCStore } from "@/hooks/stores";
 import { JsonRpcResponse, useJsonRpc } from "@/hooks/useJsonRpc";
+import { HID_RPC_MESSAGE_TYPES, useHidRpc } from "@/hooks/useHidRpc";
 import { hidKeyToModifierMask, keys, modifiers } from "@/keyboardMappings";
 
 export default function useKeyboard() {
   const { send } = useJsonRpc();
-  const { rpcDataChannel } = useRTCStore();
+  const { rpcDataChannel, rpcHidChannel } = useRTCStore();
   const { keysDownState, setKeysDownState } = useHidStore();
 
   // INTRODUCTION: The earlier version of the JetKVM device shipped with all keyboard state
@@ -19,7 +20,19 @@ export default function useKeyboard() {
   // dynamically set when the device responds to the first key press event or reports its
   // keysDownState when queried since the keyPressReport was introduced together with the 
   // getKeysDownState API.
-  const { keyPressReportApiAvailable, setkeyPressReportApiAvailable} = useHidStore();
+  const { keyPressReportApiAvailable, setkeyPressReportApiAvailable } = useHidStore();
+
+  // HidRPC is a binary format for exchanging keyboard and mouse events
+  const { reportKeyboardEvent, reportKeypressEvent } = useHidRpc((message) => {
+    if (message.type === HID_RPC_MESSAGE_TYPES.KeysDownState) {
+      if (!message.keysDownState) {
+        return;
+      }
+
+      setKeysDownState(message.keysDownState);
+      setkeyPressReportApiAvailable(true);
+    }
+  });
 
   // sendKeyboardEvent is used to send the full keyboard state to the device for macro handling
   // and resetting keyboard state. It sends the keys currently pressed and the modifier state.
@@ -27,9 +40,16 @@ export default function useKeyboard() {
   // or just accept the state if it does not support (returning no result)
   const sendKeyboardEvent = useCallback(
     async (state: KeysDownState) => {
-      if (rpcDataChannel?.readyState !== "open") return;
+      if (rpcDataChannel?.readyState !== "open" && rpcHidChannel?.readyState !== "open") return;
 
       console.debug(`Send keyboardReport keys: ${state.keys}, modifier: ${state.modifier}`);
+
+      if (rpcHidChannel?.readyState === "open") {
+        console.debug("Sending keyboard report via HidRPC");
+        reportKeyboardEvent(state.keys, state.modifier);
+        return;
+      }
+
       send("keyboardReport", { keys: state.keys, modifier: state.modifier }, (resp: JsonRpcResponse) => {
         if ("error" in resp) {
           console.error(`Failed to send keyboard report ${state}`, resp.error);
@@ -44,13 +64,20 @@ export default function useKeyboard() {
           } else {
             // older devices versions do not return the keyDownState
             // so we just pretend they accepted what we sent
-            setKeysDownState(state); 
+            setKeysDownState(state);
             setkeyPressReportApiAvailable(false); // we ALSO know they do not support keyPressReport
           }
         }
       });
     },
-    [rpcDataChannel?.readyState, send, setKeysDownState, setkeyPressReportApiAvailable],
+    [
+      rpcDataChannel?.readyState,
+      rpcHidChannel?.readyState,
+      send,
+      reportKeyboardEvent,
+      setKeysDownState,
+      setkeyPressReportApiAvailable,
+    ],
   );
 
   // sendKeypressEvent is used to send a single key press/release event to the device.
@@ -61,9 +88,16 @@ export default function useKeyboard() {
   // in client/browser-side code using simulateDeviceSideKeyHandlingForLegacyDevices.
   const sendKeypressEvent = useCallback(
     async (key: number, press: boolean) => {
-      if (rpcDataChannel?.readyState !== "open") return;
+      if (rpcDataChannel?.readyState !== "open" && rpcHidChannel?.readyState !== "open") return;
 
       console.debug(`Send keypressEvent key: ${key}, press: ${press}`);
+
+      if (rpcHidChannel?.readyState === "open") {
+        console.debug("Sending keypress event via HidRPC");
+        reportKeypressEvent(key, press);
+        return; 
+      }
+
       send("keypressReport", { key, press }, (resp: JsonRpcResponse) => {
         if ("error" in resp) {
           // -32601 means the method is not supported because the device is running an older version
@@ -83,7 +117,14 @@ export default function useKeyboard() {
         }
       });
     },
-    [rpcDataChannel?.readyState, send, setkeyPressReportApiAvailable, setKeysDownState],
+    [
+      rpcDataChannel?.readyState,
+      rpcHidChannel?.readyState,
+      send,
+      setkeyPressReportApiAvailable,
+      setKeysDownState,
+      reportKeypressEvent,
+    ],
   );
 
   // resetKeyboardState is used to reset the keyboard state to no keys pressed and no modifiers.
@@ -135,8 +176,14 @@ export default function useKeyboard() {
   // It then sends the full keyboard state to the device.
   const handleKeyPress = useCallback(
     async (key: number, press: boolean) => {
-      if (rpcDataChannel?.readyState !== "open") return;
+      if (rpcDataChannel?.readyState !== "open" && rpcHidChannel?.readyState !== "open") return;
       if ((key || 0) === 0) return; // ignore zero key presses (they are bad mappings)
+
+      if (rpcHidChannel?.readyState === "open") {
+        console.debug("Sending keypress event via HidRPC");
+        reportKeypressEvent(key, press);
+        return;
+      }
 
       if (keyPressReportApiAvailable) {
         // if the keyPress api is available, we can just send the key press event
@@ -152,7 +199,16 @@ export default function useKeyboard() {
         }
       }
     },
-    [keyPressReportApiAvailable, keysDownState, resetKeyboardState, rpcDataChannel?.readyState, sendKeyboardEvent, sendKeypressEvent],
+    [
+      keyPressReportApiAvailable,
+      keysDownState,
+      resetKeyboardState,
+      rpcDataChannel?.readyState,
+      rpcHidChannel?.readyState,
+      sendKeyboardEvent,
+      sendKeypressEvent,
+      reportKeypressEvent,
+    ],
   );
 
   // IMPORTANT: See the keyPressReportApiAvailable comment above for the reason this exists

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -21,23 +21,15 @@ export default function useKeyboard() {
   // dynamically set when the device responds to the first key press event or reports its
   // keysDownState when queried since the keyPressReport was introduced together with the 
   // getKeysDownState API.
-  const { keyPressReportApiAvailable, setkeyPressReportApiAvailable } = useHidStore();
-  const enableKeyPressReport = useCallback((reason: string) => {
-    if (keyPressReportApiAvailable) return;
-    console.debug(`Enable keyPressReport API because ${reason}`);
-    setkeyPressReportApiAvailable(true);
-  }, [setkeyPressReportApiAvailable, keyPressReportApiAvailable]);
 
   // HidRPC is a binary format for exchanging keyboard and mouse events
   const { reportKeyboardEvent, reportKeypressEvent, rpcHidReady } = useHidRpc((message) => {
     switch (message.constructor) {
       case KeysDownStateMessage:
         setKeysDownState((message as KeysDownStateMessage).keysDownState);
-        enableKeyPressReport("HidRPC:KeysDownStateMessage received");
         break;
       case KeyboardLedStateMessage:
         setKeyboardLedState((message as KeyboardLedStateMessage).keyboardLedState);
-        enableKeyPressReport("HidRPC:KeyboardLedStateMessage received");
         break;
       default:
         break;
@@ -57,7 +49,6 @@ export default function useKeyboard() {
       if (rpcHidReady) {
         console.debug("Sending keyboard report via HidRPC");
         reportKeyboardEvent(state.keys, state.modifier);
-        enableKeyPressReport("HidRPC:KeyboardReport received");
         return;
       }
 
@@ -72,7 +63,6 @@ export default function useKeyboard() {
       rpcHidReady,
       send,
       reportKeyboardEvent,
-      enableKeyPressReport,
     ],
   );
 
@@ -154,7 +144,7 @@ export default function useKeyboard() {
         return;
       }
 
-      if (keyPressReportApiAvailable) {
+      if (rpcHidReady) {
         // if the keyPress api is available, we can just send the key press event
         sendKeypressEvent(key, press);
       } else {
@@ -169,11 +159,10 @@ export default function useKeyboard() {
       }
     },
     [
-      keyPressReportApiAvailable,
+      rpcHidReady,
       keysDownState,
       resetKeyboardState,
       rpcDataChannel?.readyState,
-      rpcHidReady,
       sendKeyboardEvent,
       sendKeypressEvent,
       reportKeypressEvent,

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -22,16 +22,22 @@ export default function useKeyboard() {
   // keysDownState when queried since the keyPressReport was introduced together with the 
   // getKeysDownState API.
   const { keyPressReportApiAvailable, setkeyPressReportApiAvailable } = useHidStore();
+  const enableKeyPressReport = useCallback((reason: string) => {
+    if (keyPressReportApiAvailable) return;
+    console.debug(`Enable keyPressReport API because ${reason}`);
+    setkeyPressReportApiAvailable(true);
+  }, [setkeyPressReportApiAvailable, keyPressReportApiAvailable]);
 
   // HidRPC is a binary format for exchanging keyboard and mouse events
   const { reportKeyboardEvent, reportKeypressEvent, rpcHidReady } = useHidRpc((message) => {
     switch (message.constructor) {
       case KeysDownStateMessage:
         setKeysDownState((message as KeysDownStateMessage).keysDownState);
-        setkeyPressReportApiAvailable(true);
+        enableKeyPressReport("HidRPC:KeysDownStateMessage received");
         break;
       case KeyboardLedStateMessage:
         setKeyboardLedState((message as KeyboardLedStateMessage).keyboardLedState);
+        enableKeyPressReport("HidRPC:KeyboardLedStateMessage received");
         break;
       default:
         break;
@@ -51,7 +57,7 @@ export default function useKeyboard() {
       if (rpcHidReady) {
         console.debug("Sending keyboard report via HidRPC");
         reportKeyboardEvent(state.keys, state.modifier);
-        setkeyPressReportApiAvailable(true);
+        enableKeyPressReport("HidRPC:KeyboardReport received");
         return;
       }
 
@@ -66,7 +72,7 @@ export default function useKeyboard() {
       rpcHidReady,
       send,
       reportKeyboardEvent,
-      setkeyPressReportApiAvailable,
+      enableKeyPressReport,
     ],
   );
 

--- a/ui/src/hooks/useMouse.ts
+++ b/ui/src/hooks/useMouse.ts
@@ -13,11 +13,6 @@ export interface AbsMouseMoveHandlerProps {
   videoHeight: number;
 }
 
-export interface RelMouseMoveHandlerProps {
-  isPointerLockActive: boolean;
-  isPointerLockPossible: boolean;
-}
-
 export default function useMouse() {
   // states
   const { setMousePosition, setMouseMove } = useMouseStore();
@@ -55,9 +50,8 @@ export default function useMouse() {
   );
 
   const getRelMouseMoveHandler = useCallback(
-    ({ isPointerLockActive, isPointerLockPossible }: RelMouseMoveHandlerProps) => (e: MouseEvent) => {
+    () => (e: MouseEvent) => {
       if (mouseMode !== "relative") return;
-      if (isPointerLockActive === false && isPointerLockPossible) return;
 
       // Send mouse movement
       const { buttons } = e;

--- a/ui/src/hooks/useMouse.ts
+++ b/ui/src/hooks/useMouse.ts
@@ -1,0 +1,178 @@
+import { useCallback, useState } from "react";
+
+import { useJsonRpc } from "./useJsonRpc";
+import { useHidRpc } from "./useHidRpc";
+import { useMouseStore, useSettingsStore } from "./stores";
+
+const calcDelta = (pos: number) => (Math.abs(pos) < 10 ? pos * 2 : pos);
+
+export interface AbsMouseMoveHandlerProps {
+  videoClientWidth: number;
+  videoClientHeight: number;
+  videoWidth: number;
+  videoHeight: number;
+}
+
+export interface RelMouseMoveHandlerProps {
+  isPointerLockActive: boolean;
+  isPointerLockPossible: boolean;
+}
+
+export default function useMouse() {
+  // states
+  const { setMousePosition, setMouseMove } = useMouseStore();
+  const [blockWheelEvent, setBlockWheelEvent] = useState(false);
+
+  const { mouseMode, scrollThrottling } = useSettingsStore();
+
+  // RPC hooks
+  const { send } = useJsonRpc();
+  const { reportAbsMouseEvent, reportRelMouseEvent, rpcHidReady } = useHidRpc();
+  // Mouse-related
+
+  const sendRelMouseMovement = useCallback(
+    (x: number, y: number, buttons: number) => {
+      if (mouseMode !== "relative") return;
+      // if we ignore the event, double-click will not work
+      // if (x === 0 && y === 0 && buttons === 0) return;
+      const dx = calcDelta(x);
+      const dy = calcDelta(y);
+      if (rpcHidReady) {
+        reportRelMouseEvent(dx, dy, buttons);
+      } else {
+        // kept for backward compatibility
+        send("relMouseReport", { dx, dy, buttons });
+      }
+      setMouseMove({ x, y, buttons });
+    },
+    [
+      send,
+      reportRelMouseEvent,
+      setMouseMove,
+      mouseMode,
+      rpcHidReady,
+    ],
+  );
+
+  const getRelMouseMoveHandler = useCallback(
+    ({ isPointerLockActive, isPointerLockPossible }: RelMouseMoveHandlerProps) => (e: MouseEvent) => {
+      if (mouseMode !== "relative") return;
+      if (isPointerLockActive === false && isPointerLockPossible) return;
+
+      // Send mouse movement
+      const { buttons } = e;
+      sendRelMouseMovement(e.movementX, e.movementY, buttons);
+    },
+    [sendRelMouseMovement, mouseMode],
+  );
+
+  const sendAbsMouseMovement = useCallback(
+    (x: number, y: number, buttons: number) => {
+      if (mouseMode !== "absolute") return;
+      if (rpcHidReady) {
+        reportAbsMouseEvent(x, y, buttons);
+      } else {
+        // kept for backward compatibility
+        send("absMouseReport", { x, y, buttons });
+      }
+      // We set that for the debug info bar
+      setMousePosition(x, y);
+    },
+    [
+      send,
+      reportAbsMouseEvent,
+      setMousePosition,
+      mouseMode,
+      rpcHidReady,
+    ],
+  );
+
+  const getAbsMouseMoveHandler = useCallback(
+    ({ videoClientWidth, videoClientHeight, videoWidth, videoHeight }: AbsMouseMoveHandlerProps) => (e: MouseEvent) => {
+      if (!videoClientWidth || !videoClientHeight) return;
+      if (mouseMode !== "absolute") return;
+
+      // Get the aspect ratios of the video element and the video stream
+      const videoElementAspectRatio = videoClientWidth / videoClientHeight;
+      const videoStreamAspectRatio = videoWidth / videoHeight;
+
+      // Calculate the effective video display area
+      let effectiveWidth = videoClientWidth;
+      let effectiveHeight = videoClientHeight;
+      let offsetX = 0;
+      let offsetY = 0;
+
+      if (videoElementAspectRatio > videoStreamAspectRatio) {
+        // Pillarboxing: black bars on the left and right
+        effectiveWidth = videoClientHeight * videoStreamAspectRatio;
+        offsetX = (videoClientWidth - effectiveWidth) / 2;
+      } else if (videoElementAspectRatio < videoStreamAspectRatio) {
+        // Letterboxing: black bars on the top and bottom
+        effectiveHeight = videoClientWidth / videoStreamAspectRatio;
+        offsetY = (videoClientHeight - effectiveHeight) / 2;
+      }
+
+      // Clamp mouse position within the effective video boundaries
+      const clampedX = Math.min(Math.max(offsetX, e.offsetX), offsetX + effectiveWidth);
+      const clampedY = Math.min(Math.max(offsetY, e.offsetY), offsetY + effectiveHeight);
+
+      // Map clamped mouse position to the video stream's coordinate system
+      const relativeX = (clampedX - offsetX) / effectiveWidth;
+      const relativeY = (clampedY - offsetY) / effectiveHeight;
+
+      // Convert to HID absolute coordinate system (0-32767 range)
+      const x = Math.round(relativeX * 32767);
+      const y = Math.round(relativeY * 32767);
+
+      // Send mouse movement
+      const { buttons } = e;
+      sendAbsMouseMovement(x, y, buttons);
+    }, [mouseMode, sendAbsMouseMovement],
+  );
+
+  const getMouseWheelHandler = useCallback(
+    () => (e: WheelEvent) => {
+      if (scrollThrottling && blockWheelEvent) {
+        return;
+      }
+
+      // Determine if the wheel event is an accel scroll value
+      const isAccel = Math.abs(e.deltaY) >= 100;
+
+      // Calculate the accel scroll value
+      const accelScrollValue = e.deltaY / 100;
+
+      // Calculate the no accel scroll value
+      const noAccelScrollValue = Math.sign(e.deltaY);
+
+      // Get scroll value
+      const scrollValue = isAccel ? accelScrollValue : noAccelScrollValue;
+
+      // Apply clamping (i.e. min and max mouse wheel hardware value)
+      const clampedScrollValue = Math.max(-127, Math.min(127, scrollValue));
+
+      // Invert the clamped scroll value to match expected behavior
+      const invertedScrollValue = -clampedScrollValue;
+
+      send("wheelReport", { wheelY: invertedScrollValue });
+
+      // Apply blocking delay based of throttling settings
+      if (scrollThrottling && !blockWheelEvent) {
+        setBlockWheelEvent(true);
+        setTimeout(() => setBlockWheelEvent(false), scrollThrottling);
+      }
+    },
+    [send, blockWheelEvent, scrollThrottling],
+  );
+
+  const resetMousePosition = useCallback(() => {
+    sendAbsMouseMovement(0, 0, 0);
+  }, [sendAbsMouseMovement]);
+
+  return {
+    getRelMouseMoveHandler,
+    getAbsMouseMoveHandler,
+    getMouseWheelHandler,
+    resetMousePosition,
+  };
+}

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -583,7 +583,6 @@ export default function KvmIdRoute() {
   const { 
     keyboardLedState,  setKeyboardLedState,
     keysDownState, setKeysDownState, setUsbState,
-    setkeyPressReportApiAvailable
   } = useHidStore();
 
   const [hasUpdated, setHasUpdated] = useState(false);
@@ -621,7 +620,6 @@ export default function KvmIdRoute() {
       const downState = resp.params as KeysDownState;
       console.debug("Setting key down state:", downState);
       setKeysDownState(downState);
-      setkeyPressReportApiAvailable(true); // if they returned a keyDownState, we know they also support keyPressReport
     }
 
     if (resp.method === "otaState") {
@@ -698,7 +696,6 @@ export default function KvmIdRoute() {
         if (resp.error.code === -32601) {
           // if we don't support key down state, we know key press is also not available
           console.warn("Failed to get key down state, switching to old-school", resp.error);
-          setkeyPressReportApiAvailable(false);
         } else {
           console.error("Failed to get key down state", resp.error);
         }
@@ -706,11 +703,10 @@ export default function KvmIdRoute() {
         const downState = resp.result as KeysDownState;
         console.debug("Keyboard key down state", downState);
         setKeysDownState(downState);
-        setkeyPressReportApiAvailable(true); // if they returned a keyDownState, we know they also support keyPressReport
       }
       setNeedKeyDownState(false);
     });
-  }, [keysDownState, needKeyDownState, rpcDataChannel?.readyState, send, setkeyPressReportApiAvailable, setKeysDownState]);
+  }, [keysDownState, needKeyDownState, rpcDataChannel?.readyState, send, setKeysDownState]);
 
   // When the update is successful, we need to refresh the client javascript and show a success modal
   useEffect(() => {

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -135,7 +135,8 @@ export default function KvmIdRoute() {
     setRpcDataChannel,
     isTurnServerInUse, setTurnServerInUse,
     rpcDataChannel,
-    setTransceiver
+    setTransceiver,
+    setRpcHidChannel,
   } = useRTCStore();
 
   const location = useLocation();
@@ -482,6 +483,12 @@ export default function KvmIdRoute() {
       setRpcDataChannel(rpcDataChannel);
     };
 
+    const rpcHidChannel = pc.createDataChannel("hidrpc");
+    rpcHidChannel.binaryType = "arraybuffer";
+    rpcHidChannel.onopen = () => {
+      setRpcHidChannel(rpcHidChannel);
+    };
+
     setPeerConnection(pc);
   }, [
     cleanupAndStopReconnecting,
@@ -492,6 +499,7 @@ export default function KvmIdRoute() {
     setPeerConnection,
     setPeerConnectionState,
     setRpcDataChannel,
+    setRpcHidChannel,
     setTransceiver,
   ]);
 

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -28,6 +28,9 @@ export default defineConfig(({ mode, command }) => {
 
   return {
     plugins,
+    esbuild: {
+      pure: ["console.debug"],
+    },
     build: { outDir: isCloud ? "dist" : "../static" },
     server: {
       host: "0.0.0.0",

--- a/usb.go
+++ b/usb.go
@@ -27,13 +27,13 @@ func initUsbGadget() {
 
 	gadget.SetOnKeyboardStateChange(func(state usbgadget.KeyboardState) {
 		if currentSession != nil {
-			writeJSONRPCEvent("keyboardLedState", state, currentSession)
+			reportHidRpcKeyboardLedState(state, currentSession)
 		}
 	})
 
 	gadget.SetOnKeysDownChange(func(state usbgadget.KeysDownState) {
 		if currentSession != nil {
-			writeJSONRPCEvent("keysDownState", state, currentSession)
+			reportHidRpcKeysDownState(state, currentSession)
 		}
 	})
 

--- a/usb.go
+++ b/usb.go
@@ -27,13 +27,13 @@ func initUsbGadget() {
 
 	gadget.SetOnKeyboardStateChange(func(state usbgadget.KeyboardState) {
 		if currentSession != nil {
-			reportHidRpcKeyboardLedState(state, currentSession)
+			currentSession.reportHidRPCKeyboardLedState(state)
 		}
 	})
 
 	gadget.SetOnKeysDownChange(func(state usbgadget.KeysDownState) {
 		if currentSession != nil {
-			reportHidRpcKeysDownState(state, currentSession)
+			currentSession.reportHidRPCKeysDownState(state)
 		}
 	})
 

--- a/webrtc.go
+++ b/webrtc.go
@@ -158,7 +158,11 @@ func newSession(config SessionConfig) (*Session, error) {
 		case "hidrpc":
 			session.HidChannel = d
 			d.OnMessage(func(msg webrtc.DataChannelMessage) {
-				l := scopedLogger.With().Str("data", string(msg.Data)).Int("length", len(msg.Data)).Logger()
+				l := scopedLogger.With().Int("length", len(msg.Data)).Logger()
+				// only log data if the log level is debug or lower
+				if scopedLogger.GetLevel() > zerolog.DebugLevel {
+					l = l.With().Str("data", string(msg.Data)).Logger()
+				}
 
 				if msg.IsString {
 					l.Warn().Msg("received string data in HID RPC message handler")

--- a/webrtc.go
+++ b/webrtc.go
@@ -134,21 +134,24 @@ func newSession(config SessionConfig) (*Session, error) {
 		}()
 
 		scopedLogger.Info().Str("label", d.Label()).Uint16("id", *d.ID()).Msg("New DataChannel")
+
 		switch d.Label() {
 		case "hidrpc":
 			session.HidChannel = d
 			d.OnMessage(func(msg webrtc.DataChannelMessage) {
+				l := scopedLogger.With().Str("data", string(msg.Data)).Int("length", len(msg.Data)).Logger()
+
 				if msg.IsString {
-					scopedLogger.Warn().Str("data", string(msg.Data)).Msg("received string data in HID RPC message handler")
+					l.Warn().Msg("received string data in HID RPC message handler")
 					return
 				}
 
 				if len(msg.Data) < 1 {
-					scopedLogger.Warn().Int("length", len(msg.Data)).Msg("received empty data in HID RPC message handler")
+					l.Warn().Msg("received empty data in HID RPC message handler")
 					return
 				}
 
-				scopedLogger.Debug().Str("data", string(msg.Data)).Msg("received data in HID RPC message handler")
+				l.Trace().Msg("received data in HID RPC message handler")
 
 				// Enqueue to ensure ordered processing
 				session.hidQueue <- msg

--- a/webrtc.go
+++ b/webrtc.go
@@ -22,7 +22,10 @@ type Session struct {
 	RPCChannel               *webrtc.DataChannel
 	HidChannel               *webrtc.DataChannel
 	shouldUmountVirtualMedia bool
-	rpcQueue                 chan webrtc.DataChannelMessage
+
+	hidRpcAvailable bool
+	hidQueue        chan webrtc.DataChannelMessage
+	rpcQueue        chan webrtc.DataChannelMessage
 }
 
 type SessionConfig struct {
@@ -105,17 +108,49 @@ func newSession(config SessionConfig) (*Session, error) {
 		scopedLogger.Warn().Err(err).Msg("Failed to create PeerConnection")
 		return nil, err
 	}
+
 	session := &Session{peerConnection: peerConnection}
 	session.rpcQueue = make(chan webrtc.DataChannelMessage, 256)
+	session.hidQueue = make(chan webrtc.DataChannelMessage, 1024)
+
 	go func() {
 		for msg := range session.rpcQueue {
-			onRPCMessage(msg, session)
+			// TODO: only use goroutine if the task is asynchronous
+			go onRPCMessage(msg, session)
+		}
+	}()
+
+	go func() {
+		for msg := range session.hidQueue {
+			onHidMessage(msg.Data, session)
 		}
 	}()
 
 	peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
+		defer func() {
+			if r := recover(); r != nil {
+				scopedLogger.Warn().Interface("error", r).Msg("Recovered from panic in DataChannel handler")
+			}
+		}()
+
 		scopedLogger.Info().Str("label", d.Label()).Uint16("id", *d.ID()).Msg("New DataChannel")
 		switch d.Label() {
+		case "hidrpc":
+			session.HidChannel = d
+			d.OnMessage(func(msg webrtc.DataChannelMessage) {
+				if msg.IsString {
+					scopedLogger.Warn().Str("data", string(msg.Data)).Msg("received string data in HID RPC message handler")
+					return
+				}
+
+				if len(msg.Data) < 1 {
+					scopedLogger.Warn().Int("length", len(msg.Data)).Msg("received empty data in HID RPC message handler")
+					return
+				}
+
+				// Enqueue to ensure ordered processing
+				session.hidQueue <- msg
+			})
 		case "rpc":
 			session.RPCChannel = d
 			d.OnMessage(func(msg webrtc.DataChannelMessage) {

--- a/webrtc.go
+++ b/webrtc.go
@@ -23,7 +23,7 @@ type Session struct {
 	HidChannel               *webrtc.DataChannel
 	shouldUmountVirtualMedia bool
 
-	hidRpcAvailable bool
+	hidRPCAvailable bool
 	hidQueue        chan webrtc.DataChannelMessage
 	rpcQueue        chan webrtc.DataChannelMessage
 }
@@ -111,7 +111,7 @@ func newSession(config SessionConfig) (*Session, error) {
 
 	session := &Session{peerConnection: peerConnection}
 	session.rpcQueue = make(chan webrtc.DataChannelMessage, 256)
-	session.hidQueue = make(chan webrtc.DataChannelMessage, 1024)
+	session.hidQueue = make(chan webrtc.DataChannelMessage, 256)
 
 	go func() {
 		for msg := range session.rpcQueue {
@@ -129,7 +129,7 @@ func newSession(config SessionConfig) (*Session, error) {
 	peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
 		defer func() {
 			if r := recover(); r != nil {
-				scopedLogger.Warn().Interface("error", r).Msg("Recovered from panic in DataChannel handler")
+				scopedLogger.Error().Interface("error", r).Msg("Recovered from panic in DataChannel handler")
 			}
 		}()
 
@@ -234,6 +234,11 @@ func newSession(config SessionConfig) (*Session, error) {
 			if session.rpcQueue != nil {
 				close(session.rpcQueue)
 				session.rpcQueue = nil
+			}
+			// Stop HID RPC processor
+			if session.hidQueue != nil {
+				close(session.hidQueue)
+				session.hidQueue = nil
 			}
 			if session.shouldUmountVirtualMedia {
 				if err := rpcUnmountImage(); err != nil {

--- a/webrtc.go
+++ b/webrtc.go
@@ -148,6 +148,8 @@ func newSession(config SessionConfig) (*Session, error) {
 					return
 				}
 
+				scopedLogger.Debug().Str("data", string(msg.Data)).Msg("received data in HID RPC message handler")
+
 				// Enqueue to ensure ordered processing
 				session.hidQueue <- msg
 			})

--- a/webrtc.go
+++ b/webrtc.go
@@ -6,10 +6,12 @@ import (
 	"encoding/json"
 	"net"
 	"strings"
+	"sync"
 
 	"github.com/coder/websocket"
 	"github.com/coder/websocket/wsjson"
 	"github.com/gin-gonic/gin"
+	"github.com/jetkvm/kvm/internal/hidrpc"
 	"github.com/jetkvm/kvm/internal/logging"
 	"github.com/pion/webrtc/v4"
 	"github.com/rs/zerolog"
@@ -23,9 +25,11 @@ type Session struct {
 	HidChannel               *webrtc.DataChannel
 	shouldUmountVirtualMedia bool
 
+	rpcQueue chan webrtc.DataChannelMessage
+
 	hidRPCAvailable bool
-	hidQueue        chan webrtc.DataChannelMessage
-	rpcQueue        chan webrtc.DataChannelMessage
+	hidQueueLock    sync.Mutex
+	hidQueue        []chan webrtc.DataChannelMessage
 }
 
 type SessionConfig struct {
@@ -70,6 +74,23 @@ func (s *Session) ExchangeOffer(offerStr string) (string, error) {
 	return base64.StdEncoding.EncodeToString(localDescription), nil
 }
 
+func (s *Session) initQueues() {
+	s.hidQueueLock.Lock()
+	defer s.hidQueueLock.Unlock()
+
+	s.hidQueue = make([]chan webrtc.DataChannelMessage, 0)
+	for i := 0; i < 4; i++ {
+		q := make(chan webrtc.DataChannelMessage, 256)
+		s.hidQueue = append(s.hidQueue, q)
+	}
+}
+
+func (s *Session) handleQueues(index int) {
+	for msg := range s.hidQueue[index] {
+		onHidMessage(msg.Data, s)
+	}
+}
+
 func newSession(config SessionConfig) (*Session, error) {
 	webrtcSettingEngine := webrtc.SettingEngine{
 		LoggerFactory: logging.GetPionDefaultLoggerFactory(),
@@ -111,7 +132,7 @@ func newSession(config SessionConfig) (*Session, error) {
 
 	session := &Session{peerConnection: peerConnection}
 	session.rpcQueue = make(chan webrtc.DataChannelMessage, 256)
-	session.hidQueue = make(chan webrtc.DataChannelMessage, 256)
+	session.initQueues()
 
 	go func() {
 		for msg := range session.rpcQueue {
@@ -120,11 +141,9 @@ func newSession(config SessionConfig) (*Session, error) {
 		}
 	}()
 
-	go func() {
-		for msg := range session.hidQueue {
-			onHidMessage(msg.Data, session)
-		}
-	}()
+	for i := 0; i < len(session.hidQueue); i++ {
+		go session.handleQueues(i)
+	}
 
 	peerConnection.OnDataChannel(func(d *webrtc.DataChannel) {
 		defer func() {
@@ -154,7 +173,19 @@ func newSession(config SessionConfig) (*Session, error) {
 				l.Trace().Msg("received data in HID RPC message handler")
 
 				// Enqueue to ensure ordered processing
-				session.hidQueue <- msg
+				queueIndex := hidrpc.GetQueueIndex(hidrpc.MessageType(msg.Data[0]))
+				if queueIndex >= len(session.hidQueue) || queueIndex < 0 {
+					l.Warn().Int("queueIndex", queueIndex).Msg("received data in HID RPC message handler, but queue index not found")
+					queueIndex = 3
+				}
+
+				queue := session.hidQueue[queueIndex]
+				if queue != nil {
+					queue <- msg
+				} else {
+					l.Warn().Int("queueIndex", queueIndex).Msg("received data in HID RPC message handler, but queue is nil")
+					return
+				}
 			})
 		case "rpc":
 			session.RPCChannel = d
@@ -238,11 +269,13 @@ func newSession(config SessionConfig) (*Session, error) {
 				close(session.rpcQueue)
 				session.rpcQueue = nil
 			}
+
 			// Stop HID RPC processor
-			if session.hidQueue != nil {
-				close(session.hidQueue)
-				session.hidQueue = nil
+			for i := 0; i < len(session.hidQueue); i++ {
+				close(session.hidQueue[i])
+				session.hidQueue[i] = nil
 			}
+
 			if session.shouldUmountVirtualMedia {
 				if err := rpcUnmountImage(); err != nil {
 					scopedLogger.Warn().Err(err).Msg("unmount image failed on connection close")


### PR DESCRIPTION
This PR moved HID events to a dedicated queue and switched from JSONRPC to a custom binary format to improve performance under poor network conditions.

It's also worth noting that the `/dev/hidg*` endpoints can sometimes hang indefinitely, so a timeout was introduced to prevent the queue from being blocked forever in such cases.
