### PR TITLE
bug: fix null pointer in wakeDisplay

### DIFF
--- a/display.go
+++ b/display.go
@@ -305,11 +305,11 @@ func wakeDisplay(force bool, reason string) {
 		displayLogger.Warn().Err(err).Msg("failed to wake display")
 	}
 
-	if config.DisplayDimAfterSec != 0 {
+	if config.DisplayDimAfterSec != 0 && dimTicker != nil {
 		dimTicker.Reset(time.Duration(config.DisplayDimAfterSec) * time.Second)
 	}
 
-	if config.DisplayOffAfterSec != 0 {
+	if config.DisplayOffAfterSec != 0 && offTicker != nil {
 		offTicker.Reset(time.Duration(config.DisplayOffAfterSec) * time.Second)
 	}
 	backlightState = 0

--- a/ui/src/routes/devices.$id.settings.hardware.tsx
+++ b/ui/src/routes/devices.$id.settings.hardware.tsx
@@ -46,10 +46,10 @@ export default function SettingsHardwareRoute() {
     }
 
     setBacklightSettings(settings);
-    handleBacklightSettingsSave();
+    handleBacklightSettingsSave(settings);
   };
 
-  const handleBacklightSettingsSave = () => {
+  const handleBacklightSettingsSave = (backlightSettings: BacklightSettings) => {
     send("setBacklightSettings", { params: backlightSettings }, (resp: JsonRpcResponse) => {
       if ("error" in resp) {
         notifications.error(
@@ -81,7 +81,7 @@ export default function SettingsHardwareRoute() {
     const duration = enabled ? 90 : -1;
     send("setVideoSleepMode", { duration }, (resp: JsonRpcResponse) => {
       if ("error" in resp) {
-        notifications.error(m.hardware_power_saving_failed_error({ error: resp.error.data ||m.unknown_error() }));
+        notifications.error(m.hardware_power_saving_failed_error({ error: resp.error.data || m.unknown_error() }));
         setPowerSavingEnabled(!enabled); // Attempt to revert on error
         return;
       }


### PR DESCRIPTION
I managed to trigger a null pointer in the `display.go` - this pr prevents this from happening again.

```2025-10-27T12:26:08Z INF jetkvm display set brightness brightness=64 reason=active_sessions_changed
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x4 pc=0x141414]

goroutine 3678 [running]:
time.(*Ticker).Reset(0x0, 0x1a3185c5000)
	time/tick.go:69 +0x4c
github.com/jetkvm/kvm.wakeDisplay(0x0, {0xd3cb94, 0x17})
	github.com/jetkvm/kvm/display.go:313 +0x160
github.com/jetkvm/kvm.requestDisplayUpdate.func1()
	github.com/jetkvm/kvm/display.go:188 +0x38
created by github.com/jetkvm/kvm.requestDisplayUpdate in goroutine 3674
	github.com/jetkvm/kvm/display.go:186 +0xb8
```

When figuring out the issues, I also noticed that the FE is passing stale `useState` values to the backend. This is now fixed!	