### PR TITLE
Add delay before forced page-reload

### DIFF
--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -313,6 +313,8 @@ export default function SettingsAdvancedRoute() {
                 text={m.advanced_reset_config_button()}
                 onClick={() => {
                   handleResetConfig();
+                  // Add 2s delay between resetting the configuration and calling reload() to prevent reload from interrupting the RPC call to reset things.
+                  await sleep(2000);
                   window.location.reload();
                 }}
               />

--- a/ui/src/routes/devices.$id.settings.general.reboot.tsx
+++ b/ui/src/routes/devices.$id.settings.general.reboot.tsx
@@ -11,6 +11,8 @@ export default function SettingsGeneralRebootRoute() {
   
   const onClose = useCallback(() => {
     navigate(".."); // back to the devices.$id.settings page
+    // Add 1s delay between navigation and calling reload() to prevent reload from interrupting the navigation.
+    await sleep(1000);
     window.location.reload(); // force a full reload to ensure the current device/cloud UI version is loaded
   }, [navigate]);
 

--- a/ui/src/routes/devices.$id.settings.general.update.tsx
+++ b/ui/src/routes/devices.$id.settings.general.update.tsx
@@ -23,6 +23,8 @@ export default function SettingsGeneralUpdateRoute() {
 
   const onClose = useCallback(() => {
     navigate(".."); // back to the devices.$id.settings page
+    // Add 1s delay between navigation and calling reload() to prevent reload from interrupting the navigation.
+    await sleep(1000);
     window.location.reload(); // force a full reload to ensure the current device/cloud UI version is loaded
   }, [navigate]);
 


### PR DESCRIPTION
This ensures the navigation or RPC call has time to finish before reloading.
