### PR TITLE
Fix auto release and keypress timeouts

### DIFF
--- a/internal/usbgadget/consts.go
+++ b/internal/usbgadget/consts.go
@@ -4,4 +4,13 @@ import "time"
 
 const dwc3Path = "/sys/bus/platform/drivers/dwc3"
 
-const hidWriteTimeout = 10 * time.Millisecond
+// Timeout for HID writes to gadget endpoints. Some hosts poll at ~10ms, but
+// under load this can be longer. Use a slightly higher value to reduce
+// spurious timeouts while still preventing indefinite blocking.
+const hidWriteTimeout = 50 * time.Millisecond
+
+// Auto-release configuration. When keys are down and no successful HID write
+// has happened for this duration, clear the keyboard state to prevent stuck
+// keys after network hiccups.
+const keyAutoReleaseAfter = 2 * time.Second
+const keyAutoReleaseCheckInterval = 200 * time.Millisecond

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -256,15 +256,37 @@ func (u *UsbGadget) keyboardWriteHidFile(modifier byte, keys []byte) error {
 		return err
 	}
 
-	_, err := u.writeWithTimeout(u.keyboardHidFile, append([]byte{modifier, 0x00}, keys[:hidKeyBufferSize]...))
-	if err != nil {
-		u.logWithSuppression("keyboardWriteHidFile", 100, u.log, err, "failed to write to hidg0")
-		u.keyboardHidFile.Close()
-		u.keyboardHidFile = nil
-		return err
+	data := append([]byte{modifier, 0x00}, keys[:hidKeyBufferSize]...)
+	file := u.keyboardHidFile
+	done := make(chan error, 1)
+	go func(f *os.File, payload []byte) {
+		_, err := f.Write(payload)
+		done <- err
+	}(file, data)
+
+	t := time.NewTimer(hidWriteTimeout)
+	defer t.Stop()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			u.logWithSuppression("keyboardWriteHidFile", 100, u.log, err, "failed to write to hidg0")
+			_ = file.Close()
+			if u.keyboardHidFile == file {
+				u.keyboardHidFile = nil
+			}
+			return err
+		}
+		u.resetLogSuppressionCounter("keyboardWriteHidFile")
+		return nil
+	case <-t.C:
+		u.logWithSuppression("keyboardWriteHidFileTimeout", 100, u.log, fmt.Errorf("deadline exceeded"), "write timed out: %s", file.Name())
+		_ = file.Close()
+		if u.keyboardHidFile == file {
+			u.keyboardHidFile = nil
+		}
+		return fmt.Errorf("keyboard write timeout")
 	}
-	u.resetLogSuppressionCounter("keyboardWriteHidFile")
-	return nil
 }
 
 func (u *UsbGadget) UpdateKeysDown(modifier byte, keys []byte) KeysDownState {

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -163,9 +163,16 @@ func (u *UsbGadget) updateKeyDownState(state KeysDownState) {
 	}
 
 	if u.onKeysDownChange != nil {
-		u.log.Trace().Interface("state", state).Msg("calling onKeysDownChange")
-		(*u.onKeysDownChange)(state)
-		u.log.Trace().Interface("state", state).Msg("onKeysDownChange called")
+		// Call the callback asynchronously to avoid blocking the HID RPC handler path
+		// and to prevent timeouts when the network is slow or the channel back-pressures.
+		st := state
+		// make a copy of the slice to avoid data races
+		st.Keys = append([]byte(nil), state.Keys...)
+		go func(s KeysDownState) {
+			u.log.Trace().Interface("state", s).Msg("calling onKeysDownChange")
+			(*u.onKeysDownChange)(s)
+			u.log.Trace().Interface("state", s).Msg("onKeysDownChange called")
+		}(st)
 	}
 }
 
@@ -234,6 +241,8 @@ func (u *UsbGadget) openKeyboardHidFile() error {
 
 	u.keyboardStateCtx, u.keyboardStateCancel = context.WithCancel(context.Background())
 	u.listenKeyboardEvents()
+	// Start auto-release monitor to clear stuck keys after inactivity
+	u.listenKeyboardAutoRelease()
 
 	return nil
 }
@@ -399,4 +408,60 @@ func (u *UsbGadget) KeypressReport(key byte, press bool) (KeysDownState, error) 
 	}
 
 	return u.UpdateKeysDown(modifier, keys), err
