### PR TITLE
Fix AltGr handling for Windows clients

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useResizeObserver } from "usehooks-ts";
 
 import { cx } from "@/cva.config";
+import { isWindows } from "@/utils";
 import useKeyboard from "@hooks/useKeyboard";
 import useMouse from "@hooks/useMouse";
 import {
@@ -73,6 +74,12 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
     },
     [setVideoClientSize, setVideoSize]
   );
+
+  // AltGr Fix for Windows Clients
+  const altGrSyntheticThresholdMs = 3;
+  const isWindowsClient = useMemo(() => isWindows(), []);
+  const lastKeyDownRef = useRef<{ hidKey: number; time: number } | null>(null);
+  const altGrLoopRef = useRef(false);
 
   useResizeObserver({
     ref: videoElm as React.RefObject<HTMLElement>,
@@ -250,13 +257,41 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
   const keyDownHandler = useCallback(
     (e: KeyboardEvent) => {
       e.preventDefault();
-      if (e.repeat) return;
       const code = getAdjustedKeyCode(e);
       const hidKey = keys[code];
 
       if (hidKey === undefined) {
         console.warn(`Key down not mapped: ${code}`);
         return;
+      }
+
+      // Detect Windows synthetic AltGr (CtrlLeft then AltRight within ~3ms) and cancel the synthetic Ctrl
+      if (isWindowsClient) {
+        // Buffer ControlLeft briefly; if no AltRight follows within the threshold, treat it as a real ControlLeft press.
+        if (hidKey === keys.ControlLeft) {
+          const controlLeftDownTime = e.timeStamp;
+          lastKeyDownRef.current = { hidKey, time: controlLeftDownTime };
+          setTimeout(() => {
+            if (
+              lastKeyDownRef.current?.hidKey === keys.ControlLeft &&
+              lastKeyDownRef.current.time === controlLeftDownTime
+            ) {
+              lastKeyDownRef.current = null;
+              handleKeyPress(keys.ControlLeft, true);
+            }
+          }, altGrSyntheticThresholdMs);
+          return;
+        }
+
+        // If AltRight arrives shortly after ControlLeft, treat the pair as AltGr and cancel the pending ControlLeft.
+        if (
+          hidKey === keys.AltRight &&
+          lastKeyDownRef.current?.hidKey === keys.ControlLeft &&
+          e.timeStamp - lastKeyDownRef.current.time <= altGrSyntheticThresholdMs
+        ) {
+          altGrLoopRef.current = true;
+          lastKeyDownRef.current = null;
+        }
       }
 
       // When pressing the meta key + another key, the key will never trigger a keyup
@@ -282,7 +317,7 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
         }, 100);
       }
     },
-    [handleKeyPress, isKeyboardLockActive],
+    [handleKeyPress, isKeyboardLockActive, isWindowsClient],
   );
 
   const keyUpHandler = useCallback(
@@ -296,10 +331,27 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
         return;
       }
 
+      // On Windows, handle ControlLeft specially to preserve FIFO semantics with AltGr buffering.
+      if (isWindowsClient && hidKey === keys.ControlLeft) {
+
+        // Synthetic AltGr ControlLeft: never sent a down, swallow the release as well.
+        if (altGrLoopRef.current) {
+          altGrLoopRef.current = false;
+          return;
+        }
+
+        // Very fast real Ctrl tap: flush the pending down before the up.
+        if (lastKeyDownRef.current?.hidKey === keys.ControlLeft) {
+          handleKeyPress(keys.ControlLeft, true);
+        }
+
+        lastKeyDownRef.current = null;
+      }
+
       console.debug(`Key up: ${hidKey}`);
       handleKeyPress(hidKey, false);
     },
-    [handleKeyPress],
+    [handleKeyPress, isWindowsClient],
   );
 
   const videoKeyUpHandler = useCallback((e: KeyboardEvent) => {


### PR DESCRIPTION
## Issue

This PR fixes AltGr keyboard handling for **Windows clients**.

On Windows with international layouts (e.g. French), AltGr-based characters such as `@`, `€`, `|` were not working correctly. JetKVM's UI saw both `ControlLeft` and `AltRight` instead of a proper AltGr (right Alt) modifier, and forwarded both to the remote system, so the expected characters were never produced..

## Root Cause

Windows emulates AltGr by injecting a synthetic `ControlLeft` before `AltRight`. Browsers therefore see a sequence like:

```text
↓ ControlLeft
↓ AltRight
… later …
↑ ControlLeft
↑ AltRight
```
This happens for each AltGr press (and repeats when the key is held down). The remote side, however, typically expects only AltRight to be held for AltGr.


## Fix

This change adds a small, Windows-only, adjustment in the keyboard handling:

- On Windows, the component now tracks the **last keydown** event (`code` and timestamp).
- When a new `AltRight` keydown is received, it checks whether the **previous** keydown was `ControlLeft` and whether it happened within a small time window (`altGrSyntheticThresholdMs = 3 ms`).
- If both conditions are true, this is considered the **synthetic AltGr sequence** generated by Windows (CtrlLeft immediately followed by AltRight). In that case, the code sends a synthetic `ControlLeft` keyup to cancel the extra Ctrl modifier, so the effective state on the guest is “AltRight (AltGr) only”.
- In all other cases (including normal `Ctrl + AltRight` combinations with human timing), key events are forwarded unchanged.

The 3 ms threshold was chosen based on measurements made on 2 Windows PCs, where the synthetic `ControlLeft → AltRight` gap was consistently observed between 0 and ~2.1 ms. 3 ms gives a small safety margin to catch the Windows-generated pattern, while still being far below any realistic human keypress interval.


## Limitations / Trade-offs

The early guard to avoid issues when holding modifier keys ```if (e.repeat) return;``` is left unmodified.
Because of that, some less common combinations where AltRight is pressed first and a Control key is pressed while AltGr is held may not behave perfectly on Windows. In practice, these are rare compared to:
- The primary AltGr use case (typing symbols), and
- More typical Ctrl+Alt combinations (e.g. ControlLeft + AltLeft).

The goal here is to fix the main AltGr problem with minimal added complexity. If there’s real-world demand for those more exotic combinations, the logic around e.repeat can be revisited in a follow-up change.

