### PR TITLE
fix: Fix video quality 

### DIFF
--- a/config.go
+++ b/config.go
@@ -177,7 +177,8 @@ func getDefaultConfig() Config {
 			_ = confparser.SetDefaultsAndValidate(c)
 			return c
 		}(),
-		DefaultLogLevel: "INFO",
+		DefaultLogLevel:    "INFO",
+		VideoQualityFactor: 1.0,
 	}
 }
 

--- a/internal/native/cgo/ctrl.c
+++ b/internal/native/cgo/ctrl.c
@@ -306,7 +306,7 @@ int jetkvm_ui_add_flag(const char *obj_name, const char *flag_name) {
     if (obj == NULL) {
         return -1;
     }
-    
+
     lv_obj_flag_t flag_val = str_to_lv_obj_flag(flag_name);
     if (flag_val == 0)
     {
@@ -368,7 +368,7 @@ void jetkvm_video_stop() {
 }
 
 int jetkvm_video_set_quality_factor(float quality_factor) {
-    if (quality_factor < 0 || quality_factor > 1) {
+    if (quality_factor <= 0 || quality_factor > 1) {
         return -1;
     }
     video_set_quality_factor(quality_factor);

--- a/internal/native/cgo/video.c
+++ b/internal/native/cgo/video.c
@@ -235,7 +235,7 @@ int video_init(float factor)
 {
     detect_sleep_mode();
 
-    if (factor < 0 || factor > 1) {
+    if (factor <= 0 || factor > 1) {
         factor = 1.0f;
     }
     quality_factor = factor;

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -69,7 +69,7 @@ func NewNative(opts NativeOptions) *Native {
 	sleepModeSupported := isSleepModeSupported()
 
 	defaultQualityFactor := opts.DefaultQualityFactor
-	if defaultQualityFactor < 0 || defaultQualityFactor > 1 {
+	if defaultQualityFactor <= 0 || defaultQualityFactor > 1 {
 		defaultQualityFactor = 1.0
 	}
 

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -177,10 +177,8 @@ func rpcReboot(force bool) error {
 	return hwReboot(force, nil, 0)
 }
 
-var streamFactor = 1.0
-
 func rpcGetStreamQualityFactor() (float64, error) {
-	return streamFactor, nil
+	return config.VideoQualityFactor, nil
 }
 
 func rpcSetStreamQualityFactor(factor float64) error {
@@ -190,7 +188,10 @@ func rpcSetStreamQualityFactor(factor float64) error {
 		return err
 	}
 
-	streamFactor = factor
+	config.VideoQualityFactor = factor
+	if err := SaveConfig(); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
 	return nil
 }
 


### PR DESCRIPTION
We got reports that the video quality decreased in the last release.

The issue was no default stream quality factor, and therefore it was falling back on 0, which effectively puts the default stream in "Low" mode.

Additionally, when setting and getting the video quality stream, we didn't store the value in the config but updated a local quality variable that was used in the old implementation.