### PR TITLE
Fix assigning static IPv6 address to network address (#1082)

### DIFF
--- a/pkg/nmlite/link/utils.go
+++ b/pkg/nmlite/link/utils.go
@@ -40,12 +40,14 @@ func ParseIPv4Netmask(address, netmask string) (*net.IPNet, error) {
 
 // ParseIPv6Prefix parses an IPv6 address and prefix length
 func ParseIPv6Prefix(address string, prefixLength int) (*net.IPNet, error) {
+	var ipNet net.IPMask = nil
 	if strings.Contains(address, "/") {
-		_, ipNet, err := net.ParseCIDR(address)
+		_, ipCidr, err := net.ParseCIDR(address)
 		if err != nil {
 			return nil, fmt.Errorf("invalid IPv6 address: %s", address)
 		}
-		return ipNet, nil
+		address = address[:strings.Index(address, "/")]
+		ipNet = ipCidr.Mask
 	}
 
 	ip := net.ParseIP(address)
@@ -56,13 +58,17 @@ func ParseIPv6Prefix(address string, prefixLength int) (*net.IPNet, error) {
 		return nil, fmt.Errorf("not an IPv6 address: %s", address)
 	}
 
-	if prefixLength < 0 || prefixLength > 128 {
+	if ipNet == nil && (prefixLength < 0 || prefixLength > 128) {
 		return nil, fmt.Errorf("invalid IPv6 prefix length: %d (must be 0-128)", prefixLength)
+	}
+
+	if ipNet == nil {
+		ipNet = net.CIDRMask(prefixLength, 128)
 	}
 
 	return &net.IPNet{
 		IP:   ip,
-		Mask: net.CIDRMask(prefixLength, 128),
+		Mask: ipNet,
 	}, nil
 }
 


### PR DESCRIPTION
Fixes #1082

### Summary
- Currently, when you set a static IPv6, JetKVM sets it self to the network address.
- Static IPv6 addresses were being set to the output of `net.ParseCIDR()`
- `net.ParseCIDR()` only returns the network address, not the host address.
- Instead, we use `net.ParseCIDR()` to obtain the mask, then strip away the IPv6 prefix length and continue to parse the IP address.


### Checklist
- [ X ] Ran `make test_e2e` locally and passed
- [ X ] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [ X ] One problem per PR (no unrelated changes)
- [ X ] Lints pass; CI green
