### PR TITLE
Fix nil pointer dereference in OnICECandidate during legacy signaling

### DIFF
--- a/webrtc.go
+++ b/webrtc.go
@@ -369,7 +369,7 @@ func newSession(config SessionConfig) (*Session, error) {
 
 	peerConnection.OnICECandidate(func(candidate *webrtc.ICECandidate) {
 		scopedLogger.Info().Interface("candidate", candidate).Msg("WebRTC peerConnection has a new ICE candidate")
-		if candidate != nil {
+		if candidate != nil && config.ws != nil {
 			err := wsjson.Write(context.Background(), config.ws, gin.H{"type": "new-ice-candidate", "data": candidate.ToJSON()})
 			if err != nil {
 				scopedLogger.Warn().Err(err).Msg("failed to write new-ice-candidate to WebRTC signaling channel")


### PR DESCRIPTION
Fixes #1085 

### Summary
- Adds nil check for websocket connection before attempting to send ICE candidates, preventing crashes when using the legacy HTTP signaling endpoint during OTA updates. The legacy path includes ICE candidates in the initial SDP offer/answer and doesn't support trickle ICE over WebSocket.

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
