### PR TITLE
chore: remove msgpack from gin dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ VERSION := 0.4.8
 PROMETHEUS_TAG := github.com/prometheus/common/version
 KVM_PKG_NAME := github.com/jetkvm/kvm
 
-GO_BUILD_ARGS := -tags netgo -tags timetzdata
+GO_BUILD_ARGS := -tags netgo,timetzdata,nomsgpack
 GO_RELEASE_BUILD_ARGS := -trimpath $(GO_BUILD_ARGS)
 GO_LDFLAGS := \
   -s -w \


### PR DESCRIPTION
It should be able to reduce the binary size by ~7 MB.

https://github.com/jetkvm/kvm/actions/runs/18001570015
https://github.com/ym/jetkvm-kvm/actions/runs/18023015779
 
```
➜  Downloads du -sh jetkvm-app\ \(13\)/bin/jetkvm_app
 37M	jetkvm-app (13)/bin/jetkvm_app
➜  Downloads du -sh jetkvm-app\ \(14\)/bin/jetkvm_app
 30M	jetkvm-app (14)/bin/jetkvm_app
```