### PR TITLE
feat(e2e): add integration tests for config reset, HDMI sleep, and HTTPS mode

### DIFF
--- a/ui/e2e/config-reset.spec.ts
+++ b/ui/e2e/config-reset.spec.ts
@@ -1,0 +1,112 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  waitForWebRTCReady,
+  waitForVideoStream,
+  wakeDisplay,
+  verifyHidAndVideo,
+} from "./helpers";
+
+// Time to wait after reset config before reloading (ms)
+const RESET_CONFIG_DELAY = 2000;
+
+// Time to wait for welcome screen animations (ms)
+const ANIMATION_DELAY = 3000;
+
+test.describe("Config Reset and Welcome Screen Tests", () => {
+  // This test modifies device configuration, so use a longer timeout
+  test.setTimeout(180000); // 3 minutes
+
+  test("reset config and walk through welcome screen without password", async ({ page }) => {
+    // === Step 1: Navigate to the device ===
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+
+    // Check if we're already on the welcome screen (device was previously reset)
+    const currentUrl = page.url();
+    const isOnWelcome = currentUrl.includes("/welcome");
+
+    if (!isOnWelcome) {
+      // Device is set up, need to reset it first
+      console.log("Device is set up, navigating to advanced settings to reset...");
+
+      // === Step 2: Navigate to advanced settings ===
+      await page.goto("/settings/advanced");
+      await page.waitForLoadState("networkidle");
+
+      // === Step 3: Enable Troubleshooting mode ===
+      // SettingsItem renders as a <label> containing both the title and the checkbox
+      const troubleshootingLabel = page.locator("label").filter({ hasText: "Troubleshooting Mode" });
+      await expect(troubleshootingLabel).toBeVisible({ timeout: 10000 });
+      const troubleshootingCheckbox = troubleshootingLabel.locator('input[type="checkbox"]');
+      await expect(troubleshootingCheckbox).toBeVisible({ timeout: 5000 });
+
+      // Check if troubleshooting mode is already enabled
+      const isChecked = await troubleshootingCheckbox.isChecked();
+      if (!isChecked) {
+        await troubleshootingCheckbox.click();
+        await page.waitForTimeout(500);
+      }
+
+      // === Step 4: Click Reset Config button ===
+      const resetConfigButton = page.getByRole("button", { name: /Reset Config/i });
+      await expect(resetConfigButton).toBeVisible({ timeout: 10000 });
+      await resetConfigButton.click();
+
+      // === Step 5: Wait for reset to complete and reload ===
+      await page.waitForTimeout(RESET_CONFIG_DELAY);
+      await page.reload();
+
+      // === Step 6: Should redirect to /welcome screen ===
+      await page.waitForURL("**/welcome", { timeout: 10000 });
+      await page.waitForLoadState("networkidle");
+    } else {
+      console.log("Device already on welcome screen, proceeding with setup...");
+      // Navigate to the base welcome page if we're on a sub-route
+      if (!currentUrl.endsWith("/welcome")) {
+        await page.goto("/welcome");
+        await page.waitForLoadState("networkidle");
+      }
+    }
+
+    // Wait for animations to complete
+    await page.waitForTimeout(ANIMATION_DELAY);
+
+    // === Step 6: Click "Set up your JetKVM" button to go to /welcome/mode ===
+    const setupButton = page.getByRole("link", { name: /Set up your JetKVM/i });
+    await expect(setupButton).toBeVisible({ timeout: 10000 });
+    await setupButton.click();
+
+    // === Step 7: Wait for mode selection page ===
+    await page.waitForURL("**/welcome/mode", { timeout: 10000 });
+    await page.waitForLoadState("networkidle");
+    await page.waitForTimeout(1000); // Wait for animations
+
+    // === Step 8: Select "No Password" option ===
+    const noPasswordRadio = page.locator('input[type="radio"][value="noPassword"]');
+    await expect(noPasswordRadio).toBeVisible({ timeout: 5000 });
+    await noPasswordRadio.click();
+
+    // === Step 9: Click Continue button ===
+    const continueButton = page.getByRole("button", { name: /Continue/i });
+    await expect(continueButton).toBeEnabled({ timeout: 5000 });
+    await continueButton.click();
+
+    // === Step 10: Should redirect to main page ===
+    await page.waitForURL("/", { timeout: 15000 });
+
+    // === Step 11: Wait for WebRTC connection ===
+    await waitForWebRTCReady(page, 45000);
+    await wakeDisplay(page);
+    await waitForVideoStream(page, 45000);
+
+    // === Step 12: Verify video, mouse, and keyboard all work ===
+    await verifyHidAndVideo(page);
+
+    console.log("✓ Config reset and welcome screen flow completed successfully");
+    console.log("✓ Video stream is active");
+    console.log("✓ Mouse is working");
+    console.log("✓ Keyboard is working");
+  });
+});
+

