### PR TITLE
Add pointer even when HDMI isn't feeding video

### DIFF
--- a/ui/src/components/VideoOverlay.tsx
+++ b/ui/src/components/VideoOverlay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import { ArrowPathIcon, ArrowRightIcon } from "@heroicons/react/16/solid";
 import { motion, AnimatePresence } from "framer-motion";
-import { LuPlay } from "react-icons/lu";
+import { LuMaximize, LuPlay } from "react-icons/lu";
 import { BsMouseFill } from "react-icons/bs";
 
 import { Button, LinkButton } from "@components/Button";
@@ -209,9 +209,10 @@ export function PeerConnectionDisconnectedOverlay({
 interface HDMIErrorOverlayProps {
   readonly show: boolean;
   readonly hdmiState: string;
+  readonly requestFullscreen: () => void;
 }
 
-export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
+export function HDMIErrorOverlay({ show, hdmiState, requestFullscreen }: HDMIErrorOverlayProps) {
   const isNoSignal = hdmiState === "no_signal";
   const isOtherError = hdmiState === "no_lock" || hdmiState === "out_of_range";
 
@@ -247,14 +248,25 @@ export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
                         </li>
                       </ul>
                     </div>
-                    <div>
-                      <LinkButton
-                        to={"https://jetkvm.com/docs/getting-started/troubleshooting"}
-                        theme="light"
-                        text="Learn more"
-                        TrailingIcon={ArrowRightIcon}
-                        size="SM"
-                      />
+                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 py-1.5">
+                      <div className="relative flex flex-wrap items-center gap-x-2 gap-y-2">
+                        <LinkButton
+                          to={"https://jetkvm.com/docs/getting-started/troubleshooting"}
+                          theme="light"
+                          text="Learn more"
+                          TrailingIcon={ArrowRightIcon}
+                          size="SM"
+                        />
+                      </div>
+                      <div className="flex flex-wrap items-right gap-x-2 gap-y-2">
+                        <Button
+                          size="XS"
+                          theme="light"
+                          text="Fullscreen"
+                          LeadingIcon={LuMaximize}
+                          onClick={() => requestFullscreen()}
+                        />
+                      </div>
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/VideoOverlay.tsx
+++ b/ui/src/components/VideoOverlay.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import { ArrowPathIcon, ArrowRightIcon } from "@heroicons/react/16/solid";
 import { motion, AnimatePresence } from "framer-motion";
-import { LuMaximize, LuPlay } from "react-icons/lu";
+import { LuPlay } from "react-icons/lu";
 import { BsMouseFill } from "react-icons/bs";
 
 import { Button, LinkButton } from "@components/Button";
@@ -209,10 +209,9 @@ export function PeerConnectionDisconnectedOverlay({
 interface HDMIErrorOverlayProps {
   readonly show: boolean;
   readonly hdmiState: string;
-  readonly requestFullscreen: () => void;
 }
 
-export function HDMIErrorOverlay({ show, hdmiState, requestFullscreen }: HDMIErrorOverlayProps) {
+export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
   const isNoSignal = hdmiState === "no_signal";
   const isOtherError = hdmiState === "no_lock" || hdmiState === "out_of_range";
 
@@ -248,25 +247,14 @@ export function HDMIErrorOverlay({ show, hdmiState, requestFullscreen }: HDMIErr
                         </li>
                       </ul>
                     </div>
-                    <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2 py-1.5">
-                      <div className="relative flex flex-wrap items-center gap-x-2 gap-y-2">
-                        <LinkButton
-                          to={"https://jetkvm.com/docs/getting-started/troubleshooting"}
-                          theme="light"
-                          text="Learn more"
-                          TrailingIcon={ArrowRightIcon}
-                          size="SM"
-                        />
-                      </div>
-                      <div className="flex flex-wrap items-right gap-x-2 gap-y-2">
-                        <Button
-                          size="XS"
-                          theme="light"
-                          text="Fullscreen"
-                          LeadingIcon={LuMaximize}
-                          onClick={() => requestFullscreen()}
-                        />
-                      </div>
+                    <div>
+                      <LinkButton
+                        to={"https://jetkvm.com/docs/getting-started/troubleshooting"}
+                        theme="light"
+                        text="Learn more"
+                        TrailingIcon={ArrowRightIcon}
+                        size="SM"
+                      />
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -542,7 +542,7 @@ export default function WebRTCVideo() {
                           style={{ animationDuration: "500ms" }}
                           className="animate-slideUpFade pointer-events-none absolute inset-0 flex items-center justify-center"
                         >
-                          <div className="relative h-full w-full rounded-md">
+                          <div className="relative h-full w-full rounded-md" onClick={requestPointerLock}>
                             <LoadingVideoOverlay show={isVideoLoading} />
                             <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} />
                             <NoAutoplayPermissionsOverlay

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -405,7 +405,7 @@ export default function WebRTCVideo() {
       });
 
       if (isRelativeMouseMode) {
-        videoElmRefValue.addEventListener("click",
+        containerRef.current?.addEventListener("click",
           () => {
             if (isPointerLockPossible && !isPointerLockActive && !document.pointerLockElement) {
               requestPointerLock();
@@ -542,7 +542,7 @@ export default function WebRTCVideo() {
                           style={{ animationDuration: "500ms" }}
                           className="animate-slideUpFade pointer-events-none absolute inset-0 flex items-center justify-center"
                         >
-                          <div className="relative h-full w-full rounded-md" onClick={requestPointerLock}>
+                          <div className="relative h-full w-full rounded-md">
                             <LoadingVideoOverlay show={isVideoLoading} />
                             <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} />
                             <NoAutoplayPermissionsOverlay

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -544,7 +544,7 @@ export default function WebRTCVideo() {
                         >
                           <div className="relative h-full w-full rounded-md" onClick={requestPointerLock}>
                             <LoadingVideoOverlay show={isVideoLoading} />
-                            <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} />
+                            <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} requestFullscreen={requestFullscreen}/>
                             <NoAutoplayPermissionsOverlay
                               show={hasNoAutoPlayPermissions}
                               onPlayClick={() => {

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -544,7 +544,7 @@ export default function WebRTCVideo() {
                         >
                           <div className="relative h-full w-full rounded-md" onClick={requestPointerLock}>
                             <LoadingVideoOverlay show={isVideoLoading} />
-                            <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} requestFullscreen={requestFullscreen}/>
+                            <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} />
                             <NoAutoplayPermissionsOverlay
                               show={hasNoAutoPlayPermissions}
                               onPlayClick={() => {


### PR DESCRIPTION
My use case for my JetKVM is to control another computer on my desktop that has its own display, so I have no need for the video display. However, I do want to be able to enable Pointer Lock and Keyboard Lock.

This PR adds two UI features to provide this:

* It allows enabling Pointer Lock by clicking anywhere where the video display would be
* It adds a Fullscreen button in the HDMI signal message. There is not currently a way with any browser to enable Keyboard Lock without entering fullscreen.

I accept any input on the UI, as I'm not a frontend dev. I had also implemented Pointer Lock and Fullscreen buttons in the Actionbar, but it's already a bit crowded. It might also be worth hiding this functionality behind an options toggle, but it mirrors similar behavior on PiKVM.