### PR TITLE
feat: re-add keyboard and keypress report handlers to RPC

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1168,6 +1168,8 @@ var rpcHandlers = map[string]RPCHandler{
 	"renewDHCPLease":         {Func: rpcRenewDHCPLease},
 	"getKeyboardLedState":    {Func: rpcGetKeyboardLedState},
 	"getKeyDownState":        {Func: rpcGetKeysDownState},
+	"keyboardReport":         {Func: rpcKeyboardReport, Params: []string{"modifier", "keys"}},
+	"keypressReport":         {Func: rpcKeypressReport, Params: []string{"key", "press"}},
 	"absMouseReport":         {Func: rpcAbsMouseReport, Params: []string{"x", "y", "buttons"}},
 	"relMouseReport":         {Func: rpcRelMouseReport, Params: []string{"dx", "dy", "buttons"}},
 	"wheelReport":            {Func: rpcWheelReport, Params: []string{"wheelY"}},


### PR DESCRIPTION
[Enough users](https://github.com/jetkvm/kvm/discussions/809) are using the dev channel and the JetKVM Cloud. As a quick fix for this keyboard rewrite, let's just add this back, and remove it once we promote the `0.4.8-dev` to a main channel update - which we don't expect taking too long.

Long term, we should figure out how to ensure that we and the users have the same mental model of what to expect of the Dev Channel or similar.