### PR TITLE
  Fix paste modal character detection for Spanish and accented characters

### DIFF
--- a/ui/src/components/popovers/PasteModal.tsx
+++ b/ui/src/components/popovers/PasteModal.tsx
@@ -66,7 +66,8 @@ export default function PasteModal() {
       const macroSteps: MacroStep[] = [];
 
       for (const char of text) {
-        const keyprops = selectedKeyboard.chars[char];
+        const normalizedChar = char.normalize('NFC');
+        const keyprops = selectedKeyboard.chars[normalizedChar];
         if (!keyprops) continue;
 
         const { key, shift, altRight, deadKey, accentKey } = keyprops;
@@ -164,7 +165,7 @@ export default function PasteModal() {
                           ...new Set(
                             // @ts-expect-error TS doesn't recognize Intl.Segmenter in some environments
                             [...new Intl.Segmenter().segment(value)]
-                              .map(x => x.segment)
+                              .map(x => x.segment.normalize('NFC'))
                               .filter(char => !selectedKeyboard.chars[char]),
                           ),
                         ];


### PR DESCRIPTION
Fixes #957 - Paste modal now correctly detects Spanish characters requiring AltRight modifier (@, |, #) and accented characters (ñ) by normalizing all input text to NFC form before keyboard layout lookup.

Root cause: macOS and other sources may provide text in NFD (decomposed) form while keyboard layouts store characters in NFC (composed) form. JavaScript object property lookup requires exact byte match, causing lookups to fail despite characters being defined.

Solution: Apply .normalize('NFC') to all user input characters before validation and paste execution.

Testing: Browser-based validation testing completed with Spanish keyboard layout (es-ES) using text from multiple sources (TextEdit, Safari, Notes) on macOS. Hardware testing requires JetKVM device.