### PR TITLE
Improve E2E tests

### DIFF
--- a/ui/e2e/edid-roundtrip.spec.ts
+++ b/ui/e2e/edid-roundtrip.spec.ts
@@ -37,6 +37,34 @@ test.describe("EDID Round-Trip Tests", () => {
   // Testing 2 random EDIDs, so 2 minutes should be plenty
   test.setTimeout(120000); // 2 minutes
 
+  // Restore EDID to default after tests complete (for subsequent test runs)
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      await page.goto("/settings/video");
+      await page.waitForLoadState("networkidle");
+      const edidDropdown = page.locator("select").filter({
+        has: page.locator('option[value="custom"]'),
+      });
+      if (await edidDropdown.isVisible({ timeout: 5000 })) {
+        // Get the first non-custom option (the default)
+        const firstOption = await edidDropdown.evaluate((el: HTMLSelectElement) => {
+          const opts = Array.from(el.options);
+          const nonCustom = opts.find(o => !o.value.toLowerCase().includes("custom"));
+          return nonCustom?.value;
+        });
+        if (firstOption) {
+          await edidDropdown.selectOption(firstOption);
+          await page.waitForTimeout(3000); // Wait for EDID change
+        }
+      } else {
+        console.warn("[EDID cleanup] EDID dropdown not visible, skipping restoration");
+      }
+    } finally {
+      await page.close();
+    }
+  });
+
   test("video streams correctly after changing EDID presets", async ({ page }) => {
     // Navigate to settings/video to discover EDID options
     await page.goto("/settings/video");
@@ -44,9 +72,10 @@ test.describe("EDID Round-Trip Tests", () => {
     // Wait for the page to load and EDID dropdown to be ready
     await page.waitForLoadState("networkidle");
 
-    // Find the EDID dropdown - it's inside a Fieldset with the EDID settings
-    // The dropdown is a select element within the EDID SettingsItem
-    const edidSelect = page.locator("select").last();
+    // Find the EDID dropdown by looking for a select with "custom" option
+    const edidSelect = page.locator("select").filter({
+      has: page.locator('option[value="custom"]'),
+    });
     await expect(edidSelect).toBeVisible({ timeout: 10000 });
 
     // Wait for the dropdown to be enabled (not in loading state)
@@ -84,7 +113,9 @@ test.describe("EDID Round-Trip Tests", () => {
       }
 
       // Re-locate the dropdown (page may have reloaded)
-      const dropdown = page.locator("select").last();
+      const dropdown = page.locator("select").filter({
+        has: page.locator('option[value="custom"]'),
+      });
       await expect(dropdown).toBeVisible({ timeout: 10000 });
       await expect(dropdown).toBeEnabled({ timeout: 10000 });
 
@@ -125,13 +156,6 @@ test.describe("EDID Round-Trip Tests", () => {
       await page.waitForTimeout(FINGERPRINT_INTERVAL);
       const fpB = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
       expect(fpB, "Failed to capture fingerprint B").not.toBeNull();
-
-      // Verify the stream is updating (not frozen/black)
-      const distance = fingerprintDistance(fpA!, fpB!);
-      expect(
-        distance,
-        `Video stream should be updating for EDID "${option.label}" (distance=${distance}, expected >= 0)`,
-      ).toBeGreaterThanOrEqual(0);
 
       // Verify we're not getting a black/blank screen
       const uniqueValues = new Set(fpA!);

--- a/ui/e2e/edid-roundtrip.spec.ts
+++ b/ui/e2e/edid-roundtrip.spec.ts
@@ -1,0 +1,147 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  waitForWebRTCReady,
+  waitForVideoStream,
+  wakeDisplay,
+  getVideoStreamDimensions,
+  captureVideoRegionFingerprint,
+  fingerprintDistance,
+} from "./helpers";
+
+// Minimum video dimensions to consider valid (sanity check)
+const MIN_VIDEO_DIMENSION = 100;
+
+// Region size for video capture (pixels around center)
+const CAPTURE_REGION_SIZE = 80;
+
+// Time to wait for EDID setting callback to complete (ms)
+const EDID_CALLBACK_TIMEOUT = 15000;
+
+// Time to wait for video signal to stabilize after EDID change (ms)
+const SIGNAL_STABILIZATION_TIME = 5000;
+
+// Number of random EDID options to test (to keep test time reasonable)
+const NUM_EDIDS_TO_TEST = 2;
+
+// Time between fingerprint captures to verify stream is updating (ms)
+const FINGERPRINT_INTERVAL = 500;
+
+interface EdidOption {
+  value: string;
+  label: string;
+}
+
+test.describe("EDID Round-Trip Tests", () => {
+  // Each EDID takes ~20-30 seconds (10s callback + 5s stabilization + WebRTC reconnect + verification)
+  // Testing 2 random EDIDs, so 2 minutes should be plenty
+  test.setTimeout(120000); // 2 minutes
+
+  test("video streams correctly after changing EDID presets", async ({ page }) => {
+    // Navigate to settings/video to discover EDID options
+    await page.goto("/settings/video");
+
+    // Wait for the page to load and EDID dropdown to be ready
+    await page.waitForLoadState("networkidle");
+
+    // Find the EDID dropdown - it's inside a Fieldset with the EDID settings
+    // The dropdown is a select element within the EDID SettingsItem
+    const edidSelect = page.locator("select").last();
+    await expect(edidSelect).toBeVisible({ timeout: 10000 });
+
+    // Wait for the dropdown to be enabled (not in loading state)
+    await expect(edidSelect).toBeEnabled({ timeout: 10000 });
+
+    // Extract all options from the dropdown
+    const allOptions = await edidSelect.evaluate((el: HTMLSelectElement) => {
+      return Array.from(el.options).map(o => ({
+        value: o.value,
+        label: o.text,
+      }));
+    });
+
+    // Filter out any options containing "custom" (case-insensitive)
+    const edidOptions: EdidOption[] = allOptions.filter(
+      o =>
+        !o.value.toLowerCase().includes("custom") &&
+        !o.label.toLowerCase().includes("custom"),
+    );
+    expect(edidOptions.length, "Should have at least one non-custom EDID option").toBeGreaterThan(0);
+
+    // Randomly select NUM_EDIDS_TO_TEST options to test (or all if fewer available)
+    const shuffled = [...edidOptions].sort(() => Math.random() - 0.5);
+    const selectedOptions = shuffled.slice(0, Math.min(NUM_EDIDS_TO_TEST, edidOptions.length));
+    console.log(`Testing ${selectedOptions.length} EDIDs: ${selectedOptions.map(o => o.label).join(", ")}`);
+
+    // Cycle through selected EDID options
+    for (let i = 0; i < selectedOptions.length; i++) {
+      const option = selectedOptions[i];
+
+      // Navigate to settings/video (may already be there, but ensures clean state)
+      if (i > 0) {
+        await page.goto("/settings/video");
+        await page.waitForLoadState("networkidle");
+      }
+
+      // Re-locate the dropdown (page may have reloaded)
+      const dropdown = page.locator("select").last();
+      await expect(dropdown).toBeVisible({ timeout: 10000 });
+      await expect(dropdown).toBeEnabled({ timeout: 10000 });
+
+      // Select the EDID option and wait for callback to complete
+      await dropdown.selectOption(option.value);
+      await page.waitForTimeout(500); // Brief wait for loading state to start
+      await expect(dropdown).toBeEnabled({ timeout: EDID_CALLBACK_TIMEOUT });
+
+      // Wait for video signal to stabilize
+      await page.waitForTimeout(SIGNAL_STABILIZATION_TIME);
+
+      // Navigate back to the main page to access video
+      await page.goto("/");
+
+      // Wait for WebRTC connection and video stream
+      await waitForWebRTCReady(page, 45000);
+      await wakeDisplay(page);
+      await waitForVideoStream(page, 45000);
+
+      // Get current video dimensions (resolution may have changed with EDID)
+      const dimensions = await getVideoStreamDimensions(page);
+      expect(dimensions, "Video dimensions should be available").not.toBeNull();
+      const { width: videoWidth, height: videoHeight } = dimensions!;
+      expect(videoWidth, `Video width should be >= ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThanOrEqual(MIN_VIDEO_DIMENSION);
+      expect(videoHeight, `Video height should be >= ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThanOrEqual(MIN_VIDEO_DIMENSION);
+
+      // Calculate center region for fingerprint capture (based on current resolution)
+      const centerX = Math.floor(videoWidth / 2);
+      const centerY = Math.floor(videoHeight / 2);
+      const regionX = Math.max(0, centerX - CAPTURE_REGION_SIZE / 2);
+      const regionY = Math.max(0, centerY - CAPTURE_REGION_SIZE / 2);
+      const regionWidth = Math.min(CAPTURE_REGION_SIZE, videoWidth - regionX);
+      const regionHeight = Math.min(CAPTURE_REGION_SIZE, videoHeight - regionY);
+
+      // Capture two fingerprints to verify stream is updating
+      const fpA = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
+      expect(fpA, "Failed to capture fingerprint A").not.toBeNull();
+      await page.waitForTimeout(FINGERPRINT_INTERVAL);
+      const fpB = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
+      expect(fpB, "Failed to capture fingerprint B").not.toBeNull();
+
+      // Verify the stream is updating (not frozen/black)
+      const distance = fingerprintDistance(fpA!, fpB!);
+      expect(
+        distance,
+        `Video stream should be updating for EDID "${option.label}" (distance=${distance}, expected >= 0)`,
+      ).toBeGreaterThanOrEqual(0);
+
+      // Verify we're not getting a black/blank screen
+      const uniqueValues = new Set(fpA!);
+      expect(
+        uniqueValues.size,
+        `Video should not be blank/single color for EDID "${option.label}"`,
+      ).toBeGreaterThan(1);
+
+      console.log(`✓ ${option.label} (${videoWidth}x${videoHeight})`);
+    }
+  });
+});
+

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -81,7 +81,7 @@ export async function waitForVideoStream(page: Page, timeout = 30000): Promise<v
  * @param taps - Number of key taps to send (default: 3)
  * @param delayMs - Delay between taps in milliseconds (default: 200)
  */
-export async function wakeDisplay(page: Page, taps = 3, delayMs = 200): Promise<void> {
+export async function wakeDisplay(page: Page, taps = 3, delayMs = 500): Promise<void> {
   for (let i = 0; i < taps; i++) {
     await tapKey(page, HID_KEY.SPACE);
     await page.waitForTimeout(delayMs);

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -74,6 +74,21 @@ export async function waitForVideoStream(page: Page, timeout = 30000): Promise<v
 }
 
 /**
+ * Wake the display by sending keystrokes to dismiss screensaver/sleep.
+ * Sends multiple Space key taps with delays.
+ *
+ * @param page - Playwright page object
+ * @param taps - Number of key taps to send (default: 3)
+ * @param delayMs - Delay between taps in milliseconds (default: 200)
+ */
+export async function wakeDisplay(page: Page, taps = 3, delayMs = 200): Promise<void> {
+  for (let i = 0; i < taps; i++) {
+    await tapKey(page, HID_KEY.SPACE);
+    await page.waitForTimeout(delayMs);
+  }
+}
+
+/**
  * Send a keypress event via the test hooks.
  *
  * @param page - Playwright page object
@@ -148,6 +163,131 @@ export async function waitForLedState(
     .toBe(expectedValue);
 }
 
+/**
+ * Video stream dimensions interface
+ */
+export interface VideoStreamDimensions {
+  width: number;
+  height: number;
+}
+
+/**
+ * Send an absolute mouse move event via the test hooks.
+ *
+ * @param page - Playwright page object
+ * @param x - X coordinate in HID absolute range (0-32767)
+ * @param y - Y coordinate in HID absolute range (0-32767)
+ * @param buttons - Mouse button bitmask (default: 0)
+ */
+export async function sendAbsMouseMove(
+  page: Page,
+  x: number,
+  y: number,
+  buttons = 0,
+): Promise<void> {
+  await page.evaluate(
+    ({ x, y, buttons }) => {
+      const hooks = window.__kvmTestHooks;
+      if (!hooks) throw new Error("Test hooks not available");
+      hooks.sendAbsMouseMove(x, y, buttons);
+    },
+    { x, y, buttons },
+  );
+}
+
+/**
+ * Get the video stream dimensions.
+ *
+ * @param page - Playwright page object
+ * @returns The video dimensions or null if not available
+ */
+export async function getVideoStreamDimensions(
+  page: Page,
+): Promise<VideoStreamDimensions | null> {
+  return page.evaluate(() => {
+    const hooks = window.__kvmTestHooks;
+    if (!hooks) return null;
+    return hooks.getVideoStreamDimensions();
+  });
+}
+
+/**
+ * Capture a region of the video frame as a base64 PNG.
+ *
+ * @param page - Playwright page object
+ * @param x - X coordinate of the region (in video pixels)
+ * @param y - Y coordinate of the region (in video pixels)
+ * @param width - Width of the region
+ * @param height - Height of the region
+ * @returns Base64-encoded PNG string or null if capture failed
+ */
+export async function captureVideoRegion(
+  page: Page,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+): Promise<string | null> {
+  return page.evaluate(
+    ({ x, y, width, height }) => {
+      const hooks = window.__kvmTestHooks;
+      if (!hooks) return null;
+      return hooks.captureVideoRegion(x, y, width, height);
+    },
+    { x, y, width, height },
+  );
+}
+
+/**
+ * Capture a small fingerprint of a region of the video frame.
+ * This is more tolerant to small frame-to-frame noise than comparing PNGs.
+ */
+export async function captureVideoRegionFingerprint(
+  page: Page,
+  x: number,
+  y: number,
+  width: number,
+  height: number,
+  gridSize = 8,
+): Promise<number[] | null> {
+  return page.evaluate(
+    ({ x, y, width, height, gridSize }) => {
+      const hooks = window.__kvmTestHooks;
+      if (!hooks) return null;
+      return hooks.captureVideoRegionFingerprint(x, y, width, height, gridSize);
+    },
+    { x, y, width, height, gridSize },
+  );
+}
+
+export function fingerprintDistance(a: number[], b: number[]): number {
+  const n = Math.min(a.length, b.length);
+  let sum = 0;
+  for (let i = 0; i < n; i++) sum += Math.abs(a[i] - b[i]);
+  return sum;
+}
+
+/**
+ * Convert HID absolute coordinates (0-32767) to video pixel coordinates.
+ *
+ * @param hidX - X in HID absolute range
+ * @param hidY - Y in HID absolute range
+ * @param videoWidth - Video width in pixels
+ * @param videoHeight - Video height in pixels
+ * @returns Pixel coordinates
+ */
+export function hidToPixelCoords(
+  hidX: number,
+  hidY: number,
+  videoWidth: number,
+  videoHeight: number,
+): { x: number; y: number } {
+  return {
+    x: Math.round((hidX / 32767) * videoWidth),
+    y: Math.round((hidY / 32767) * videoHeight),
+  };
+}
+
 // TypeScript declarations for the test hooks on window
 declare global {
   interface Window {
@@ -155,6 +295,21 @@ declare global {
       getKeyboardLedState: () => KeyboardLedState | null;
       getKeysDownState: () => { modifier: number; keys: number[] } | null;
       sendKeypress: (key: number, press: boolean) => void;
+      sendAbsMouseMove: (x: number, y: number, buttons: number) => void;
+      captureVideoRegion: (
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+      ) => Promise<string | null>;
+      captureVideoRegionFingerprint: (
+        x: number,
+        y: number,
+        width: number,
+        height: number,
+        gridSize?: number,
+      ) => number[] | null;
+      getVideoStreamDimensions: () => VideoStreamDimensions | null;
       isWebRTCConnected: () => boolean;
       isHidRpcReady: () => boolean;
       isVideoStreamActive: () => boolean;

--- a/ui/e2e/mouse-roundtrip.spec.ts
+++ b/ui/e2e/mouse-roundtrip.spec.ts
@@ -1,0 +1,221 @@
+import fs from "fs/promises";
+
+import { test, expect } from "@playwright/test";
+
+import {
+  waitForWebRTCReady,
+  waitForVideoStream,
+  wakeDisplay,
+  sendAbsMouseMove,
+  getVideoStreamDimensions,
+  captureVideoRegion,
+  captureVideoRegionFingerprint,
+  fingerprintDistance,
+  hidToPixelCoords,
+} from "./helpers";
+
+// Minimum video dimensions to consider valid (sanity check)
+const MIN_VIDEO_DIMENSION = 100;
+
+function dataUrlToPngBuffer(dataUrl: string): Buffer {
+  const prefix = "data:image/png;base64,";
+  if (!dataUrl.startsWith(prefix)) {
+    throw new Error(`Unexpected data URL prefix: ${dataUrl.slice(0, 32)}...`);
+  }
+  return Buffer.from(dataUrl.slice(prefix.length), "base64");
+}
+
+async function persistPng(testInfo: ReturnType<typeof test.info>, filename: string, dataUrl: string) {
+  const buf = dataUrlToPngBuffer(dataUrl);
+  await fs.writeFile(testInfo.outputPath(filename), buf);
+  await testInfo.attach(filename, { body: buf, contentType: "image/png" });
+}
+
+// Region size for cursor detection (pixels around the expected cursor position)
+const CAPTURE_REGION_SIZE = 80;
+
+// HID absolute coordinate range is 0-32767
+const HID_MAX = 32767;
+const HID_CENTER = Math.floor(HID_MAX / 2); // 16383
+
+test.describe("Mouse Round-Trip Tests", () => {
+  test.beforeEach(async ({ page }) => {
+    // Navigate to the device page (on-device mode uses "/" as the device route)
+    await page.goto("/");
+
+    // Wait for WebRTC connection to be established
+    await waitForWebRTCReady(page);
+  });
+
+  test("mouse movement changes video at cursor position", async ({ page }) => {
+    // Wake display if screensaver/sleep is active
+    await wakeDisplay(page);
+
+    // Wait for video stream to be active
+    await waitForVideoStream(page);
+
+    // Get video dimensions and validate them
+    const dimensions = await getVideoStreamDimensions(page);
+    expect(dimensions, "Video stream dimensions should be available").not.toBeNull();
+    const { width: videoWidth, height: videoHeight } = dimensions!;
+    expect(videoWidth, `Video width should be at least ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThan(MIN_VIDEO_DIMENSION);
+    expect(videoHeight, `Video height should be at least ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThan(MIN_VIDEO_DIMENSION);
+    console.log(`Video dimensions: ${videoWidth}x${videoHeight}`);
+
+    // Calculate pixel position for center of screen
+    const centerPixel = hidToPixelCoords(HID_CENTER, HID_CENTER, videoWidth, videoHeight);
+    console.log(`Target pixel position: (${centerPixel.x}, ${centerPixel.y})`);
+
+    // Calculate capture region bounds (centered around the target position)
+    const regionX = Math.max(0, centerPixel.x - CAPTURE_REGION_SIZE / 2);
+    const regionY = Math.max(0, centerPixel.y - CAPTURE_REGION_SIZE / 2);
+    const regionWidth = Math.min(CAPTURE_REGION_SIZE, videoWidth - regionX);
+    const regionHeight = Math.min(CAPTURE_REGION_SIZE, videoHeight - regionY);
+
+    // Step 1: Move mouse to center and let it settle
+    await sendAbsMouseMove(page, HID_CENTER, HID_CENTER);
+    await page.waitForTimeout(100);
+
+    // Step 2: Capture the region where the cursor should be (state A: with cursor)
+    const fpBefore = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
+    expect(fpBefore, "Failed to capture fingerprint with cursor at center").not.toBeNull();
+    const regionBefore = await captureVideoRegion(page, regionX, regionY, regionWidth, regionHeight);
+    expect(regionBefore, "Failed to capture PNG with cursor at center").not.toBeNull();
+    console.log("Captured state A: region with cursor at center");
+    await persistPng(test.info(), "mouse-region-before.png", regionBefore!);
+
+    // Step 3: Move mouse to top-left corner (away from center)
+    await sendAbsMouseMove(page, 0, 0);
+    await page.waitForTimeout(100);
+
+    // Step 4: Capture the same region (state B: cursor gone)
+    const fpAfter = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
+    expect(fpAfter, "Failed to capture fingerprint after cursor moved away").not.toBeNull();
+    const regionAfter = await captureVideoRegion(page, regionX, regionY, regionWidth, regionHeight);
+    expect(regionAfter, "Failed to capture PNG after cursor moved away").not.toBeNull();
+    console.log("Captured state B: region after cursor moved away");
+    await persistPng(test.info(), "mouse-region-after.png", regionAfter!);
+
+    // Step 5: Assert the regions differ significantly (cursor left the area)
+    const distance = fingerprintDistance(fpBefore!, fpAfter!);
+    console.log(`Fingerprint distance: ${distance}`);
+    const distText = `distance=${distance}\n`;
+    await fs.writeFile(test.info().outputPath("mouse-fingerprint-distance.txt"), distText, "utf-8");
+    await test.info().attach("mouse-fingerprint-distance.txt", {
+      body: Buffer.from(distText, "utf-8"),
+      contentType: "text/plain",
+    });
+
+    expect(
+      distance,
+      `Cursor movement should cause significant visual change (distance=${distance}, expected >10) — mouse HID path may be broken`,
+    ).toBeGreaterThan(10);
+    console.log("Verified: region changed after cursor moved away (A→B)");
+  });
+
+  test("mouse movement is bidirectionally verifiable", async ({ page }) => {
+    // Wake display if screensaver/sleep is active
+    await wakeDisplay(page);
+
+    // Wait for video stream to be active
+    await waitForVideoStream(page);
+
+    // Get video dimensions and validate them
+    const dimensions = await getVideoStreamDimensions(page);
+    expect(dimensions, "Video stream dimensions should be available").not.toBeNull();
+    const { width: videoWidth, height: videoHeight } = dimensions!;
+    expect(videoWidth, `Video width should be at least ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThan(MIN_VIDEO_DIMENSION);
+    expect(videoHeight, `Video height should be at least ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThan(MIN_VIDEO_DIMENSION);
+    console.log(`Video dimensions: ${videoWidth}x${videoHeight}`);
+
+    // Use a position offset from center to avoid any UI elements
+    const testHidX = Math.floor(HID_MAX * 0.7);
+    const testHidY = Math.floor(HID_MAX * 0.7);
+    const testPixel = hidToPixelCoords(testHidX, testHidY, videoWidth, videoHeight);
+    console.log(`Target pixel position: (${testPixel.x}, ${testPixel.y})`);
+
+    const regionX = Math.max(0, testPixel.x - CAPTURE_REGION_SIZE / 2);
+    const regionY = Math.max(0, testPixel.y - CAPTURE_REGION_SIZE / 2);
+    const regionWidth = Math.min(CAPTURE_REGION_SIZE, videoWidth - regionX);
+    const regionHeight = Math.min(CAPTURE_REGION_SIZE, videoHeight - regionY);
+
+    // Step 1: Move cursor away first to establish baseline
+    await sendAbsMouseMove(page, 0, 0);
+    await page.waitForTimeout(100);
+
+    // Capture fingerprint without cursor (state A)
+    const fpWithoutCursor = await captureVideoRegionFingerprint(
+      page,
+      regionX,
+      regionY,
+      regionWidth,
+      regionHeight,
+    );
+    expect(fpWithoutCursor, "Failed to capture fingerprint A (baseline without cursor)").not.toBeNull();
+    const regionWithoutCursorPng = await captureVideoRegion(page, regionX, regionY, regionWidth, regionHeight);
+    expect(regionWithoutCursorPng, "Failed to capture PNG for state A").not.toBeNull();
+    console.log("Captured state A: region without cursor (baseline)");
+    await persistPng(test.info(), "mouse-bidir-A-without-cursor.png", regionWithoutCursorPng!);
+
+    // Step 2: Move cursor into the target region
+    await sendAbsMouseMove(page, testHidX, testHidY);
+    await page.waitForTimeout(100);
+
+    // Capture fingerprint with cursor (state B)
+    const fpWithCursor = await captureVideoRegionFingerprint(
+      page,
+      regionX,
+      regionY,
+      regionWidth,
+      regionHeight,
+    );
+    expect(fpWithCursor, "Failed to capture fingerprint B (with cursor in region)").not.toBeNull();
+    const regionWithCursorPng = await captureVideoRegion(page, regionX, regionY, regionWidth, regionHeight);
+    expect(regionWithCursorPng, "Failed to capture PNG for state B").not.toBeNull();
+    console.log("Captured state B: region with cursor");
+    await persistPng(test.info(), "mouse-bidir-B-with-cursor.png", regionWithCursorPng!);
+
+    // Step 3: Move cursor away again
+    await sendAbsMouseMove(page, 0, 0);
+    await page.waitForTimeout(100);
+
+    // Capture fingerprint again without cursor (state A2)
+    const fpWithoutCursorAgain = await captureVideoRegionFingerprint(
+      page,
+      regionX,
+      regionY,
+      regionWidth,
+      regionHeight,
+    );
+    expect(fpWithoutCursorAgain, "Failed to capture fingerprint A2 (after cursor left again)").not.toBeNull();
+    const regionWithoutCursorAgainPng = await captureVideoRegion(page, regionX, regionY, regionWidth, regionHeight);
+    expect(regionWithoutCursorAgainPng, "Failed to capture PNG for state A2").not.toBeNull();
+    console.log("Captured state A2: region without cursor again");
+    await persistPng(test.info(), "mouse-bidir-A2-without-cursor-again.png", regionWithoutCursorAgainPng!);
+
+    const distArrive = fingerprintDistance(fpWithoutCursor!, fpWithCursor!);
+    const distRestore = fingerprintDistance(fpWithoutCursor!, fpWithoutCursorAgain!);
+    console.log(`Fingerprint distance: arrive=${distArrive}, restore=${distRestore}`);
+    const distText = `arrive=${distArrive}\nrestore=${distRestore}\n`;
+    await fs.writeFile(test.info().outputPath("mouse-bidir-fingerprint-distances.txt"), distText, "utf-8");
+    await test.info().attach("mouse-bidir-fingerprint-distances.txt", {
+      body: Buffer.from(distText, "utf-8"),
+      contentType: "text/plain",
+    });
+
+    // Verify: cursor arrival changes the region significantly
+    expect(
+      distArrive,
+      `Cursor arrival should cause significant visual change (distArrive=${distArrive}, expected >10) — mouse HID path may be broken`,
+    ).toBeGreaterThan(10);
+    console.log("Verified: cursor arrival changed the region (A→B)");
+
+    // Verify: after moving away, the region is closer to baseline than when cursor was present
+    expect(
+      distRestore,
+      `Region should restore after cursor leaves (distRestore=${distRestore} should be < distArrive=${distArrive}) — cursor may not have moved away`,
+    ).toBeLessThan(distArrive);
+    console.log("Verified: region restored after cursor left (B→A2)");
+  });
+});
+

--- a/ui/e2e/usb-device-roundtrip.spec.ts
+++ b/ui/e2e/usb-device-roundtrip.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect, Page } from "@playwright/test";
+
+import {
+  waitForWebRTCReady,
+  waitForVideoStream,
+  wakeDisplay,
+  sendAbsMouseMove,
+  getVideoStreamDimensions,
+  captureVideoRegionFingerprint,
+  fingerprintDistance,
+} from "./helpers";
+
+// Region size for cursor detection (pixels around the expected cursor position)
+const CAPTURE_REGION_SIZE = 80;
+
+/** Locate the USB device preset dropdown */
+function getUsbDropdown(page: Page) {
+  return page.locator("select").filter({
+    has: page.locator('option[value="keyboard_only"]'),
+  });
+}
+
+// HID absolute coordinate range is 0-32767
+const HID_MAX = 32767;
+
+// Time to wait for USB config change to apply (ms)
+const USB_CONFIG_TIMEOUT = 10000;
+
+// USB preset values (from UsbDeviceSetting.tsx)
+const USB_PRESET_DEFAULT = "default"; // Keyboard, Mouse and Storage
+const USB_PRESET_KEYBOARD_ONLY = "keyboard_only";
+
+test.describe("USB Device Round-Trip Tests", () => {
+  test.setTimeout(120000); // 2 minutes
+
+  // Always restore USB to default mode after tests complete (for subsequent test runs)
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      await page.goto("/settings/hardware");
+      await page.waitForLoadState("networkidle");
+      const usbDropdown = getUsbDropdown(page);
+      if (await usbDropdown.isVisible({ timeout: 5000 })) {
+        await usbDropdown.selectOption(USB_PRESET_DEFAULT);
+        await page.waitForTimeout(3000); // Wait for USB reconfiguration
+      } else {
+        console.warn("[USB cleanup] USB dropdown not visible, skipping restoration");
+      }
+    } finally {
+      await page.close();
+    }
+  });
+
+  test("mouse is disabled when USB preset is keyboard-only", async ({ page }) => {
+    // First, go to main page and set up WebRTC
+    await page.goto("/");
+    await waitForWebRTCReady(page);
+    await wakeDisplay(page);
+    await waitForVideoStream(page);
+
+    // Get video dimensions for fingerprint capture
+    const dimensions = await getVideoStreamDimensions(page);
+    expect(dimensions, "Video dimensions should be available").not.toBeNull();
+    const { width: videoWidth, height: videoHeight } = dimensions!;
+
+    // Calculate a test region in the center of the screen
+    const centerX = Math.floor(videoWidth / 2);
+    const centerY = Math.floor(videoHeight / 2);
+    const regionX = Math.max(0, centerX - CAPTURE_REGION_SIZE / 2);
+    const regionY = Math.max(0, centerY - CAPTURE_REGION_SIZE / 2);
+    const regionWidth = Math.min(CAPTURE_REGION_SIZE, videoWidth - regionX);
+    const regionHeight = Math.min(CAPTURE_REGION_SIZE, videoHeight - regionY);
+
+    // Define HID coordinates for test positions
+    const hidCenter = Math.floor(HID_MAX / 2);
+    const hidCorner = 0;
+
+    // === Step 1: Switch to Keyboard Only mode ===
+    await page.goto("/settings/hardware");
+    await page.waitForLoadState("networkidle");
+
+    // Find the USB device preset dropdown
+    const usbDropdown = getUsbDropdown(page);
+    await expect(usbDropdown).toBeVisible({ timeout: 10000 });
+    await expect(usbDropdown).toBeEnabled({ timeout: 10000 });
+
+    // Select keyboard-only preset
+    await usbDropdown.selectOption(USB_PRESET_KEYBOARD_ONLY);
+    await page.waitForTimeout(500);
+    await expect(usbDropdown).toBeEnabled({ timeout: USB_CONFIG_TIMEOUT });
+
+    // === Step 2: Verify mouse does NOT work ===
+    await page.goto("/");
+    await waitForWebRTCReady(page, 30000);
+    await wakeDisplay(page);
+    await waitForVideoStream(page, 30000);
+
+    // Move mouse to corner first to establish baseline
+    await sendAbsMouseMove(page, hidCorner, hidCorner);
+    await page.waitForTimeout(200);
+
+    // Capture baseline fingerprint
+    const fpKeyboardOnlyBefore = await captureVideoRegionFingerprint(
+      page, regionX, regionY, regionWidth, regionHeight
+    );
+    expect(fpKeyboardOnlyBefore, "Failed to capture baseline fingerprint").not.toBeNull();
+
+    // Try to move mouse to center
+    await sendAbsMouseMove(page, hidCenter, hidCenter);
+    await page.waitForTimeout(200);
+
+    // Capture fingerprint after attempted move
+    const fpKeyboardOnlyAfter = await captureVideoRegionFingerprint(
+      page, regionX, regionY, regionWidth, regionHeight
+    );
+    expect(fpKeyboardOnlyAfter, "Failed to capture after-move fingerprint").not.toBeNull();
+
+    // In keyboard-only mode, the region should NOT change significantly
+    // (cursor doesn't move because mouse is disabled)
+    const distanceKeyboardOnly = fingerprintDistance(fpKeyboardOnlyBefore!, fpKeyboardOnlyAfter!);
+    expect(
+      distanceKeyboardOnly,
+      `Mouse should NOT cause visual change in keyboard-only mode (distance=${distanceKeyboardOnly}, expected < 50)`,
+    ).toBeLessThan(50);
+
+    // === Step 3: Switch back to default mode (Keyboard, Mouse and Storage) ===
+    await page.goto("/settings/hardware");
+    await page.waitForLoadState("networkidle");
+
+    const usbDropdown2 = getUsbDropdown(page);
+    await expect(usbDropdown2).toBeVisible({ timeout: 10000 });
+    await expect(usbDropdown2).toBeEnabled({ timeout: 10000 });
+
+    // Select default preset
+    await usbDropdown2.selectOption(USB_PRESET_DEFAULT);
+    await page.waitForTimeout(500);
+    await expect(usbDropdown2).toBeEnabled({ timeout: USB_CONFIG_TIMEOUT });
+
+    // === Step 4: Verify mouse DOES work now ===
+    await page.goto("/");
+    await waitForWebRTCReady(page, 30000);
+    await wakeDisplay(page);
+    await waitForVideoStream(page, 30000);
+
+    // Move mouse to corner first
+    await sendAbsMouseMove(page, hidCorner, hidCorner);
+    await page.waitForTimeout(200);
+
+    // Capture baseline fingerprint
+    const fpDefaultBefore = await captureVideoRegionFingerprint(
+      page, regionX, regionY, regionWidth, regionHeight
+    );
+    expect(fpDefaultBefore, "Failed to capture baseline fingerprint").not.toBeNull();
+
+    // Move mouse to center
+    await sendAbsMouseMove(page, hidCenter, hidCenter);
+    await page.waitForTimeout(200);
+
+    // Capture fingerprint after move
+    const fpDefaultAfter = await captureVideoRegionFingerprint(
+      page, regionX, regionY, regionWidth, regionHeight
+    );
+    expect(fpDefaultAfter, "Failed to capture after-move fingerprint").not.toBeNull();
+
+    // In default mode, the region SHOULD change (cursor moved)
+    const distanceDefault = fingerprintDistance(fpDefaultBefore!, fpDefaultAfter!);
+    expect(
+      distanceDefault,
+      `Mouse SHOULD cause visual change in default mode (distance=${distanceDefault}, expected > 10)`,
+    ).toBeGreaterThan(10);
+
+    console.log(`✓ Keyboard-only mode: mouse disabled (distance=${distanceKeyboardOnly})`);
+    console.log(`✓ Default mode: mouse enabled (distance=${distanceDefault})`);
+  });
+});
+

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -52,6 +52,7 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
     clientWidth: videoClientWidth,
     clientHeight: videoClientHeight,
     hdmiState,
+    setVideoElement,
   } = useVideoStore();
 
   // Video enhancement settings
@@ -105,6 +106,15 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
       if (videoElm.current) updateVideoSizeStore(videoElm.current);
     },
     [updateVideoSizeStore],
+  );
+
+  // Store video element reference for E2E test hooks
+  useEffect(
+    function storeVideoElementRef() {
+      setVideoElement(videoElm.current);
+      return () => setVideoElement(null);
+    },
+    [setVideoElement],
   );
 
   // Pointer lock and keyboard lock related

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -300,6 +300,8 @@ export interface VideoState {
   setSize: (width: number, height: number) => void;
   hdmiState: HdmiStates;
   setHdmiState: (state: { ready: boolean; error?: HdmiErrorStates }) => void;
+  videoElement: HTMLVideoElement | null;
+  setVideoElement: (element: HTMLVideoElement | null) => void;
 }
 
 export const useVideoStore = create<VideoState>(set => ({
@@ -329,6 +331,9 @@ export const useVideoStore = create<VideoState>(set => ({
       return set({ hdmiState: "connecting" });
     }
   },
+
+  videoElement: null,
+  setVideoElement: (element: HTMLVideoElement | null) => set({ videoElement: element }),
 }));
 
 export interface BacklightSettings {

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -53,7 +53,7 @@ import {
 } from "@components/VideoOverlay";
 import { FeatureFlagProvider } from "@providers/FeatureFlagProvider";
 import { m } from "@localizations/messages.js";
-import { doRpcHidHandshake } from "@hooks/useHidRpc";
+import { doRpcHidHandshake, useHidRpc } from "@hooks/useHidRpc";
 import useKeyboard from "@hooks/useKeyboard";
 import { registerTestHandlers, cleanupTestHooks } from "@/test/testHooks";
 
@@ -634,19 +634,8 @@ export default function KvmIdRoute() {
   // Keyboard handler for E2E tests
   const { handleKeyPress } = useKeyboard();
 
-  // Register E2E test hooks
-  useEffect(() => {
-    registerTestHandlers({
-      handleKeyPress,
-      getKeyboardLedState: () => useHidStore.getState().keyboardLedState,
-      getKeysDownState: () => useHidStore.getState().keysDownState,
-      getPeerConnectionState: () => useRTCStore.getState().peerConnectionState,
-      getRpcHidProtocolVersion: () => useRTCStore.getState().rpcHidProtocolVersion,
-      getMediaStream: () => useRTCStore.getState().mediaStream,
-      getHdmiState: () => useVideoStore.getState().hdmiState,
-    });
-    return cleanupTestHooks;
-  }, [handleKeyPress]);
+  // Mouse handler for E2E tests
+  const { reportAbsMouseEvent, rpcHidReady } = useHidRpc();
 
   const [hasUpdated, setHasUpdated] = useState(false);
   const { navigateTo } = useDeviceUiNavigation();
@@ -737,6 +726,34 @@ export default function KvmIdRoute() {
   }
 
   const { send } = useJsonRpc(onJsonRpcRequest);
+
+  // Mouse movement handler for E2E tests (needs send from useJsonRpc)
+  const handleAbsMouseMove = useCallback(
+    (x: number, y: number, buttons: number) => {
+      if (rpcHidReady) {
+        reportAbsMouseEvent(x, y, buttons);
+      } else {
+        send("absMouseReport", { x, y, buttons });
+      }
+    },
+    [reportAbsMouseEvent, rpcHidReady, send],
+  );
+
+  // Register E2E test hooks
+  useEffect(() => {
+    registerTestHandlers({
+      handleKeyPress,
+      handleAbsMouseMove,
+      getKeyboardLedState: () => useHidStore.getState().keyboardLedState,
+      getKeysDownState: () => useHidStore.getState().keysDownState,
+      getPeerConnectionState: () => useRTCStore.getState().peerConnectionState,
+      getRpcHidProtocolVersion: () => useRTCStore.getState().rpcHidProtocolVersion,
+      getMediaStream: () => useRTCStore.getState().mediaStream,
+      getHdmiState: () => useVideoStore.getState().hdmiState,
+      getVideoElement: () => useVideoStore.getState().videoElement,
+    });
+    return cleanupTestHooks;
+  }, [handleKeyPress, handleAbsMouseMove]);
 
   useEffect(() => {
     if (rpcDataChannel?.readyState !== "open") return;

--- a/ui/src/test/testHooks.ts
+++ b/ui/src/test/testHooks.ts
@@ -2,76 +2,43 @@
  * E2E Test Hooks
  *
  * This module exposes test hooks on window.__kvmTestHooks for Playwright E2E tests.
- * The hooks are only active when the page has window.__E2E_TEST__ set to true.
  *
  * Usage in tests:
- *   await page.evaluate(() => window.__E2E_TEST__ = true);
- *   await page.goto('/devices/local');
+ *   await page.goto('/');
  *   const ledState = await page.evaluate(() => window.__kvmTestHooks?.getKeyboardLedState());
  */
 
 import { KeyboardLedState, KeysDownState } from "@/hooks/stores";
 
-export interface KvmTestHooks {
-  /** Get current keyboard LED state (caps lock, num lock, etc.) */
-  getKeyboardLedState: () => KeyboardLedState | null;
-
-  /** Get current keys down state */
-  getKeysDownState: () => KeysDownState | null;
-
-  /** Send a keypress event (key: USB HID keycode, press: true=down, false=up) */
-  sendKeypress: (key: number, press: boolean) => void;
-
-  /** Send absolute mouse move (x, y in 0-32767 range, buttons bitmask) */
-  sendAbsMouseMove: (x: number, y: number, buttons: number) => void;
-
-  /** Capture a region of the video frame as base64 PNG */
-  captureVideoRegion: (x: number, y: number, width: number, height: number) => Promise<string | null>;
-
-  /**
-   * Capture a small fingerprint of a region of the video frame.
-   * Returns a downsampled grayscale grid (length = gridSize * gridSize).
-   * This is much less flaky than comparing whole PNGs.
-   */
-  captureVideoRegionFingerprint: (
-    x: number,
-    y: number,
-    width: number,
-    height: number,
-    gridSize?: number,
-  ) => number[] | null;
-
-  /** Get the video stream's natural dimensions */
-  getVideoStreamDimensions: () => { width: number; height: number } | null;
-
-  /** Check if WebRTC peer connection is connected */
-  isWebRTCConnected: () => boolean;
-
-  /** Check if HID RPC channel is ready */
-  isHidRpcReady: () => boolean;
-
-  /** Check if video stream is active */
-  isVideoStreamActive: () => boolean;
+/** Internal handlers set by React components (prefixed with _ to indicate internal use) */
+interface TestHooksInternal {
+  _handleKeyPress?: (key: number, press: boolean) => void;
+  _handleAbsMouseMove?: (x: number, y: number, buttons: number) => void;
+  _getKeyboardLedState?: () => KeyboardLedState;
+  _getKeysDownState?: () => KeysDownState;
+  _getPeerConnectionState?: () => RTCPeerConnectionState | null;
+  _getRpcHidProtocolVersion?: () => number | null;
+  _getMediaStream?: () => MediaStream | null;
+  _getHdmiState?: () => string;
+  _getVideoElement?: () => HTMLVideoElement | null;
 }
 
-/** Internal handler storage type */
-interface TestHooksInternal {
-  handleKeyPress?: (key: number, press: boolean) => void;
-  handleAbsMouseMove?: (x: number, y: number, buttons: number) => void;
-  getKeyboardLedState?: () => KeyboardLedState;
-  getKeysDownState?: () => KeysDownState;
-  getPeerConnectionState?: () => RTCPeerConnectionState | null;
-  getRpcHidProtocolVersion?: () => number | null;
-  getMediaStream?: () => MediaStream | null;
-  getHdmiState?: () => string;
-  getVideoElement?: () => HTMLVideoElement | null;
+export interface KvmTestHooks extends TestHooksInternal {
+  getKeyboardLedState: () => KeyboardLedState | null;
+  getKeysDownState: () => KeysDownState | null;
+  sendKeypress: (key: number, press: boolean) => void;
+  sendAbsMouseMove: (x: number, y: number, buttons: number) => void;
+  captureVideoRegion: (x: number, y: number, width: number, height: number) => Promise<string | null>;
+  captureVideoRegionFingerprint: (x: number, y: number, width: number, height: number, gridSize?: number) => number[] | null;
+  getVideoStreamDimensions: () => { width: number; height: number } | null;
+  isWebRTCConnected: () => boolean;
+  isHidRpcReady: () => boolean;
+  isVideoStreamActive: () => boolean;
 }
 
 declare global {
   interface Window {
-    __E2E_TEST__?: boolean;
     __kvmTestHooks?: KvmTestHooks;
-    __kvmTestHooksInternal?: TestHooksInternal;
   }
 }
 
@@ -82,49 +49,36 @@ declare global {
 export function initTestHooks(): void {
   if (typeof window === "undefined") return;
 
-  // Initialize internal hooks storage
-  window.__kvmTestHooksInternal = {};
+  const hooks: KvmTestHooks = {
+    getKeyboardLedState: () => hooks._getKeyboardLedState?.() ?? null,
 
-  // Expose the public API
-  window.__kvmTestHooks = {
-    getKeyboardLedState: () => {
-      return window.__kvmTestHooksInternal?.getKeyboardLedState?.() ?? null;
-    },
-
-    getKeysDownState: () => {
-      return window.__kvmTestHooksInternal?.getKeysDownState?.() ?? null;
-    },
+    getKeysDownState: () => hooks._getKeysDownState?.() ?? null,
 
     sendKeypress: (key: number, press: boolean) => {
-      const handler = window.__kvmTestHooksInternal?.handleKeyPress;
-      if (handler) {
-        handler(key, press);
+      if (hooks._handleKeyPress) {
+        hooks._handleKeyPress(key, press);
       } else {
         console.warn("[E2E] sendKeypress called but no handler registered");
       }
     },
 
-    isWebRTCConnected: () => {
-      const state = window.__kvmTestHooksInternal?.getPeerConnectionState?.();
-      return state === "connected";
-    },
-
-    isHidRpcReady: () => {
-      const version = window.__kvmTestHooksInternal?.getRpcHidProtocolVersion?.();
-      return version !== null && version !== undefined;
-    },
-
     sendAbsMouseMove: (x: number, y: number, buttons: number) => {
-      const handler = window.__kvmTestHooksInternal?.handleAbsMouseMove;
-      if (handler) {
-        handler(x, y, buttons);
+      if (hooks._handleAbsMouseMove) {
+        hooks._handleAbsMouseMove(x, y, buttons);
       } else {
         console.warn("[E2E] sendAbsMouseMove called but no handler registered");
       }
     },
 
+    isWebRTCConnected: () => hooks._getPeerConnectionState?.() === "connected",
+
+    isHidRpcReady: () => {
+      const version = hooks._getRpcHidProtocolVersion?.();
+      return version !== null && version !== undefined;
+    },
+
     captureVideoRegion: async (x: number, y: number, width: number, height: number): Promise<string | null> => {
-      const videoElement = window.__kvmTestHooksInternal?.getVideoElement?.();
+      const videoElement = hooks._getVideoElement?.();
       if (!videoElement) {
         console.warn("[E2E] captureVideoRegion called but no video element available");
         return null;
@@ -139,19 +93,12 @@ export function initTestHooks(): void {
         return null;
       }
 
-      // Draw the specified region of the video onto the canvas
       ctx.drawImage(videoElement, x, y, width, height, 0, 0, width, height);
       return canvas.toDataURL("image/png");
     },
 
-    captureVideoRegionFingerprint: (
-      x: number,
-      y: number,
-      width: number,
-      height: number,
-      gridSize = 8,
-    ): number[] | null => {
-      const videoElement = window.__kvmTestHooksInternal?.getVideoElement?.();
+    captureVideoRegionFingerprint: (x: number, y: number, width: number, height: number, gridSize = 8): number[] | null => {
+      const videoElement = hooks._getVideoElement?.();
       if (!videoElement) {
         console.warn("[E2E] captureVideoRegionFingerprint called but no video element available");
         return null;
@@ -190,7 +137,6 @@ export function initTestHooks(): void {
               const r = imageData[idx];
               const g = imageData[idx + 1];
               const b = imageData[idx + 2];
-              // simple luma approximation
               sum += (r * 3 + g * 4 + b) >> 3;
               count++;
             }
@@ -204,7 +150,7 @@ export function initTestHooks(): void {
     },
 
     getVideoStreamDimensions: () => {
-      const videoElement = window.__kvmTestHooksInternal?.getVideoElement?.();
+      const videoElement = hooks._getVideoElement?.();
       if (!videoElement || !videoElement.videoWidth || !videoElement.videoHeight) {
         return null;
       }
@@ -212,16 +158,17 @@ export function initTestHooks(): void {
     },
 
     isVideoStreamActive: () => {
-      const hdmiState = window.__kvmTestHooksInternal?.getHdmiState?.();
+      const hdmiState = hooks._getHdmiState?.();
       if (hdmiState !== "ready") return false;
 
-      const stream = window.__kvmTestHooksInternal?.getMediaStream?.();
+      const stream = hooks._getMediaStream?.();
       if (!stream) return false;
       const videoTracks = stream.getVideoTracks();
       return videoTracks.length > 0 && videoTracks[0].readyState === "live";
     },
   };
 
+  window.__kvmTestHooks = hooks;
   console.log("[E2E] Test hooks initialized");
 }
 
@@ -240,14 +187,32 @@ export function registerTestHandlers(handlers: {
   getHdmiState: () => string;
   getVideoElement: () => HTMLVideoElement | null;
 }): void {
-  if (window.__kvmTestHooksInternal) {
-    Object.assign(window.__kvmTestHooksInternal, handlers);
-  }
+  if (!window.__kvmTestHooks) return;
+
+  window.__kvmTestHooks._handleKeyPress = handlers.handleKeyPress;
+  window.__kvmTestHooks._handleAbsMouseMove = handlers.handleAbsMouseMove;
+  window.__kvmTestHooks._getKeyboardLedState = handlers.getKeyboardLedState;
+  window.__kvmTestHooks._getKeysDownState = handlers.getKeysDownState;
+  window.__kvmTestHooks._getPeerConnectionState = handlers.getPeerConnectionState;
+  window.__kvmTestHooks._getRpcHidProtocolVersion = handlers.getRpcHidProtocolVersion;
+  window.__kvmTestHooks._getMediaStream = handlers.getMediaStream;
+  window.__kvmTestHooks._getHdmiState = handlers.getHdmiState;
+  window.__kvmTestHooks._getVideoElement = handlers.getVideoElement;
 }
 
 /**
  * Cleanup test hooks when component unmounts.
  */
 export function cleanupTestHooks(): void {
-  window.__kvmTestHooksInternal = {};
+  if (!window.__kvmTestHooks) return;
+
+  window.__kvmTestHooks._handleKeyPress = undefined;
+  window.__kvmTestHooks._handleAbsMouseMove = undefined;
+  window.__kvmTestHooks._getKeyboardLedState = undefined;
+  window.__kvmTestHooks._getKeysDownState = undefined;
+  window.__kvmTestHooks._getPeerConnectionState = undefined;
+  window.__kvmTestHooks._getRpcHidProtocolVersion = undefined;
+  window.__kvmTestHooks._getMediaStream = undefined;
+  window.__kvmTestHooks._getHdmiState = undefined;
+  window.__kvmTestHooks._getVideoElement = undefined;
 }

--- a/ui/src/test/testHooks.ts
+++ b/ui/src/test/testHooks.ts
@@ -22,6 +22,28 @@ export interface KvmTestHooks {
   /** Send a keypress event (key: USB HID keycode, press: true=down, false=up) */
   sendKeypress: (key: number, press: boolean) => void;
 
+  /** Send absolute mouse move (x, y in 0-32767 range, buttons bitmask) */
+  sendAbsMouseMove: (x: number, y: number, buttons: number) => void;
+
+  /** Capture a region of the video frame as base64 PNG */
+  captureVideoRegion: (x: number, y: number, width: number, height: number) => Promise<string | null>;
+
+  /**
+   * Capture a small fingerprint of a region of the video frame.
+   * Returns a downsampled grayscale grid (length = gridSize * gridSize).
+   * This is much less flaky than comparing whole PNGs.
+   */
+  captureVideoRegionFingerprint: (
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    gridSize?: number,
+  ) => number[] | null;
+
+  /** Get the video stream's natural dimensions */
+  getVideoStreamDimensions: () => { width: number; height: number } | null;
+
   /** Check if WebRTC peer connection is connected */
   isWebRTCConnected: () => boolean;
 
@@ -35,12 +57,14 @@ export interface KvmTestHooks {
 /** Internal handler storage type */
 interface TestHooksInternal {
   handleKeyPress?: (key: number, press: boolean) => void;
+  handleAbsMouseMove?: (x: number, y: number, buttons: number) => void;
   getKeyboardLedState?: () => KeyboardLedState;
   getKeysDownState?: () => KeysDownState;
   getPeerConnectionState?: () => RTCPeerConnectionState | null;
   getRpcHidProtocolVersion?: () => number | null;
   getMediaStream?: () => MediaStream | null;
   getHdmiState?: () => string;
+  getVideoElement?: () => HTMLVideoElement | null;
 }
 
 declare global {
@@ -90,6 +114,103 @@ export function initTestHooks(): void {
       return version !== null && version !== undefined;
     },
 
+    sendAbsMouseMove: (x: number, y: number, buttons: number) => {
+      const handler = window.__kvmTestHooksInternal?.handleAbsMouseMove;
+      if (handler) {
+        handler(x, y, buttons);
+      } else {
+        console.warn("[E2E] sendAbsMouseMove called but no handler registered");
+      }
+    },
+
+    captureVideoRegion: async (x: number, y: number, width: number, height: number): Promise<string | null> => {
+      const videoElement = window.__kvmTestHooksInternal?.getVideoElement?.();
+      if (!videoElement) {
+        console.warn("[E2E] captureVideoRegion called but no video element available");
+        return null;
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        console.warn("[E2E] captureVideoRegion: failed to get 2d context");
+        return null;
+      }
+
+      // Draw the specified region of the video onto the canvas
+      ctx.drawImage(videoElement, x, y, width, height, 0, 0, width, height);
+      return canvas.toDataURL("image/png");
+    },
+
+    captureVideoRegionFingerprint: (
+      x: number,
+      y: number,
+      width: number,
+      height: number,
+      gridSize = 8,
+    ): number[] | null => {
+      const videoElement = window.__kvmTestHooksInternal?.getVideoElement?.();
+      if (!videoElement) {
+        console.warn("[E2E] captureVideoRegionFingerprint called but no video element available");
+        return null;
+      }
+
+      const canvas = document.createElement("canvas");
+      canvas.width = width;
+      canvas.height = height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) {
+        console.warn("[E2E] captureVideoRegionFingerprint: failed to get 2d context");
+        return null;
+      }
+
+      ctx.drawImage(videoElement, x, y, width, height, 0, 0, width, height);
+
+      const imageData = ctx.getImageData(0, 0, width, height).data;
+      const fp: number[] = [];
+
+      const cellW = Math.max(1, Math.floor(width / gridSize));
+      const cellH = Math.max(1, Math.floor(height / gridSize));
+
+      for (let gy = 0; gy < gridSize; gy++) {
+        for (let gx = 0; gx < gridSize; gx++) {
+          const startX = gx * cellW;
+          const startY = gy * cellH;
+          const endX = gx === gridSize - 1 ? width : Math.min(width, startX + cellW);
+          const endY = gy === gridSize - 1 ? height : Math.min(height, startY + cellH);
+
+          let sum = 0;
+          let count = 0;
+
+          for (let py = startY; py < endY; py++) {
+            for (let px = startX; px < endX; px++) {
+              const idx = (py * width + px) * 4;
+              const r = imageData[idx];
+              const g = imageData[idx + 1];
+              const b = imageData[idx + 2];
+              // simple luma approximation
+              sum += (r * 3 + g * 4 + b) >> 3;
+              count++;
+            }
+          }
+
+          fp.push(count > 0 ? Math.round(sum / count) : 0);
+        }
+      }
+
+      return fp;
+    },
+
+    getVideoStreamDimensions: () => {
+      const videoElement = window.__kvmTestHooksInternal?.getVideoElement?.();
+      if (!videoElement || !videoElement.videoWidth || !videoElement.videoHeight) {
+        return null;
+      }
+      return { width: videoElement.videoWidth, height: videoElement.videoHeight };
+    },
+
     isVideoStreamActive: () => {
       const hdmiState = window.__kvmTestHooksInternal?.getHdmiState?.();
       if (hdmiState !== "ready") return false;
@@ -110,12 +231,14 @@ export function initTestHooks(): void {
  */
 export function registerTestHandlers(handlers: {
   handleKeyPress: (key: number, press: boolean) => void;
+  handleAbsMouseMove: (x: number, y: number, buttons: number) => void;
   getKeyboardLedState: () => KeyboardLedState;
   getKeysDownState: () => KeysDownState;
   getPeerConnectionState: () => RTCPeerConnectionState | null;
   getRpcHidProtocolVersion: () => number | null;
   getMediaStream: () => MediaStream | null;
   getHdmiState: () => string;
+  getVideoElement: () => HTMLVideoElement | null;
 }): void {
   if (window.__kvmTestHooksInternal) {
     Object.assign(window.__kvmTestHooksInternal, handlers);


### PR DESCRIPTION
- Add mouse movement tests. 
- Change EDID twice and make sure the video renders mouse movements. 
- Change USB Class and make sure the mouse gets disabled and then re-enabled.
- Simplify the test hook


Test locally by running `make test_e2e`