### PR TITLE
Fix TLS server to obey LocalLoopbackOnly setting (#1090)

### DIFF
--- a/web.go
+++ b/web.go
@@ -564,12 +564,9 @@ func basicAuthProtectedMiddleware(requireDeveloperMode bool) gin.HandlerFunc {
 	}
 }
 
-func RunWebServer() {
-	r := setupRouter()
-
+func getBindAddress(listenPort int) string {
 	// Determine the binding address based on the config
 	var bindAddress string
-	listenPort := 80 // default port
 	useIPv4 := config.NetworkConfig.IPv4Mode.String != "disabled"
 	useIPv6 := config.NetworkConfig.IPv6Mode.String != "disabled"
 
@@ -590,6 +587,14 @@ func RunWebServer() {
 			bindAddress = fmt.Sprintf("[::]:%d", listenPort)
 		}
 	}
+	return bindAddress
+}
+
+func RunWebServer() {
+	r := setupRouter()
+
+	// Determine the binding address based on the config
+	bindAddress := getBindAddress(80) // default port
 
 	logger.Info().Str("bindAddress", bindAddress).Bool("loopbackOnly", config.LocalLoopbackOnly).Msg("Starting web server")
 	if err := r.Run(bindAddress); err != nil {

--- a/web_tls.go
+++ b/web_tls.go
@@ -14,7 +14,6 @@ import (
 
 const (
 	tlsStorePath                     = "/userdata/jetkvm/tls"
-	webSecureListen                  = ":443"
 	webSecureSelfSignedDefaultDomain = "jetkvm.local"
 	webSecureSelfSignedCAName        = "JetKVM Self-Signed CA"
 	webSecureSelfSignedOrganization  = "JetKVM"
@@ -161,8 +160,11 @@ func runWebSecureServer() {
 
 	r := setupRouter()
 
+	// Determine the binding address based on the config
+	bindAddress := getBindAddress(443)
+
 	server := &http.Server{
-		Addr:    webSecureListen,
+		Addr:    bindAddress,
 		Handler: r,
 		TLSConfig: &tls.Config{
 			MaxVersion:       tls.VersionTLS13,
@@ -170,7 +172,7 @@ func runWebSecureServer() {
 			GetCertificate:   getCertificate,
 		},
 	}
-	websecureLogger.Info().Str("listen", webSecureListen).Msg("Starting websecure server")
+	websecureLogger.Info().Str("bindAddress", bindAddress).Bool("loopbackOnly", config.LocalLoopbackOnly).Msg("Starting websecure server")
 
 	go func() {
 		for range stopTLS {


### PR DESCRIPTION
Fixes #1090

### Summary
- TLS Webserver now obeys the LocalLoopbackOnly setting
- Move bindAddress logic to separate function used by the HTTP and TLS server

### Checklist
- [ X ] Ran `make test_e2e` locally and passed
- [ X ] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [ X ] One problem per PR (no unrelated changes)
- [ X ] Lints pass; CI green
