### PR TITLE
Prevent mDNS queries by ICE when mDNS is disabled in config (#1094)

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -454,7 +454,7 @@ func handleSessionRequest(
 		LocalIP:    req.IP,
 		ICEServers: req.ICEServers,
 		Logger:     scopedLogger,
-		NoMDNS:     config.NetworkConfig.MDNSMode.String == "disabled",
+		MDNSMode:   config.NetworkConfig.MDNSMode.String,
 	})
 	if err != nil {
 		_ = wsjson.Write(context.Background(), c, gin.H{"error": err})

--- a/cloud.go
+++ b/cloud.go
@@ -454,6 +454,7 @@ func handleSessionRequest(
 		LocalIP:    req.IP,
 		ICEServers: req.ICEServers,
 		Logger:     scopedLogger,
+		NoMDNS:     config.NetworkConfig.MDNSMode.String == "disabled",
 	})
 	if err != nil {
 		_ = wsjson.Write(context.Background(), c, gin.H{"error": err})

--- a/web.go
+++ b/web.go
@@ -212,7 +212,7 @@ func handleWebRTCSession(c *gin.Context) {
 		return
 	}
 
-	session, err := newSession(SessionConfig{})
+	session, err := newSession(SessionConfig{NoMDNS: config.NetworkConfig.MDNSMode.String == "disabled"})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
 		return

--- a/web.go
+++ b/web.go
@@ -212,7 +212,7 @@ func handleWebRTCSession(c *gin.Context) {
 		return
 	}
 
-	session, err := newSession(SessionConfig{NoMDNS: config.NetworkConfig.MDNSMode.String == "disabled"})
+	session, err := newSession(SessionConfig{MDNSMode: config.NetworkConfig.MDNSMode.String})
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
 		return

--- a/webrtc.go
+++ b/webrtc.go
@@ -124,7 +124,7 @@ type SessionConfig struct {
 	IsCloud    bool
 	ws         *websocket.Conn
 	Logger     *zerolog.Logger
-	NoMDNS     bool
+	MDNSMode   string
 }
 
 func (s *Session) ExchangeOffer(offerStr string) (string, error) {
@@ -252,7 +252,18 @@ func newSession(config SessionConfig) (*Session, error) {
 		LoggerFactory: logging.GetPionDefaultLoggerFactory(),
 	}
 
-	if config.NoMDNS {
+	mDNSNetworkTypes := make([]webrtc.NetworkType, 0)
+	if config.MDNSMode == "auto" || config.MDNSMode == "ipv4_only" {
+		mDNSNetworkTypes = append(mDNSNetworkTypes, webrtc.NetworkTypeUDP4)
+	}
+	if config.MDNSMode == "auto" || config.MDNSMode == "ipv6_only" {
+		mDNSNetworkTypes = append(mDNSNetworkTypes, webrtc.NetworkTypeUDP6)
+	}
+
+	if len(mDNSNetworkTypes) > 0 {
+		webrtcSettingEngine.SetNetworkTypes(mDNSNetworkTypes)
+		webrtcSettingEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryOnly)
+	} else {
 		webrtcSettingEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
 	}
 

--- a/webrtc.go
+++ b/webrtc.go
@@ -16,6 +16,7 @@ import (
 	"github.com/jetkvm/kvm/internal/hidrpc"
 	"github.com/jetkvm/kvm/internal/logging"
 	"github.com/jetkvm/kvm/internal/usbgadget"
+	"github.com/pion/ice/v4"
 	"github.com/pion/webrtc/v4"
 	"github.com/rs/zerolog"
 )
@@ -123,6 +124,7 @@ type SessionConfig struct {
 	IsCloud    bool
 	ws         *websocket.Conn
 	Logger     *zerolog.Logger
+	NoMDNS     bool
 }
 
 func (s *Session) ExchangeOffer(offerStr string) (string, error) {
@@ -249,6 +251,11 @@ func newSession(config SessionConfig) (*Session, error) {
 	webrtcSettingEngine := webrtc.SettingEngine{
 		LoggerFactory: logging.GetPionDefaultLoggerFactory(),
 	}
+
+	if config.NoMDNS {
+		webrtcSettingEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)
+	}
+
 	iceServer := webrtc.ICEServer{}
 
 	var scopedLogger *zerolog.Logger


### PR DESCRIPTION
Fixes #1094

### Summary
- Pass whether mDNS is enabled down to the WebRTC session
- If it is disable set ICE Multicast DNS Mode to disabled
- Prevents mDNS query spam when a client is connected to JetKVM and mDNS is set to disabled

### Checklist
- [ X ] Ran `make test_e2e` locally and passed
- [ X ] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [ X ] One problem per PR (no unrelated changes)
- [ X ] Lints pass; CI green
