### PR TITLE
Don't fetch KeybardAndMouse Icon on every re-render

### DIFF
--- a/ui/src/components/USBStateStatus.tsx
+++ b/ui/src/components/USBStateStatus.tsx
@@ -22,6 +22,39 @@ const USBStateMap: Record<USBStates, string> = {
   "not attached": "Disconnected",
   suspended: "Low power mode",
 };
+const StatusCardProps: StatusProps = {
+  configured: {
+    icon: ({ className }) => (
+      <img className={cx(className)} src={KeyboardAndMouseConnectedIcon} alt="" />
+    ),
+    iconClassName: "h-5 w-5 shrink-0",
+    statusIndicatorClassName: "bg-green-500 border-green-600",
+  },
+  attached: {
+    icon: ({ className }) => <LoadingSpinner className={cx(className)} />,
+    iconClassName: "h-5 w-5 text-blue-500",
+    statusIndicatorClassName: "bg-slate-300 border-slate-400",
+  },
+  addressed: {
+    icon: ({ className }) => <LoadingSpinner className={cx(className)} />,
+    iconClassName: "h-5 w-5 text-blue-500",
+    statusIndicatorClassName: "bg-slate-300 border-slate-400",
+  },
+  "not attached": {
+    icon: ({ className }) => (
+      <img className={cx(className)} src={KeyboardAndMouseConnectedIcon} alt="" />
+    ),
+    iconClassName: "h-5 w-5 opacity-50 grayscale filter",
+    statusIndicatorClassName: "bg-slate-300 border-slate-400",
+  },
+  suspended: {
+    icon: ({ className }) => (
+      <img className={cx(className)} src={KeyboardAndMouseConnectedIcon} alt="" />
+    ),
+    iconClassName: "h-5 w-5 opacity-50 grayscale filter",
+    statusIndicatorClassName: "bg-green-500 border-green-600",
+  },
+};
 
 export default function USBStateStatus({
   state,
@@ -30,39 +63,7 @@ export default function USBStateStatus({
   state: USBStates;
   peerConnectionState?: RTCPeerConnectionState | null;
 }) {
-  const StatusCardProps: StatusProps = {
-    configured: {
-      icon: ({ className }) => (
-        <img className={cx(className)} src={KeyboardAndMouseConnectedIcon} alt="" />
-      ),
-      iconClassName: "h-5 w-5 shrink-0",
-      statusIndicatorClassName: "bg-green-500 border-green-600",
-    },
-    attached: {
-      icon: ({ className }) => <LoadingSpinner className={cx(className)} />,
-      iconClassName: "h-5 w-5 text-blue-500",
-      statusIndicatorClassName: "bg-slate-300 border-slate-400",
-    },
-    addressed: {
-      icon: ({ className }) => <LoadingSpinner className={cx(className)} />,
-      iconClassName: "h-5 w-5 text-blue-500",
-      statusIndicatorClassName: "bg-slate-300 border-slate-400",
-    },
-    "not attached": {
-      icon: ({ className }) => (
-        <img className={cx(className)} src={KeyboardAndMouseConnectedIcon} alt="" />
-      ),
-      iconClassName: "h-5 w-5 opacity-50 grayscale filter",
-      statusIndicatorClassName: "bg-slate-300 border-slate-400",
-    },
-    suspended: {
-      icon: ({ className }) => (
-        <img className={cx(className)} src={KeyboardAndMouseConnectedIcon} alt="" />
-      ),
-      iconClassName: "h-5 w-5 opacity-50 grayscale filter",
-      statusIndicatorClassName: "bg-green-500 border-green-600",
-    },
-  };
+
   const props = StatusCardProps[state];
   if (!props) {
     console.warn("Unsupported USB state: ", state);


### PR DESCRIPTION
This doesn't solve the underlying re-rendering issue, but at least we don't fetch an icon from the device on every keypress.

@IDisposable when you've got some time over, could you spend some time looking into what's causing these re-renders?