### PR TITLE
Fix flaky E2E OTA test

### DIFF
--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -165,7 +165,7 @@ export interface RTCState {
   appendDiskDataChannelStats: (stats: RTCDataChannelStats) => void;
 
   terminalChannel: RTCDataChannel | null;
-  setTerminalChannel: (channel: RTCDataChannel) => void;
+  setTerminalChannel: (channel: RTCDataChannel | null) => void;
 }
 
 export const useRTCStore = create<RTCState>(set => ({

--- a/ui/src/keyboardLayouts.ts
+++ b/ui/src/keyboardLayouts.ts
@@ -39,7 +39,7 @@ import { nb_NO } from "@/keyboardLayouts/nb_NO";
 import { sv_SE } from "@/keyboardLayouts/sv_SE";
 import { da_DK } from "@/keyboardLayouts/da_DK";
 import { ja_JP } from "@/keyboardLayouts/ja_JP";
-import { sl_SI } from "@/keyboardLayouts/sl_SI"
+import { sl_SI } from "@/keyboardLayouts/sl_SI";
 
 export const keyboards: KeyboardLayout[] = [
   cs_CZ,

--- a/ui/src/keyboardLayouts/sl_SI.ts
+++ b/ui/src/keyboardLayouts/sl_SI.ts
@@ -1,6 +1,6 @@
-import { KeyboardLayout, KeyCombo } from "../keyboardLayouts"
+import { KeyboardLayout, KeyCombo } from "../keyboardLayouts";
 
-import { en_US } from "./en_US" // for fallback of keyDisplayMap, modifierDisplayMap, and virtualKeyboard
+import { en_US } from "./en_US"; // for fallback of keyDisplayMap, modifierDisplayMap, and virtualKeyboard
 
 const name = "Slovenian";
 const isoCode = "sl-SI";
@@ -9,10 +9,10 @@ export const chars = {
   A: { key: "KeyA", shift: true },
   B: { key: "KeyB", shift: true },
   C: { key: "KeyC", shift: true },
-  "Č": { key: "Semicolon", shift: true },
-  "Ć": { key: "Quote", shift: true },
+  Č: { key: "Semicolon", shift: true },
+  Ć: { key: "Quote", shift: true },
   D: { key: "KeyD", shift: true },
-  "Đ": { key: "BracketRight", shift: true },
+  Đ: { key: "BracketRight", shift: true },
   E: { key: "KeyE", shift: true },
   F: { key: "KeyF", shift: true },
   G: { key: "KeyG", shift: true },
@@ -28,7 +28,7 @@ export const chars = {
   Q: { key: "KeyQ", shift: true },
   R: { key: "KeyR", shift: true },
   S: { key: "KeyS", shift: true },
-  "Š": { key: "BracketLeft", shift: true },
+  Š: { key: "BracketLeft", shift: true },
   T: { key: "KeyT", shift: true },
   U: { key: "KeyU", shift: true },
   V: { key: "KeyV", shift: true },
@@ -36,14 +36,14 @@ export const chars = {
   X: { key: "KeyX", shift: true },
   Y: { key: "KeyZ", shift: true },
   Z: { key: "KeyY", shift: true },
-  "Ž": { key: "Backslash", shift: true },
+  Ž: { key: "Backslash", shift: true },
   a: { key: "KeyA" },
   b: { key: "KeyB" },
   c: { key: "KeyC" },
-  "č": { key: "Semicolon"},
-  "ć": { key: "Quote"},
+  č: { key: "Semicolon" },
+  ć: { key: "Quote" },
   d: { key: "KeyD" },
-  "đ": { key: "BracketRight"},
+  đ: { key: "BracketRight" },
   e: { key: "KeyE" },
   f: { key: "KeyF" },
   g: { key: "KeyG" },
@@ -59,7 +59,7 @@ export const chars = {
   q: { key: "KeyQ" },
   r: { key: "KeyR" },
   s: { key: "KeyS" },
-  "š": { key: "BracketLeft"},
+  š: { key: "BracketLeft" },
   t: { key: "KeyT" },
   u: { key: "KeyU" },
   v: { key: "KeyV" },
@@ -67,15 +67,15 @@ export const chars = {
   x: { key: "KeyX" },
   y: { key: "KeyZ" },
   z: { key: "KeyY" },
-  "ž": { key: "Backslash"},
+  ž: { key: "Backslash" },
   1: { key: "Digit1" },
   "!": { key: "Digit1", shift: true },
   2: { key: "Digit2" },
-  "\"": { key: "Digit2", shift: true },
+  '"': { key: "Digit2", shift: true },
   3: { key: "Digit3" },
   "#": { key: "Digit3", shift: true },
   4: { key: "Digit4" },
-  "$": { key: "Digit4", shift: true },
+  $: { key: "Digit4", shift: true },
   5: { key: "Digit5" },
   "%": { key: "Digit5", shift: true },
   6: { key: "Digit6" },
@@ -100,10 +100,10 @@ export const chars = {
   ".": { key: "Period" },
   ":": { key: "Period", shift: true },
   "-": { key: "Slash" },
-  "_": { key: "Slash", shift: true },
+  _: { key: "Slash", shift: true },
 
   "~": { key: "Digit1", shift: true },
-  "ˇ": { key: "Digit2", shift: true },
+  ˇ: { key: "Digit2", shift: true },
   "^": { key: "Digit3", shift: true },
   "˘": { key: "Digit4", shift: true },
   "°": { key: "Digit5", shift: true },
@@ -121,9 +121,9 @@ export const chars = {
   "×": { key: "BracketRight", AltGr: true },
   "[": { key: "KeyF", AltGr: true },
   "]": { key: "KeyG", AltGr: true },
-  "ł": { key: "KeyK", AltGr: true },
-  "Ł": { key: "KeyL", AltGr: true },
-  "ß": { key: "Quote", AltGr: true },
+  ł: { key: "KeyK", AltGr: true },
+  Ł: { key: "KeyL", AltGr: true },
+  ß: { key: "Quote", AltGr: true },
   "¤": { key: "Backslash", AltGr: true },
   "@": { key: "KeyV", AltGr: true },
   "{": { key: "KeyB", AltGr: true },
@@ -144,7 +144,7 @@ export const chars = {
   Break: { key: "Pause", shift: true },
   Insert: { key: "Insert" },
   Delete: { key: "Delete" },
-} as Record<string, KeyCombo>
+} as Record<string, KeyCombo>;
 
 export const sl_SI: KeyboardLayout = {
   isoCode: isoCode,
@@ -153,5 +153,5 @@ export const sl_SI: KeyboardLayout = {
   // TODO need to localize these maps and layouts
   keyDisplayMap: en_US.keyDisplayMap,
   modifierDisplayMap: en_US.modifierDisplayMap,
-  virtualKeyboard: en_US.virtualKeyboard
+  virtualKeyboard: en_US.virtualKeyboard,
 };

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -134,6 +134,8 @@ export default function KvmIdRoute() {
     setRpcHidUnreliableNonOrderedChannel,
     setRpcHidUnreliableChannel,
     setRpcHidProtocolVersion,
+    terminalChannel,
+    setTerminalChannel,
   } = useRTCStore();
 
   const location = useLocation();
@@ -530,6 +532,15 @@ export default function KvmIdRoute() {
       setRpcHidUnreliableNonOrderedChannel(rpcHidUnreliableNonOrderedChannel);
     };
 
+    // Create terminal channel as part of initial offer
+    const terminalDataChannel = pc.createDataChannel("terminal");
+    terminalDataChannel.onclose = () => console.log("terminalDataChannel has closed");
+    terminalDataChannel.onerror = (ev: Event) =>
+      console.error(`Error on terminalDataChannel '${terminalDataChannel.label}': ${ev}`);
+    terminalDataChannel.onopen = () => {
+      setTerminalChannel(terminalDataChannel);
+    };
+
     setPeerConnection(pc);
   }, [
     cleanupAndStopReconnecting,
@@ -544,6 +555,7 @@ export default function KvmIdRoute() {
     setRpcHidUnreliableNonOrderedChannel,
     setRpcHidUnreliableChannel,
     setRpcHidProtocolVersion,
+    setTerminalChannel,
     setTransceiver,
   ]);
 
@@ -571,6 +583,7 @@ export default function KvmIdRoute() {
       setSidebarView(null);
       setPeerConnection(null);
       setRpcDataChannel(null);
+      setTerminalChannel(null);
     };
   }, [
     clearCandidatePairStats,
@@ -578,6 +591,7 @@ export default function KvmIdRoute() {
     setPeerConnection,
     setSidebarView,
     setRpcDataChannel,
+    setTerminalChannel,
   ]);
 
   // TURN server usage detection
@@ -820,20 +834,15 @@ export default function KvmIdRoute() {
     }
   }, [navigate, navigateTo, queryParams, setModalView, setQueryParams]);
 
-  // System update
-  const [kvmTerminal, setKvmTerminal] = useState<RTCDataChannel | null>(null);
+  // Serial console - still created via useEffect for now
   const [serialConsole, setSerialConsole] = useState<RTCDataChannel | null>(null);
 
   useEffect(() => {
     if (!peerConnection) return;
-    if (!kvmTerminal) {
-      setKvmTerminal(peerConnection.createDataChannel("terminal"));
-    }
-
     if (!serialConsole) {
       setSerialConsole(peerConnection.createDataChannel("serial"));
     }
-  }, [kvmTerminal, peerConnection, serialConsole]);
+  }, [peerConnection, serialConsole]);
 
   // Register E2E test hooks
   useEffect(() => {
@@ -847,10 +856,10 @@ export default function KvmIdRoute() {
       getMediaStream: () => useRTCStore.getState().mediaStream,
       getHdmiState: () => useVideoStore.getState().hdmiState,
       getVideoElement: () => useVideoStore.getState().videoElement,
-      getKvmTerminal: () => kvmTerminal,
+      getKvmTerminal: () => useRTCStore.getState().terminalChannel,
     });
     return cleanupTestHooks;
-  }, [handleKeyPress, handleAbsMouseMove, kvmTerminal]);
+  }, [handleKeyPress, handleAbsMouseMove]);
 
   const outlet = useOutlet();
   const onModalClose = useCallback(() => {
@@ -999,7 +1008,9 @@ export default function KvmIdRoute() {
         </Modal>
       </div>
 
-      {kvmTerminal && <Terminal type="kvm" dataChannel={kvmTerminal} title={m.kvm_terminal()} />}
+      {terminalChannel && (
+        <Terminal type="kvm" dataChannel={terminalChannel} title={m.kvm_terminal()} />
+      )}
 
       {serialConsole && (
         <Terminal type="serial" dataChannel={serialConsole} title={m.serial_console()} />


### PR DESCRIPTION
### Summary
- We use the terminal to emulate OTA Updates
- In certain cases, there would be a race condition, as the terminal data channel was setup in the device route, and not during WebRTC connection setup, like every other data channel.
- Ran `npm run lint:fix` the project too

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