--- a/ui/e2e/hdmi-sleep-reboot.spec.ts
+++ b/ui/e2e/hdmi-sleep-reboot.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect } from "@playwright/test";
+
+import { waitForWebRTCReady, waitForVideoStream, wakeDisplay, verifyHidAndVideo } from "./helpers";
+
+// Time to wait for device to reboot (ms)
+const REBOOT_DELAY = 15000;
+
+// Time to wait for settings to apply (ms)
+const SETTINGS_APPLY_DELAY = 1000;
+
+test.describe("HDMI Sleep Mode and Reboot Tests", () => {
+  // This test involves rebooting the device, so use a longer timeout
+  test.setTimeout(180000); // 3 minutes
+
+  // Restore HDMI sleep mode to its original state after tests (optional cleanup)
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      await page.goto("/settings/hardware");
+      await page.waitForLoadState("networkidle");
+      // We don't necessarily need to restore since we're just disabling it
+      // The test leaves it in a known state (disabled)
+    } finally {
+      await page.close();
+    }
+  });
+
+  test("disable HDMI sleep mode, reboot, and verify HID/video works", async ({ page }) => {
+    // === Step 1: Navigate to hardware settings ===
+    await page.goto("/settings/hardware");
+    await page.waitForLoadState("networkidle");
+
+    // === Step 2: Find and disable HDMI sleep mode checkbox ===
+    // SettingsItem renders as a <label> containing both the title and the checkbox
+    // Find the label containing "HDMI Sleep Mode" text and get its checkbox
+    const hdmiSleepLabel = page.locator("label").filter({ hasText: "HDMI Sleep Mode" });
+    await expect(hdmiSleepLabel).toBeVisible({ timeout: 10000 });
+    const hdmiSleepCheckbox = hdmiSleepLabel.locator('input[type="checkbox"]');
+    await expect(hdmiSleepCheckbox).toBeVisible({ timeout: 5000 });
+
+    // Check if it's currently enabled and disable it
+    const isChecked = await hdmiSleepCheckbox.isChecked();
+    if (isChecked) {
+      await hdmiSleepCheckbox.click();
+      await page.waitForTimeout(SETTINGS_APPLY_DELAY);
+      console.log("✓ Disabled HDMI sleep mode");
+    } else {
+      console.log("✓ HDMI sleep mode was already disabled");
+    }
+
+    // === Step 3: Navigate to reboot page ===
+    await page.goto("/settings/general/reboot");
+    await page.waitForLoadState("networkidle");
+
+    // === Step 4: Confirm reboot by clicking "Yes" button ===
+    const yesButton = page.getByRole("button", { name: /Yes/i });
+    await expect(yesButton).toBeVisible({ timeout: 5000 });
+    await yesButton.click();
+
+    console.log("✓ Reboot initiated, waiting for device to come back online...");
+
+    // === Step 5: Wait for device to reboot ===
+    await page.waitForTimeout(REBOOT_DELAY);
+
+    // === Step 6: Navigate back to main page ===
+    // The device may redirect automatically, but we explicitly go to "/" to be sure
+    await page.goto("/");
+
+    // === Step 7: Wait for WebRTC connection with extended timeout ===
+    // After reboot, it may take longer to establish connection
+    // Retry navigating to the page until WebRTC is ready
+    let connected = false;
+    const maxRetries = 10;
+    for (let i = 0; i < maxRetries && !connected; i++) {
+      try {
+        await page.goto("/", { timeout: 10000 });
+        await waitForWebRTCReady(page, 10000);
+        connected = true;
+      } catch {
+        console.log(`Retry ${i + 1}/${maxRetries}: Device not ready yet...`);
+        await page.waitForTimeout(3000);
+      }
+    }
+    if (!connected) {
+      throw new Error("Device did not come back online after reboot");
+    }
+
+    await waitForWebRTCReady(page, 30000);
+    await wakeDisplay(page);
+    await waitForVideoStream(page, 45000);
+
+    // === Step 8: Verify video, mouse, and keyboard all work ===
+    await verifyHidAndVideo(page);
+
+    console.log("✓ Device rebooted successfully");
+    console.log("✓ Video stream is active");
+    console.log("✓ Mouse is working");
+    console.log("✓ Keyboard is working");
+  });
+});

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -288,6 +288,102 @@ export function hidToPixelCoords(
   };
 }
 
