### PR TITLE
feat(ui) Fix the CapsLock and Shift key for VirtualKeyboard

### DIFF
--- a/ui/src/components/VirtualKeyboard.tsx
+++ b/ui/src/components/VirtualKeyboard.tsx
@@ -47,7 +47,7 @@ function KeyboardWrapper() {
   }, [keysDownState]);
 
   const isCapsLockActive = useMemo(() => {
-    return keyboardLedState?.caps_lock || false;
+    return keyboardLedState.caps_lock;
   }, [keyboardLedState]);
 
   const mainLayoutName = useMemo(() => {

--- a/ui/src/components/VirtualKeyboard.tsx
+++ b/ui/src/components/VirtualKeyboard.tsx
@@ -25,7 +25,7 @@ function KeyboardWrapper() {
   const keyboardRef = useRef<HTMLDivElement>(null);
   const { isAttachedVirtualKeyboardVisible, setAttachedVirtualKeyboardVisibility } =
     useUiStore();
-  const { keysDownState, isVirtualKeyboardEnabled, setVirtualKeyboardEnabled } =
+  const { keyboardLedState, keysDownState, isVirtualKeyboardEnabled, setVirtualKeyboardEnabled } =
     useHidStore();
   const { handleKeyPress, executeMacro } = useKeyboard();
   const { selectedKeyboard } = useKeyboardLayout();
@@ -46,9 +46,15 @@ function KeyboardWrapper() {
     return decodeModifiers(keysDownState.modifier);
   }, [keysDownState]);
 
+  const isCapsLockActive = useMemo(() => {
+    return keyboardLedState?.caps_lock || false;
+  }, [keyboardLedState]);
+
   const mainLayoutName = useMemo(() => {
-    return isShiftActive ? "shift" : "default";
-  }, [isShiftActive]);
+    // if you have the CapsLock "latched", then the shift state is inverted
+    const effectiveShift = isCapsLockActive ? false === isShiftActive : isShiftActive;
+    return effectiveShift ? "shift" : "default";
+  }, [isCapsLockActive, isShiftActive]);
 
   const keyNamesForDownKeys = useMemo(() => {
     const activeModifierMask = keysDownState.modifier || 0;

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -463,7 +463,7 @@ export interface HidState {
 }
 
 export const useHidStore = create<HidState>(set => ({
-  keyboardLedState: {} as KeyboardLedState,
+  keyboardLedState: { num_lock: false, caps_lock: false, scroll_lock: false, compose: false, kana: false, shift: false } as KeyboardLedState,
   setKeyboardLedState: (ledState: KeyboardLedState): void => set({ keyboardLedState: ledState }),
 
   keysDownState: { modifier: 0, keys: [0,0,0,0,0,0] } as KeysDownState,


### PR DESCRIPTION
In the previous 0.4.x releases the Virtual Keyboard layout (key caps shown) would take into account the Caps Lock key (showing the shifted layout) and reverse the layout back to default when they user pressed the shift key. 

This is the standard behavior for PCs running Linux or Windows (but doesn't always work that way on MacOS). Once we start tracking the actual installed keyboard on the remote/host device we can do a better job, but this PR restores the previous behavior