### PR TITLE
Add iputils-ping to install dependencies script

### DIFF
--- a/.devcontainer/install-deps.sh
+++ b/.devcontainer/install-deps.sh
@@ -14,6 +14,7 @@ set -ex
 export DEBIAN_FRONTEND=noninteractive
 sudo apt-get update && \
 sudo apt-get install -y --no-install-recommends \
+  iputils-ping \
   build-essential \
   device-tree-compiler \
   gperf g++-multilib gcc-multilib \


### PR DESCRIPTION
The new dev_deploy.sh uses ping to check if we can see the JetKVM, but mcr.microsoft.com/devcontainers/go:1.25-trixie does not have ping installed.