+// HID absolute coordinate range is 0-32767
+const HID_MAX = 32767;
+
+// Region size for cursor detection (pixels around the expected cursor position)
+const CAPTURE_REGION_SIZE = 80;
+
+// Minimum video dimensions to consider valid (sanity check)
+const MIN_VIDEO_DIMENSION = 100;
+
+/**
+ * Verify keyboard works using LED round-trip.
+ * Taps CAPS_LOCK and verifies the LED state toggles.
+ *
+ * @param page - Playwright page object
+ */
+export async function verifyKeyboardWorks(page: Page): Promise<void> {
+  // Get initial CAPS_LOCK state
+  const initialState = await getLedState(page);
+  expect(initialState, "LED state should be available").not.toBeNull();
+  const initialCapsLock = initialState!.caps_lock;
+
+  // Toggle CAPS_LOCK
+  await tapKey(page, HID_KEY.CAPS_LOCK);
+  await waitForLedState(page, "caps_lock", !initialCapsLock);
+
+  // Verify the state changed
+  const newState = await getLedState(page);
+  expect(newState!.caps_lock, "CAPS_LOCK should have toggled").toBe(!initialCapsLock);
+
+  // Restore original state
+  await tapKey(page, HID_KEY.CAPS_LOCK);
+  await waitForLedState(page, "caps_lock", initialCapsLock);
+}
+
+/**
+ * Verify mouse works using fingerprint comparison.
+ * Moves the cursor and verifies the video region changes.
+ *
+ * @param page - Playwright page object
+ */
+export async function verifyMouseWorks(page: Page): Promise<void> {
+  // Get video dimensions
+  const dimensions = await getVideoStreamDimensions(page);
+  expect(dimensions, "Video stream dimensions should be available").not.toBeNull();
+  const { width: videoWidth, height: videoHeight } = dimensions!;
+  expect(videoWidth, `Video width should be at least ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThan(MIN_VIDEO_DIMENSION);
+  expect(videoHeight, `Video height should be at least ${MIN_VIDEO_DIMENSION}px`).toBeGreaterThan(MIN_VIDEO_DIMENSION);
+
+  // Calculate center position
+  const hidCenter = Math.floor(HID_MAX / 2);
+  const centerPixel = hidToPixelCoords(hidCenter, hidCenter, videoWidth, videoHeight);
+
+  // Calculate capture region bounds (centered around the target position)
+  const regionX = Math.max(0, centerPixel.x - CAPTURE_REGION_SIZE / 2);
+  const regionY = Math.max(0, centerPixel.y - CAPTURE_REGION_SIZE / 2);
+  const regionWidth = Math.min(CAPTURE_REGION_SIZE, videoWidth - regionX);
+  const regionHeight = Math.min(CAPTURE_REGION_SIZE, videoHeight - regionY);
+
+  // Move mouse to center and capture
+  await sendAbsMouseMove(page, hidCenter, hidCenter);
+  await page.waitForTimeout(100);
+  const fpBefore = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
+  expect(fpBefore, "Failed to capture fingerprint with cursor at center").not.toBeNull();
+
+  // Move mouse to corner and capture
+  await sendAbsMouseMove(page, 0, 0);
+  await page.waitForTimeout(100);
+  const fpAfter = await captureVideoRegionFingerprint(page, regionX, regionY, regionWidth, regionHeight);
+  expect(fpAfter, "Failed to capture fingerprint after cursor moved away").not.toBeNull();
+
+  // Verify the regions differ (cursor moved)
+  const distance = fingerprintDistance(fpBefore!, fpAfter!);
+  expect(
+    distance,
+    `Cursor movement should cause significant visual change (distance=${distance}, expected >10) — mouse HID path may be broken`,
+  ).toBeGreaterThan(10);
+}
+
+/**
+ * Combined verification for video stream, mouse, and keyboard.
+ * This is a convenience function that runs all three verifications.
+ *
+ * @param page - Playwright page object
+ */
+export async function verifyHidAndVideo(page: Page): Promise<void> {
+  // Verify video stream is active
+  const isVideoActive = await page.evaluate(() => window.__kvmTestHooks?.isVideoStreamActive());
+  expect(isVideoActive, "Video stream should be active").toBe(true);
+
+  // Verify mouse works
+  await verifyMouseWorks(page);
+
+  // Verify keyboard works
+  await verifyKeyboardWorks(page);
+}
+
 // TypeScript declarations for the test hooks on window
 declare global {
   interface Window {

--- a/ui/e2e/https-mode.spec.ts
+++ b/ui/e2e/https-mode.spec.ts
@@ -1,0 +1,118 @@
+import { test, expect } from "@playwright/test";
+
+import {
+  waitForWebRTCReady,
+  waitForVideoStream,
+  wakeDisplay,
+  verifyHidAndVideo,
+} from "./helpers";
+
+// Time to wait for TLS settings to apply (ms)
+const TLS_APPLY_DELAY = 2000;
+
+test.describe("HTTPS Mode Tests", () => {
+  // This test modifies TLS settings, so use a longer timeout
+  test.setTimeout(180000); // 3 minutes
+
+  // Restore TLS mode to disabled after tests complete
+  test.afterAll(async ({ browser }) => {
+    const page = await browser.newPage();
+    try {
+      // Try HTTP first (the original URL)
+      const baseUrl = process.env.JETKVM_URL || "http://localhost";
+      await page.goto(`${baseUrl}/settings/access`);
+      await page.waitForLoadState("networkidle");
+
+      // Find the TLS mode dropdown
+      const tlsDropdown = page.locator("select").filter({
+        has: page.locator('option[value="self-signed"]'),
+      });
+
+      if (await tlsDropdown.isVisible({ timeout: 5000 })) {
+        await tlsDropdown.selectOption("disabled");
+        await page.waitForTimeout(TLS_APPLY_DELAY);
+        console.log("[HTTPS cleanup] Restored TLS mode to disabled");
+      } else {
+        console.warn("[HTTPS cleanup] TLS dropdown not visible, skipping restoration");
+      }
+    } catch (error) {
+      console.warn("[HTTPS cleanup] Failed to restore TLS settings:", error);
+    } finally {
+      await page.close();
+    }
+  });
+
+  test("enable self-signed HTTPS and verify HID/video works", async ({ page, browser }) => {
+    // === Step 1: Navigate to access settings ===
+    await page.goto("/settings/access");
+    await page.waitForLoadState("networkidle");
+
+    // === Step 2: Find the TLS mode dropdown ===
+    // The dropdown has options: disabled, self-signed, custom
+    const tlsDropdown = page.locator("select").filter({
+      has: page.locator('option[value="self-signed"]'),
+    });
+    await expect(tlsDropdown).toBeVisible({ timeout: 10000 });
+    await expect(tlsDropdown).toBeEnabled({ timeout: 10000 });
+
+    // === Step 3: Change to self-signed mode ===
+    await tlsDropdown.selectOption("self-signed");
+    await page.waitForTimeout(TLS_APPLY_DELAY);
+
+    console.log("✓ Enabled self-signed HTTPS mode");
+
+    // === Step 4: Extract device hostname/IP from current URL ===
+    const currentUrl = new URL(page.url());
+    const deviceHost = currentUrl.hostname;
+    const httpsUrl = `https://${deviceHost}:443`;
+
+    console.log(`✓ Will connect to ${httpsUrl}`);
+
+    // === Step 5: Create new browser context with ignoreHTTPSErrors ===
+    // This allows Playwright to accept self-signed certificates
+    const httpsContext = await browser.newContext({
+      ignoreHTTPSErrors: true,
+    });
+    const httpsPage = await httpsContext.newPage();
+
+    try {
+      // === Step 6: Navigate to HTTPS version ===
+      await httpsPage.goto(httpsUrl, { timeout: 30000 });
+      await httpsPage.waitForLoadState("networkidle");
+
+      console.log("✓ Successfully connected via HTTPS");
+
+      // === Step 7: Wait for WebRTC connection ===
+      await waitForWebRTCReady(httpsPage, 45000);
+      await wakeDisplay(httpsPage);
+      await waitForVideoStream(httpsPage, 45000);
+
+      // === Step 8: Verify video, mouse, and keyboard all work ===
+      await verifyHidAndVideo(httpsPage);
+
+      console.log("✓ HTTPS mode working correctly");
+      console.log("✓ Video stream is active via HTTPS");
+      console.log("✓ Mouse is working via HTTPS");
+      console.log("✓ Keyboard is working via HTTPS");
+    } finally {
+      // Clean up the HTTPS context
+      await httpsPage.close();
+      await httpsContext.close();
+    }
+
+    // === Step 9: Restore TLS mode to disabled using the original HTTP page ===
+    // Navigate back to settings to restore (this happens in afterAll too, but let's be thorough)
+    await page.goto("/settings/access");
+    await page.waitForLoadState("networkidle");
+
+    const tlsDropdownRestore = page.locator("select").filter({
+      has: page.locator('option[value="self-signed"]'),
+    });
+    await expect(tlsDropdownRestore).toBeVisible({ timeout: 10000 });
+    await tlsDropdownRestore.selectOption("disabled");
+    await page.waitForTimeout(TLS_APPLY_DELAY);
+
+    console.log("✓ Restored TLS mode to disabled");
+  });
+});
+


### PR DESCRIPTION
## Summary

- **Add 3 new E2E integration tests** that verify end-to-end flows including config reset with welcome screen walkthrough, HDMI sleep mode toggle with reboot, and HTTPS mode with self-signed certificate support
- **Add shared helper functions** (`verifyKeyboardWorks`, `verifyMouseWorks`, `verifyHidAndVideo`) to helpers.ts for reusable HID and video verification across tests

## New Tests

1. **config-reset.spec.ts** - Enables troubleshooting mode, resets config, walks through welcome screen (no password), verifies mouse/keyboard/video work
2. **hdmi-sleep-reboot.spec.ts** - Disables HDMI sleep mode, reboots device, waits for reconnection, verifies mouse/keyboard/video work  
3. **https-mode.spec.ts** - Enables self-signed HTTPS, connects via port 443 with `ignoreHTTPSErrors`, verifies mouse/keyboard/video work

## Testing

All 10 E2E tests pass (including 7 existing tests).