### PR TITLE
fix(video): quality switching not taking effect

### DIFF
--- a/internal/native/cgo/video.c
+++ b/internal/native/cgo/video.c
@@ -392,7 +392,7 @@ bool get_streaming_stopped()
     bool stopped = streaming_stopped;
     pthread_mutex_unlock(&streaming_stopped_mutex);
     return stopped;
-} 
+}
 
 void write_buffer_to_file(const uint8_t *buffer, size_t length, const char *filename)
 {
@@ -773,16 +773,16 @@ void video_restart_streaming()
     {
         log_info("will not restart video streaming because it's stopped");
         return;
-    } 
+    }
 
-    if (streaming_status == 2) {
+    if (streaming_status == 1 || streaming_status == 2) {
         video_stop_streaming();
     }
 
     if (!wait_for_streaming_stopped()) {
         return;
     }
-    
+
     video_start_streaming();
 }
 

--- a/internal/native/cgo/video.c
+++ b/internal/native/cgo/video.c
@@ -769,6 +769,8 @@ uint8_t video_get_streaming_status() {
 void video_restart_streaming()
 {
     uint8_t streaming_status = video_get_streaming_status();
+    // 0 = stopped, 1 = running, 2 = stopping
+
     if (streaming_status == 0)
     {
         log_info("will not restart video streaming because it's stopped");


### PR DESCRIPTION
Changing the stream quality setting in the UI appeared to succeed but had no visible effect on the video. The quality factor was stored correctly, but the video encoder continued using the old bitrate.

**Root Cause**
`video_restart_streaming()` only called `video_stop_streaming()` when streaming status was 2 (stopping), but not when it was 1 (actively running). This caused the function to skip the stop call, timeout after 3 seconds waiting for a stop that never happened, and exit early without restarting the stream.

**Fix**
Call `video_stop_streaming()` for both status 1 (running) and status 2 (stopping), ensuring the stream is properly stopped before waiting and restarting with the new quality settings.