+}
+
+// listenKeyboardAutoRelease starts a background monitor that automatically
+// releases all keys if no input has been successfully written to the HID device
+// for a period of time. This acts as a safety net to avoid stuck keys when
+// key-up events are lost due to network issues.
+func (u *UsbGadget) listenKeyboardAutoRelease() {
+	var path string
+	if u.keyboardHidFile != nil {
+		path = u.keyboardHidFile.Name()
+	}
+	l := u.log.With().Str("listener", "keyboardAutoRelease").Str("path", path).Logger()
+	l.Trace().Msg("starting")
+
+	go func() {
+		ticker := time.NewTicker(keyAutoReleaseCheckInterval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-u.keyboardStateCtx.Done():
+				l.Info().Msg("context done")
+				return
+			case <-ticker.C:
+				// Fast path: if nothing is currently down, skip work
+				u.keyboardStateLock.Lock()
+				modifier := u.keysDownState.Modifier
+				keys := append([]byte(nil), u.keysDownState.Keys...)
+				u.keyboardStateLock.Unlock()
+
+				allZero := modifier == 0
+				if allZero {
+					for _, k := range keys {
+						if k != 0 {
+							allZero = false
+							break
+						}
+					}
+				}
+				if allZero {
+					continue
+				}
+
+				// If we have any key/modifier down and we've been idle long enough, clear state
+				if time.Since(u.GetLastUserInputTime()) >= keyAutoReleaseAfter {
+					l.Debug().Dur("idle", time.Since(u.GetLastUserInputTime())).Msg("auto-releasing stuck keys")
+					zeros := make([]byte, hidKeyBufferSize)
+					_, err := u.KeyboardReport(0x00, zeros)
+					if err != nil {
+						u.logWithSuppression("keyboardAutoReleaseWrite", 100, &l, err, "failed to auto-release keys")
+					} else {
+						u.resetLogSuppressionCounter("keyboardAutoReleaseWrite")
+					}
+				}
+			}
+		}
+	}()
 }

--- a/internal/usbgadget/utils.go
+++ b/internal/usbgadget/utils.go
@@ -116,23 +116,22 @@ func (u *UsbGadget) writeWithTimeout(file *os.File, data []byte) (n int, err err
 	}
 
 	n, err = file.Write(data)
-	if err == nil {
-		return
+	if err != nil {
+		if errors.Is(err, os.ErrDeadlineExceeded) {
+			// Promote visibility of timeouts and allow callers to recover by
+			// reopening the file. Do not swallow the error.
+			u.logWithSuppression(
+				fmt.Sprintf("writeWithTimeout_%s", file.Name()),
+				100,
+				u.log,
+				err,
+				"write timed out: %s",
+				file.Name(),
+			)
+		}
+		return n, err
 	}
-
-	if errors.Is(err, os.ErrDeadlineExceeded) {
-		u.logWithSuppression(
-			fmt.Sprintf("writeWithTimeout_%s", file.Name()),
-			1000,
-			u.log,
-			err,
-			"write timed out: %s",
-			file.Name(),
-		)
-		err = nil
-	}
-
-	return
+	return n, nil
 }
 
 func (u *UsbGadget) logWithSuppression(counterName string, every int, logger *zerolog.Logger, err error, msg string, args ...any) {

--- a/webrtc.go
+++ b/webrtc.go
@@ -274,6 +274,17 @@ func newSession(config SessionConfig) (*Session, error) {
 				session.rpcQueue = nil
 			}
 
+			// Best-effort: clear any potentially stuck keys on channel close
+			if gadget != nil {
+				go func() {
+					zeros := make([]byte, 6)
+					_, err := rpcKeyboardReport(0x00, zeros)
+					if err != nil {
+						scopedLogger.Debug().Err(err).Msg("failed to auto-release keys on channel close")
+					}
+				}()
+			}
+
 			// Stop HID RPC processor
 			for i := 0; i < len(session.hidQueue); i++ {
 				close(session.hidQueue[i])


### PR DESCRIPTION
Implement on-device keyboard auto-release and improve HID write error handling to prevent stuck keys and `keypressReport` timeouts in bad network conditions.

The original problem involved keyboard keys getting stuck due to lost key-up events in unreliable networks, as the auto-release mechanism was not robust. Additionally, `keypressReport` calls were timing out because the HID RPC handler was blocked by synchronous callbacks and HID write errors were being swallowed, preventing proper device file re-opening and recovery. This PR introduces an on-device auto-release monitor, makes RPC callbacks asynchronous, and ensures HID write timeouts are properly handled for recovery.

---
<a href="https://cursor.com/background-agent?bcId=bc-c2b7ebc3-c5ab-4a4f-9ba6-6ce7eb83809c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c2b7ebc3-c5ab-4a4f-9ba6-6ce7eb83809c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

