### PR TITLE
chore/Clean up logger messaging

### DIFF
--- a/web.go
+++ b/web.go
@@ -814,7 +814,7 @@ func handleSendWOLMagicPacket(c *gin.Context) {
 	inputMacAddr := c.Param("mac-addr")
 	macAddr, err := net.ParseMAC(inputMacAddr)
 	if err != nil {
-		logger.Warn().Err(err).Str("sendWol", inputMacAddr).Msg("Invalid mac address provided")
+		logger.Warn().Err(err).Str("inputMacAddr", inputMacAddr).Msg("Invalid MAC address provided")
 		c.String(http.StatusBadRequest, "Invalid mac address provided")
 		return
 	}
@@ -822,7 +822,7 @@ func handleSendWOLMagicPacket(c *gin.Context) {
 	macAddrString := macAddr.String()
 	err = rpcSendWOLMagicPacket(macAddrString)
 	if err != nil {
-		logger.Warn().Err(err).Str("sendWOL", macAddrString).Msg("Failed to send WOL magic packet")
+		logger.Warn().Err(err).Str("macAddrString", macAddrString).Msg("Failed to send WOL magic packet")
 		c.String(http.StatusInternalServerError, "Failed to send WOL to %s: %v", macAddrString, err)
 		return
 	}


### PR DESCRIPTION
Use the correct variable names for the `.Str()` and capslock the the MAC

Just a tiny cleanup on merged #945 
