### PR TITLE
Fix DNS configuration always flagged as changed when applying configuration (#1100)

### DIFF
--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -258,7 +258,7 @@ export default function SettingsNetworkRoute() {
         });
       }
 
-      if (dirty.ipv4_static?.dns) {
+      if (dirty.ipv4_static?.dns?.every(dirty => dirty)) {
         changes.push({
           label: m.network_ipv4_dns(),
           from: initialSettingsRef.current?.ipv4_static?.dns.join(", ").toString() ?? "",
@@ -290,7 +290,7 @@ export default function SettingsNetworkRoute() {
         });
       }
 
-      if (dirty.ipv6_static?.dns) {
+      if (dirty.ipv6_static?.dns?.every(dirty => dirty)) {
         changes.push({
           label: m.network_ipv6_dns(),
           from: initialSettingsRef.current?.ipv6_static?.dns.join(", ").toString() ?? "",


### PR DESCRIPTION
Fixes #1100 

### Summary
- When checking if the IPv4 and IPv6 DNS fields are dirty, check all of the values inside the array as flagged as dirty. 
- The DNS fields are arrays, not single strings

### Checklist
- [ X ] Ran `make test_e2e` locally and passed
- [ X ] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [ X ] One problem per PR (no unrelated changes)
- [ X ] Lints pass; CI green
