### PR TITLE
Cleaning up action versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,13 +17,13 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v5
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
           cache-dependency-path: "**/package-lock.json"
       - name: Set up Golang
-        uses: actions/setup-go@v5.5.0
+        uses: actions/setup-go@v5
         with:
           go-version: "1.24.4"
       - name: Build frontend

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,16 +22,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@ff7abcd0c3c05ccf6adc123a8cd1fd4fb30fb493 # v4.2.2
+        uses: actions/checkout@v5
       - name: Install Go
-        uses: actions/setup-go@fa96338abe5531f6e34c5cc0bbe28c1a533d5505 # v4.2.1
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.24.4
+          go-version: oldstable
       - name: Create empty resource directory
         run: |
           mkdir -p static && touch static/.gitkeep
       - name: Lint
-        uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0
+        uses: golangci/golangci-lint-action@v8
         with:
           args: --verbose
-          version: v2.0.2
+          version: v2.1

--- a/.github/workflows/ui-lint.yml
+++ b/.github/workflows/ui-lint.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"


### PR DESCRIPTION
Update setup-node to v5
Update setup-go to v5 (removed restriction to specific minor/patch) Updated the golangci-lint action to use @v5 of both checkout and setup-go. Now internally uses:
  - go version oldstable (e.g. 1.24.7 as of 2025-09-24)
  - golangci-lint version v2.1