### PR TITLE
fix: enhance reboot state management with health check and redirect o…

### DIFF
--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -697,7 +697,14 @@ export default function KvmIdRoute() {
     if (resp.method === "willReboot") {
       const postRebootAction = resp.params as unknown as PostRebootAction;
       console.debug("Setting reboot state", postRebootAction);
-      setRebootState({ isRebooting: true, postRebootAction });
+
+      setRebootState({
+        isRebooting: true,
+        postRebootAction: {
+          healthCheck: postRebootAction?.healthCheck || `${window.location.origin}/device/status`,
+          redirectTo: postRebootAction?.redirectTo || window.location.href,
+        }
+      });
       navigateTo("/");
     }
 


### PR DESCRIPTION
When the post-reboot action is null, the willReboot won't work. We need sane defaults. This can be tested easily with e.g. network hostname change, which doesn't return any opst reboot action