### PR TITLE
fix(video-stream): switch to SOCK_STREAM between main and video

### DIFF
--- a/internal/native/proxy.go
+++ b/internal/native/proxy.go
@@ -3,8 +3,10 @@ package native
 import (
 	"context"
 	"crypto/rand"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net"
 	"os"
 	"os/exec"
@@ -166,7 +168,7 @@ func (p *NativeProxy) startVideoStreamListener() error {
 	}
 
 	logger := p.logger.With().Str("socketPath", p.videoStreamUnixSocket).Logger()
-	listener, err := net.Listen("unixpacket", p.videoStreamUnixSocket)
+	listener, err := net.Listen("unix", p.videoStreamUnixSocket)
 	if err != nil {
 		logger.Warn().Err(err).Msg("failed to start video stream listener")
 		return fmt.Errorf("failed to start video stream listener: %w", err)
@@ -254,18 +256,37 @@ func (p *NativeProxy) handleVideoFrame(conn net.Conn) {
 	defer conn.Close()
 
 	inboundPacket := make([]byte, maxFrameSize)
+	frameSizeBuffer := make([]byte, 4)
 	lastFrame := time.Now()
 
 	for {
-		n, err := conn.Read(inboundPacket)
+		// Read 4-byte frame length prefix
+		_, err := io.ReadFull(conn, frameSizeBuffer)
+		if err != nil {
+			if err != io.EOF {
+				p.logger.Warn().Err(err).Msg("failed to read frame size from socket")
+			}
+			break
+		}
+
+		frameSize := binary.LittleEndian.Uint32(frameSizeBuffer)
+		if frameSize > maxFrameSize {
+			p.logger.Error().Uint32("frameSize", frameSize).Uint32("maxFrameSize", maxFrameSize).
+				Msg("received frame size exceeds maximum, rejecting")
+			break
+		}
+
+		// Read the actual frame data
+		_, err = io.ReadFull(conn, inboundPacket[:frameSize])
 		if err != nil {
 			p.logger.Warn().Err(err).Msg("failed to read video frame from socket")
 			break
 		}
+
 		now := time.Now()
 		sinceLastFrame := now.Sub(lastFrame)
 		lastFrame = now
-		p.options.OnVideoFrameReceived(inboundPacket[:n], sinceLastFrame)
+		p.options.OnVideoFrameReceived(inboundPacket[:frameSize], sinceLastFrame)
 	}
 }
 

--- a/internal/native/proxy.go
+++ b/internal/native/proxy.go
@@ -256,12 +256,12 @@ func (p *NativeProxy) handleVideoFrame(conn net.Conn) {
 	defer conn.Close()
 
 	inboundPacket := make([]byte, maxFrameSize)
-	frameSizeBuffer := make([]byte, 4)
+	var frameSizeBuffer [4]byte
 	lastFrame := time.Now()
 
 	for {
 		// Read 4-byte frame length prefix
-		_, err := io.ReadFull(conn, frameSizeBuffer)
+		_, err := io.ReadFull(conn, frameSizeBuffer[:])
 		if err != nil {
 			if err != io.EOF {
 				p.logger.Warn().Err(err).Msg("failed to read frame size from socket")
@@ -269,10 +269,10 @@ func (p *NativeProxy) handleVideoFrame(conn net.Conn) {
 			break
 		}
 
-		frameSize := binary.LittleEndian.Uint32(frameSizeBuffer)
-		if frameSize > maxFrameSize {
+		frameSize := binary.LittleEndian.Uint32(frameSizeBuffer[:])
+		if frameSize == 0 || frameSize > maxFrameSize {
 			p.logger.Error().Uint32("frameSize", frameSize).Uint32("maxFrameSize", maxFrameSize).
-				Msg("received frame size exceeds maximum, rejecting")
+				Msg("received invalid frame size")
 			break
 		}
 

--- a/internal/native/server.go
+++ b/internal/native/server.go
@@ -2,6 +2,7 @@ package native
 
 import (
 	"context"
+	"encoding/binary"
 	"fmt"
 	"net"
 	"os"
@@ -88,7 +89,7 @@ func RunNativeProcess(binaryName string) {
 	}
 
 	// Connect to video stream socket
-	conn, err := net.Dial("unixpacket", proxyOptions.VideoStreamUnixSocket)
+	conn, err := net.Dial("unix", proxyOptions.VideoStreamUnixSocket)
 	if err != nil {
 		logger.Fatal().Err(err).Msg("failed to connect to video stream socket")
 	}
@@ -96,8 +97,14 @@ func RunNativeProcess(binaryName string) {
 
 	nativeOptions := proxyOptions.toNativeOptions()
 	nativeOptions.OnVideoFrameReceived = func(frame []byte, duration time.Duration) {
-		_, err := conn.Write(frame)
-		if err != nil {
+		// Write 4-byte frame length prefix, then frame data
+		frameSizeBuffer := make([]byte, 4)
+		binary.LittleEndian.PutUint32(frameSizeBuffer, uint32(len(frame)))
+		
+		if _, err := conn.Write(frameSizeBuffer); err != nil {
+			logger.Fatal().Err(err).Msg("failed to write frame size to video stream socket")
+		}
+		if _, err := conn.Write(frame); err != nil {
 			logger.Fatal().Err(err).Msg("failed to write frame to video stream socket")
 		}
 	}

--- a/internal/native/server.go
+++ b/internal/native/server.go
@@ -100,7 +100,7 @@ func RunNativeProcess(binaryName string) {
 		// Write 4-byte frame length prefix, then frame data
 		frameSizeBuffer := make([]byte, 4)
 		binary.LittleEndian.PutUint32(frameSizeBuffer, uint32(len(frame)))
-		
+
 		if _, err := conn.Write(frameSizeBuffer); err != nil {
 			logger.Fatal().Err(err).Msg("failed to write frame size to video stream socket")
 		}

--- a/internal/native/server.go
+++ b/internal/native/server.go
@@ -98,10 +98,10 @@ func RunNativeProcess(binaryName string) {
 	nativeOptions := proxyOptions.toNativeOptions()
 	nativeOptions.OnVideoFrameReceived = func(frame []byte, duration time.Duration) {
 		// Write 4-byte frame length prefix, then frame data
-		frameSizeBuffer := make([]byte, 4)
-		binary.LittleEndian.PutUint32(frameSizeBuffer, uint32(len(frame)))
+		var frameSizeBuffer [4]byte
+		binary.LittleEndian.PutUint32(frameSizeBuffer[:], uint32(len(frame)))
 
-		if _, err := conn.Write(frameSizeBuffer); err != nil {
+		if _, err := conn.Write(frameSizeBuffer[:]); err != nil {
 			logger.Fatal().Err(err).Msg("failed to write frame size to video stream socket")
 		}
 		if _, err := conn.Write(frame); err != nil {


### PR DESCRIPTION
Fixes: https://github.com/jetkvm/kvm/issues/1017

The device in the issue crashes multiple times, with the error `@jetkvm/native/video-stream/78c05999: write: message too long`. This restarts the video process, and eventually triggers Failsafe mode. Before each crash this happens:

<details>
  <summary>Detailed Logs</summary>
  
 ```
native failed to write frame to video stream socketmerror= 0m 31m"write unixpacket @->@jetkvm/native/video-stream/78c05999: write: message too long" 0mmpid= 0m354
native event stream errormerror= 0m 31m"rpc error: code = Unavailable desc = error reading from server: EOF" 0mmpid= 0m354  36msocketPath= 0m@jetkvm/native/grpc/17e2a6f4  36mstream= 0m{"ClientStream":{}}
native failed to read video frame from socketmerror= 0m 31mEOF 0mmpid= 0m354
native native process exited, restarting ...merror= 0m 31m"exit status 1" 0mmpid= 0m354
```
</details>


The video stream uses a unixpacket socket which has a kernel-enforced size limit of ~360 KB per message. While most H.264 frames are small, I-frames (keyframes) can exceed this limit during complex scenes or stream initialization.

I was not able to reproduce the issue by simply using the JetKVM. I did however, write a small golang program that spawns a child process talking over `unixpacket` to the message size limit. The program correctly confirms message the size limit.

The fix is to switch from unixpacket (SOCK_SEQPACKET) to unix (SOCK_STREAM) with a 4-byte length prefix for framing. Stream sockets have no per-message size limit.

