### PR TITLE
fix: mobile viewport cropping on video element

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -524,7 +524,7 @@ export default function WebRTCVideo() {
                         controlsList="nofullscreen"
                         style={videoStyle}
                         className={cx(
-                          "max-h-full min-h-[384px] max-w-full min-w-[512px] bg-black/50 object-contain transition-all duration-1000",
+                          "max-h-full max-w-full sm:min-h-[384px] sm:min-w-[512px] bg-black/50 object-contain transition-all duration-1000",
                           {
                             "cursor-none": settings.isCursorHidden,
                             "opacity-0":


### PR DESCRIPTION
Remove fixed minimum dimensions (min-w-512px, min-h-384px) on mobile viewports and apply them only on desktop (≥640px) using Tailwind sm: breakpoint.

This fixes issue where video was cropped on mobile devices preventing access to UI elements like the Windows 11 shutdown button.

Fixes #565 