### PR TITLE
Implement video sleep mode detection with retries in go

### DIFF
--- a/internal/native/cgo/ctrl.c
+++ b/internal/native/cgo/ctrl.c
@@ -417,6 +417,10 @@ char *jetkvm_video_log_status() {
     return (char *)videoc_log_status();
 }
 
+void jetkvm_video_detect_sleep_mode() {
+    video_detect_sleep_mode();
+}
+
 int jetkvm_video_init(float factor) {
     return video_init(factor);
 }

--- a/internal/native/cgo/ctrl.h
+++ b/internal/native/cgo/ctrl.h
@@ -53,6 +53,7 @@ const char *jetkvm_ui_get_lvgl_version();
 
 const char *jetkvm_ui_event_code_to_name(int code);
 
+void jetkvm_video_detect_sleep_mode();
 int jetkvm_video_init(float quality_factor);
 void jetkvm_video_shutdown();
 void jetkvm_video_start();

--- a/internal/native/cgo/main.c
+++ b/internal/native/cgo/main.c
@@ -71,12 +71,12 @@ void jetkvm_rpc_handler(const char *method, const char *params) {
 
 int main(int argc, char *argv[]) {
     const char *socket_path = SOCKET_PATH;
-    
+
     // Allow custom socket path via command line argument
     if (argc > 1) {
         socket_path = argv[1];
     }
-    
+
     // Remove existing socket file if it exists
     unlink(socket_path);
 
@@ -86,14 +86,18 @@ int main(int argc, char *argv[]) {
     jetkvm_set_video_state_handler(&jetkvm_video_state_handler);
     jetkvm_set_indev_handler(&jetkvm_indev_handler);
     jetkvm_set_rpc_handler(&jetkvm_rpc_handler);
-    
-    // Initialize video first (before accepting connections)
+
+    // Detect sleep mode (may block on I2C)
+    fprintf(stderr, "Detecting sleep mode...\n");
+    jetkvm_video_detect_sleep_mode();
+
+    // Initialize video (before accepting connections)
     fprintf(stderr, "Initializing video...\n");
     if (jetkvm_video_init(1.0) != 0) {
         fprintf(stderr, "Failed to initialize video\n");
         return 1;
     }
-    
+
     // Start video streaming - frames will be sent via video_send_frame
     // which calls the video handler we set up
     jetkvm_video_start();
@@ -107,7 +111,7 @@ int main(int argc, char *argv[]) {
         jetkvm_video_shutdown();
         return 1;
     }
-    
+
     // Make socket non-blocking
     int flags = fcntl(server_fd, F_GETFL, 0);
     if (flags < 0 || fcntl(server_fd, F_SETFL, flags | O_NONBLOCK) < 0) {
@@ -117,13 +121,13 @@ int main(int argc, char *argv[]) {
         jetkvm_video_shutdown();
         return 1;
     }
-    
+
     // Bind socket to path
     struct sockaddr_un addr;
     memset(&addr, 0, sizeof(addr));
     addr.sun_family = AF_UNIX;
     strncpy(addr.sun_path, socket_path, sizeof(addr.sun_path) - 1);
-    
+
     if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
         perror("bind");
         close(server_fd);
@@ -131,7 +135,7 @@ int main(int argc, char *argv[]) {
         jetkvm_video_shutdown();
         return 1;
     }
-    
+
     // Listen for connections
     if (listen(server_fd, 1) < 0) {
         perror("listen");
@@ -140,18 +144,18 @@ int main(int argc, char *argv[]) {
         jetkvm_video_shutdown();
         return 1;
     }
-    
+
     fprintf(stderr, "Listening on Unix socket: %s (non-blocking)\n", socket_path);
     fprintf(stderr, "Video frames will be sent to connected clients...\n");
-    
+
     // Main loop: check for new connections and handle client disconnections
     fd_set read_fds;
     struct timeval timeout;
-    
+
     while (1) {
         FD_ZERO(&read_fds);
         FD_SET(server_fd, &read_fds);
-        
+
         pthread_mutex_lock(&client_fd_mutex);
         int current_client_fd = client_fd;
         if (current_client_fd >= 0) {
@@ -159,10 +163,10 @@ int main(int argc, char *argv[]) {
         }
         int max_fd = (current_client_fd > server_fd) ? current_client_fd : server_fd;
         pthread_mutex_unlock(&client_fd_mutex);
-        
+
         timeout.tv_sec = 1;
         timeout.tv_usec = 0;
-        
+
         int result = select(max_fd + 1, &read_fds, NULL, NULL, &timeout);
         if (result < 0) {
             if (errno == EINTR) {
@@ -171,7 +175,7 @@ int main(int argc, char *argv[]) {
             perror("select");
             break;
         }
-        
+
         // Check for new connection
         if (FD_ISSET(server_fd, &read_fds)) {
             int accepted_fd = accept(server_fd, NULL, NULL);
@@ -188,12 +192,12 @@ int main(int argc, char *argv[]) {
                 perror("accept");
             }
         }
-        
+
         // Check if client disconnected
         pthread_mutex_lock(&client_fd_mutex);
         current_client_fd = client_fd;
         pthread_mutex_unlock(&client_fd_mutex);
-        
+
         if (current_client_fd >= 0 && FD_ISSET(current_client_fd, &read_fds)) {
             // Client sent data or closed connection
             char buffer[1];
@@ -206,11 +210,11 @@ int main(int argc, char *argv[]) {
             }
         }
     }
-    
+
     // Stop video streaming
     jetkvm_video_stop();
     jetkvm_video_shutdown();
-    
+
     // Cleanup
     pthread_mutex_lock(&client_fd_mutex);
     if (client_fd >= 0) {
@@ -218,10 +222,10 @@ int main(int argc, char *argv[]) {
         client_fd = -1;
     }
     pthread_mutex_unlock(&client_fd_mutex);
-    
+
     close(server_fd);
     unlink(socket_path);
-    
+
     return 0;
 }
 

--- a/internal/native/cgo/video.c
+++ b/internal/native/cgo/video.c
@@ -92,6 +92,11 @@ static void detect_sleep_mode()
     ensure_sleep_mode_disabled();
 }
 
+void video_detect_sleep_mode()
+{
+    detect_sleep_mode();
+}
+
 double calculate_bitrate(float bitrate_factor, int width, int height)
 {
     const int32_t base_bitrate_high = 2000;
@@ -233,8 +238,6 @@ pthread_t *format_thread = NULL;
 
 int video_init(float factor)
 {
-    detect_sleep_mode();
-
     if (factor <= 0 || factor > 1) {
         factor = 1.0f;
     }

--- a/internal/native/cgo/video.h
+++ b/internal/native/cgo/video.h
@@ -2,6 +2,12 @@
 #define VIDEO_DAEMON_VIDEO_H
 
 /**
+ * @brief Detect and configure HDMI sleep mode if available.
+ * Call before video_init() - may block on I2C access.
+ */
+void video_detect_sleep_mode();
+
+/**
  * @brief Initialize the video subsystem
  *
  * @return int 0 on success, -1 on failure

--- a/internal/native/cgo_linux.go
+++ b/internal/native/cgo_linux.go
@@ -135,6 +135,12 @@ func uiTick() {
 	C.jetkvm_ui_tick()
 }
 
+// videoDetectSleepMode detects and configures HDMI sleep mode.
+// No lock - this may block on I2C and we want Go to be able to timeout.
+func videoDetectSleepMode() {
+	C.jetkvm_video_detect_sleep_mode()
+}
+
 func videoInit(factor float64) error {
 	cgoLock.Lock()
 	defer cgoLock.Unlock()

--- a/internal/native/native.go
+++ b/internal/native/native.go
@@ -133,6 +133,36 @@ func (n *Native) Start() error {
 	n.initUI()
 	go n.tickUI()
 
+	const maxRetries = 3
+	const retryTimeout = 5 * time.Second
+
+	// Detect sleep mode with retries - may block on I2C on some devices
+	sleepModeOK := false
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		done := make(chan struct{})
+		go func() {
+			n.l.Info().Int("attempt", attempt).Msg("detecting sleep mode")
+			videoDetectSleepMode()
+			close(done)
+		}()
+
+		select {
+		case <-done:
+			n.l.Info().Int("attempt", attempt).Msg("sleep mode detection completed")
+			sleepModeOK = true
+		case <-time.After(retryTimeout):
+			n.l.Info().Int("attempt", attempt).Msg("sleep mode detection timed out, retrying...")
+		}
+
+		if sleepModeOK {
+			break
+		}
+	}
+
+	if !sleepModeOK {
+		n.l.Info().Msg("sleep mode detection failed after 3 attempts, proceeding without it")
+	}
+
 	if err := videoInit(n.defaultQualityFactor); err != nil {
 		n.l.Error().Err(err).Msg("failed to initialize video")
 		return err


### PR DESCRIPTION
Fixes #1074, #1066

### Summary

Added retry timeout for HDMI sleep mode detection during native process startup

I can't reproduce the issue, but my best guess is that on some devices, the I2C bus to the HDMI receiver chip may be temporarily unresponsive at early boot, causing `detect_sleep_mode()` to block indefinitely when accessing /sys/devices/platform/ff470000.i2c/i2c-4/4-000f/sleep_mode. 

The app now retries up to 3 times with 5-second timeouts, then proceeds without sleep mode management if all attempts fail - matching the behavior of v0.4.8 which didn't have sleep mode code and worked fine on affected devices.

Keeping this in draft mode for now. Will try to get a hold of the issue creators, to see if this PR solves the issue for them. 

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green
