### PR TITLE
Improve failsafe handling 

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -133,6 +133,16 @@ func supervise() error {
 	}
 
 	if exiterr, ok := cmdErr.(*exec.ExitError); ok {
+		// Append crash info to the log file
+		fmt.Fprintf(logFile, "\n=== SUPERVISOR CRASH INFO ===\n")
+		fmt.Fprintf(logFile, "Timestamp: %s\n", time.Now().Format(time.RFC3339))
+		fmt.Fprintf(logFile, "Exit Code: %d\n", exiterr.ExitCode())
+		if ws, ok := exiterr.Sys().(syscall.WaitStatus); ok {
+			if ws.Signaled() {
+				fmt.Fprintf(logFile, "Signal: %s\n", ws.Signal())
+			}
+		}
+
 		createErrorDump(logFile)
 		os.Exit(exiterr.ExitCode())
 	}

--- a/failsafe.go
+++ b/failsafe.go
@@ -1,6 +1,7 @@
 package kvm
 
 import (
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -67,14 +68,15 @@ func checkFailsafeReason() {
 		}
 
 		// open the last crash log file and find if it contains the string "panic"
-		content, err := os.ReadFile(lastCrashPath)
+		// read only the last 50KB to avoid memory issues with large log files
+		content, err := readFileTail(lastCrashPath, 50*1024)
 		if err != nil {
 			l.Warn().Err(err).Msg("failed to read last crash log")
 			return
 		}
 
 		// unlink the last crash log file
-		failsafeCrashLog = string(content)
+		failsafeCrashLog = content
 		_ = os.Remove(lastCrashPath)
 
 		// TODO: read the goroutine stack trace and check which goroutine is panicking
@@ -90,6 +92,34 @@ func checkFailsafeReason() {
 			failsafeModeReason = "unknown"
 		}
 	})
+}
+
+// readFileTail reads at most maxBytes from the end of a file.
+// This prevents memory issues when reading potentially large log files.
+func readFileTail(path string, maxBytes int64) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	if err != nil {
+		return "", err
+	}
+
+	size := fi.Size()
+	if size > maxBytes {
+		if _, err := f.Seek(size-maxBytes, io.SeekStart); err != nil {
+			return "", err
+		}
+	}
+
+	data, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
 }
 
 func notifyFailsafeMode(session *Session) {

--- a/internal/mdns/mdns.go
+++ b/internal/mdns/mdns.go
@@ -130,10 +130,7 @@ func (m *MDNS) start(allowRestart bool) error {
 		}
 	}
 
-	mDNSConn, err := pion_mdns.Server(p4, p6, &pion_mdns.Config{
-		LocalNames:    newLocalNames,
-		LoggerFactory: logging.GetPionDefaultLoggerFactory(),
-	})
+	mDNSConn, err := pion_mdns.Server(p4, p6, &pion_mdns.Config{LocalNames: newLocalNames})
 
 	if err != nil {
 		scopeLogger.Warn().Err(err).Msg("failed to start mDNS server")

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -11,7 +11,6 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
-	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -21,9 +20,7 @@ import (
 	"github.com/rs/zerolog"
 	"go.bug.st/serial"
 
-	"github.com/jetkvm/kvm/internal/diagnostics"
 	"github.com/jetkvm/kvm/internal/hidrpc"
-	"github.com/jetkvm/kvm/internal/supervisor"
 	"github.com/jetkvm/kvm/internal/usbgadget"
 	"github.com/jetkvm/kvm/internal/utils"
 )
@@ -676,117 +673,6 @@ func rpcResetConfig() error {
 	return nil
 }
 
-func rpcGetDiagnostics() (string, error) {
-	var sb strings.Builder
-
-	// Section 1: Application log (last.log) - last 500 lines
-	// Read only the last 512KB to avoid memory issues with large log files
-	sb.WriteString("=== APPLICATION LOG ===\n")
-	if data, err := readFileTail(supervisor.AppLogPath, 512*1024); err == nil {
-		content := cleanLogOutput(data)
-		lines := strings.Split(content, "\n")
-		if len(lines) > 500 {
-			content = "... (truncated, showing last 500 lines)\n" + strings.Join(lines[len(lines)-500:], "\n")
-		}
-		sb.WriteString(content)
-	} else {
-		sb.WriteString(fmt.Sprintf("Error reading log: %v\n", err))
-	}
-	sb.WriteString("\n\n")
-
-	// Collect diagnostics to a buffer (not to last.log)
-	var diagBuf strings.Builder
-	diag := diagnostics.New(diagnostics.Options{
-		Writer: &diagBuf,
-		GetSessionInfo: func() diagnostics.SessionInfo {
-			info := diagnostics.SessionInfo{
-				ActiveSessions:    getActiveSessions(),
-				HasCurrentSession: currentSession != nil,
-			}
-			if currentSession != nil {
-				sessionInfo := currentSession.GetDiagnosticsInfo()
-				info.ICEConnectionState = sessionInfo.ICEConnectionState
-				info.SignalingState = sessionInfo.SignalingState
-				info.ConnectionState = sessionInfo.ConnectionState
-				info.DataChannels = sessionInfo.DataChannels
-			}
-			return info
-		},
-	})
-	diag.LogAll("download")
-
-	// Section 2: System diagnostics
-	sb.WriteString("=== SYSTEM DIAGNOSTICS ===\n")
-	sb.WriteString(diagBuf.String())
-	sb.WriteString("\n")
-
-	// Section 3: Recent crash dumps (sorted by time, newest first)
-	sb.WriteString("=== RECENT CRASH DUMPS ===\n")
-	if entries, err := os.ReadDir(supervisor.ErrorDumpDir); err == nil {
-		type fileInfo struct {
-			name    string
-			modTime time.Time
-		}
-		var crashFiles []fileInfo
-		for _, entry := range entries {
-			if entry.IsDir() || entry.Name() == supervisor.ErrorDumpLastFile {
-				continue
-			}
-			// Match jetkvm-*.log pattern
-			if !strings.HasPrefix(entry.Name(), "jetkvm-") || !strings.HasSuffix(entry.Name(), ".log") {
-				continue
-			}
-			info, err := entry.Info()
-			if err != nil {
-				continue
-			}
-			crashFiles = append(crashFiles, fileInfo{name: entry.Name(), modTime: info.ModTime()})
-		}
-		// Sort by modification time (newest first)
-		sort.Slice(crashFiles, func(i, j int) bool {
-			return crashFiles[i].modTime.After(crashFiles[j].modTime)
-		})
-
-		// Take 12 most recent crash dumps
-		if len(crashFiles) > 12 {
-			crashFiles = crashFiles[:12]
-		}
-
-		for i, cf := range crashFiles {
-			sb.WriteString(fmt.Sprintf("--- %s ---\n", cf.name))
-			crashPath := filepath.Join(supervisor.ErrorDumpDir, cf.name)
-			// Latest crash gets 512KB, older ones get 100KB
-			maxBytes := int64(100 * 1024)
-			if i == 0 {
-				maxBytes = 512 * 1024
-			}
-			if data, err := readFileTail(crashPath, maxBytes); err == nil {
-				sb.WriteString(cleanLogOutput(data))
-			} else {
-				sb.WriteString(fmt.Sprintf("Error reading: %v\n", err))
-			}
-			sb.WriteString("\n")
-		}
-		if len(crashFiles) == 0 {
-			sb.WriteString("No crash dumps found\n")
-		}
-	} else {
-		sb.WriteString(fmt.Sprintf("Error reading crash directory: %v\n", err))
-	}
-	sb.WriteString("\n")
-
-	// Section 4: Configuration
-	sb.WriteString("=== CONFIGURATION ===\n")
-	if data, err := os.ReadFile(configPath); err == nil {
-		sb.WriteString(string(data))
-	} else {
-		sb.WriteString(fmt.Sprintf("Error reading config: %v\n", err))
-	}
-	sb.WriteString("\n")
-
-	return sb.String(), nil
-}
-
 type DCPowerState struct {
 	IsOn         bool    `json:"isOn"`
 	Voltage      float64 `json:"voltage"`
@@ -1336,5 +1222,4 @@ var rpcHandlers = map[string]RPCHandler{
 	"setLocalLoopbackOnly":   {Func: rpcSetLocalLoopbackOnly, Params: []string{"enabled"}},
 	"getPublicIPAddresses":   {Func: rpcGetPublicIPAddresses, Params: []string{"refresh"}},
 	"checkPublicIPAddresses": {Func: rpcCheckPublicIPAddresses},
-	"getDiagnostics":         {Func: rpcGetDiagnostics},
 }

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -680,9 +680,10 @@ func rpcGetDiagnostics() (string, error) {
 	var sb strings.Builder
 
 	// Section 1: Application log (last.log) - last 500 lines
+	// Read only the last 512KB to avoid memory issues with large log files
 	sb.WriteString("=== APPLICATION LOG ===\n")
-	if data, err := os.ReadFile(supervisor.AppLogPath); err == nil {
-		content := cleanLogOutput(string(data))
+	if data, err := readFileTail(supervisor.AppLogPath, 512*1024); err == nil {
+		content := cleanLogOutput(data)
 		lines := strings.Split(content, "\n")
 		if len(lines) > 500 {
 			content = "... (truncated, showing last 500 lines)\n" + strings.Join(lines[len(lines)-500:], "\n")
@@ -719,17 +720,7 @@ func rpcGetDiagnostics() (string, error) {
 	sb.WriteString(diagBuf.String())
 	sb.WriteString("\n")
 
-	// Section 3: Last crash log
-	lastCrashPath := filepath.Join(supervisor.ErrorDumpDir, supervisor.ErrorDumpLastFile)
-	sb.WriteString("=== LAST CRASH LOG ===\n")
-	if data, err := os.ReadFile(lastCrashPath); err == nil {
-		sb.WriteString(cleanLogOutput(string(data)))
-	} else {
-		sb.WriteString(fmt.Sprintf("No crash log found: %v\n", err))
-	}
-	sb.WriteString("\n\n")
-
-	// Section 4: Recent crash dumps (excluding last-crash.log)
+	// Section 3: Recent crash dumps (sorted by time, newest first)
 	sb.WriteString("=== RECENT CRASH DUMPS ===\n")
 	if entries, err := os.ReadDir(supervisor.ErrorDumpDir); err == nil {
 		type fileInfo struct {
@@ -764,16 +755,13 @@ func rpcGetDiagnostics() (string, error) {
 		for i, cf := range crashFiles {
 			sb.WriteString(fmt.Sprintf("--- %s ---\n", cf.name))
 			crashPath := filepath.Join(supervisor.ErrorDumpDir, cf.name)
-			if data, err := os.ReadFile(crashPath); err == nil {
-				content := cleanLogOutput(string(data))
-				// First file is full, rest are last 50 lines
-				if i > 0 {
-					lines := strings.Split(content, "\n")
-					if len(lines) > 100 {
-						content = "... (truncated)\n" + strings.Join(lines[len(lines)-50:], "\n")
-					}
-				}
-				sb.WriteString(content)
+			// Latest crash gets 512KB, older ones get 100KB
+			maxBytes := int64(100 * 1024)
+			if i == 0 {
+				maxBytes = 512 * 1024
+			}
+			if data, err := readFileTail(crashPath, maxBytes); err == nil {
+				sb.WriteString(cleanLogOutput(data))
 			} else {
 				sb.WriteString(fmt.Sprintf("Error reading: %v\n", err))
 			}
@@ -787,7 +775,7 @@ func rpcGetDiagnostics() (string, error) {
 	}
 	sb.WriteString("\n")
 
-	// Section 5: Configuration
+	// Section 4: Configuration
 	sb.WriteString("=== CONFIGURATION ===\n")
 	if data, err := os.ReadFile(configPath); err == nil {
 		sb.WriteString(string(data))

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -208,7 +208,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonPropsType>(
 
 Button.displayName = "Button";
 
-type LinkPropsType = Pick<LinkProps, "to" | "target" | "reloadDocument"> &
+type LinkPropsType = Pick<LinkProps, "to" | "target" | "reloadDocument" | "download"> &
   React.ComponentProps<typeof ButtonContent> & { disabled?: boolean };
 export const LinkButton = ({ to, ...props }: LinkPropsType) => {
   const classes = cx(

--- a/ui/src/components/FailSafeModeOverlay.tsx
+++ b/ui/src/components/FailSafeModeOverlay.tsx
@@ -2,7 +2,7 @@ import { useState } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import { motion, AnimatePresence } from "framer-motion";
 
-import { Button } from "@components/Button";
+import { Button, LinkButton } from "@components/Button";
 import { GridCard } from "@components/Card";
 import { GitHubIcon } from "@components/Icons";
 import { useDeviceUiNavigation } from "@hooks/useAppNavigation";
@@ -10,7 +10,7 @@ import { useVersion } from "@hooks/useVersion";
 import { useDeviceStore } from "@hooks/stores";
 import notifications from "@/notifications";
 import { DOWNGRADE_VERSION } from "@/ui.config";
-import { callJsonRpc } from "@/utils/jsonrpc";
+import { sleep } from "../utils";
 
 interface FailSafeModeOverlayProps {
   reason: string;
@@ -55,38 +55,9 @@ export function FailSafeModeOverlay({ reason }: FailSafeModeOverlayProps) {
 
   const handleReportAndDownloadLogs = async () => {
     setIsDownloadingLogs(true);
+    await sleep(2000);
 
     try {
-      const response = await callJsonRpc<string>({
-        method: "getDiagnostics",
-        attemptTimeoutMs: 20000, // 20s - diagnostics collects a lot of data
-        maxAttempts: 1,
-      });
-
-      if (response.error) {
-        notifications.error(`Failed to get diagnostics: ${response.error.message}`);
-        return;
-      }
-
-      // Download logs
-      const logContent = response.result;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-      const filename = `jetkvm-recovery-${reason}-${timestamp}.txt`;
-
-      const blob = new Blob([logContent], { type: "text/plain" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      a.click();
-      await new Promise(resolve => setTimeout(resolve, 1000));
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-
-      notifications.success("Crash logs downloaded successfully");
-
       // Open GitHub issue
       const issueBody = `## Issue Description
 The \`${reason}\` process encountered an error and failsafe mode was activated.
@@ -97,11 +68,10 @@ The \`${reason}\` process encountered an error and failsafe mode was activated.
 **System Version:** ${systemVersion || "Unknown"}
 
 ## Logs
-Please attach the recovery logs file that was downloaded to your computer:
-\`${filename}\`
+Please attach the diagnostics ZIP file that was downloaded to your computer.
 
 > [!NOTE]
-> Please remove any sensitive information from the logs. The reports are public and can be viewed by anyone.
+> Please remove any sensitive information from the logs before attaching. The reports are public and can be viewed by anyone.
 
 ## Additional Context
 [Please describe what you were doing when this occurred]`;
@@ -114,7 +84,7 @@ Please attach the recovery logs file that was downloaded to your computer:
       window.open(issueUrl, "_blank");
     } catch (error) {
       notifications.error(
-        `Failed to get diagnostics: ${error instanceof Error ? error.message : "Request timed out"}`,
+        `Failed to download diagnostics: ${error instanceof Error ? error.message : "Unknown error"}`,
       );
     } finally {
       setIsDownloadingLogs(false);
@@ -147,9 +117,14 @@ Please attach the recovery logs file that was downloaded to your computer:
                   <p className="text-sm">{message}</p>
                 </div>
                 <div className="space-y-3">
-                  <div className="flex flex-wrap items-center gap-2">
-                    <Button
-                      onClick={handleReportAndDownloadLogs}
+                  <div
+                    className="flex flex-wrap items-center gap-2"
+                    onClick={handleReportAndDownloadLogs}
+                  >
+                    <LinkButton
+                      to="/diagnostics"
+                      reloadDocument
+                      download
                       theme="primary"
                       size="SM"
                       disabled={isDownloadingLogs}

--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -3,7 +3,7 @@ import { useCallback, useEffect, useState } from "react";
 import { useSettingsStore } from "@hooks/stores";
 import { JsonRpcError, JsonRpcResponse, useJsonRpc } from "@hooks/useJsonRpc";
 import { useDeviceUiNavigation } from "@hooks/useAppNavigation";
-import { Button } from "@components/Button";
+import { Button, LinkButton } from "@components/Button";
 import Checkbox, { CheckboxWithLabel } from "@components/Checkbox";
 import { ConfirmDialog } from "@components/ConfirmDialog";
 import { GridCard } from "@components/Card";
@@ -191,51 +191,6 @@ export default function SettingsAdvancedRoute() {
     applyLoopbackOnlyMode(true);
     setShowLoopbackWarning(false);
   }, [applyLoopbackOnlyMode, setShowLoopbackWarning]);
-
-  const handleDownloadDiagnostics = useCallback(async () => {
-    setDiagnosticsLoading(true);
-
-    try {
-      const response = await callJsonRpc<string>({
-        method: "getDiagnostics",
-        attemptTimeoutMs: 20000, // 20s - diagnostics collects a lot of data
-        maxAttempts: 1,
-      });
-
-      if (response.error) {
-        notifications.error(
-          m.advanced_error_download_diagnostics({
-            error: response.error.data || m.unknown_error(),
-          }),
-        );
-        return;
-      }
-
-      const logContent = response.result;
-      const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
-      const filename = `jetkvm-diagnostics-${timestamp}.txt`;
-
-      const blob = new Blob([logContent], { type: "text/plain" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = filename;
-      document.body.appendChild(a);
-      a.click();
-      document.body.removeChild(a);
-      URL.revokeObjectURL(url);
-
-      notifications.success(m.advanced_success_download_diagnostics());
-    } catch (error) {
-      notifications.error(
-        m.advanced_error_download_diagnostics({
-          error: error instanceof Error ? error.message : m.unknown_error(),
-        }),
-      );
-    } finally {
-      setDiagnosticsLoading(false);
-    }
-  }, []);
 
   const handleVersionUpdateError = useCallback((error?: JsonRpcError | string) => {
     notifications.error(
@@ -533,13 +488,15 @@ export default function SettingsAdvancedRoute() {
               title={m.advanced_download_diagnostics_title()}
               description={m.advanced_download_diagnostics_description()}
             >
-              <Button
+              <LinkButton
+                to="/diagnostics"
+                reloadDocument
+                download
                 size="SM"
                 disabled={diagnosticsLoading}
                 theme="light"
                 text={m.advanced_download_diagnostics_button()}
                 loading={diagnosticsLoading}
-                onClick={handleDownloadDiagnostics}
               />
             </SettingsItem>
           </NestedSettingsGroup>

--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -17,7 +17,7 @@ import { isOnDevice } from "@/main";
 import notifications from "@/notifications";
 import { m } from "@localizations/messages.js";
 import { sleep } from "@/utils";
-import { callJsonRpc, checkUpdateComponents, UpdateComponents } from "@/utils/jsonrpc";
+import { checkUpdateComponents, UpdateComponents } from "@/utils/jsonrpc";
 import { SystemVersionInfo } from "@hooks/useVersion";
 
 import { FeatureFlag } from "../components/FeatureFlag";
@@ -38,7 +38,6 @@ export default function SettingsAdvancedRoute() {
   const [resetConfig, setResetConfig] = useState(false);
   const [versionChangeAcknowledged, setVersionChangeAcknowledged] = useState(false);
   const [customVersionUpdateLoading, setCustomVersionUpdateLoading] = useState(false);
-  const [diagnosticsLoading, setDiagnosticsLoading] = useState(false);
   const settings = useSettingsStore();
 
   useEffect(() => {
@@ -493,10 +492,8 @@ export default function SettingsAdvancedRoute() {
                 reloadDocument
                 download
                 size="SM"
-                disabled={diagnosticsLoading}
                 theme="light"
                 text={m.advanced_download_diagnostics_button()}
-                loading={diagnosticsLoading}
               />
             </SettingsItem>
           </NestedSettingsGroup>

--- a/web.go
+++ b/web.go
@@ -1,16 +1,19 @@
 package kvm
 
 import (
+	"archive/zip"
 	"bytes"
 	"context"
 	"embed"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net"
 	"net/http"
 	"net/http/pprof"
+	"os"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -21,7 +24,9 @@ import (
 	gin_logger "github.com/gin-contrib/logger"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
+	"github.com/jetkvm/kvm/internal/diagnostics"
 	"github.com/jetkvm/kvm/internal/logging"
+	"github.com/jetkvm/kvm/internal/supervisor"
 	"github.com/pion/webrtc/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -187,6 +192,8 @@ func setupRouter() *gin.Engine {
 		protected.POST("/storage/upload", handleUploadHttp)
 
 		protected.POST("/device/send-wol/:mac-addr", handleSendWOLMagicPacket)
+
+		protected.GET("/diagnostics", handleDiagnosticsDownload)
 	}
 
 	// Catch-all route for SPA
@@ -833,4 +840,96 @@ func handleSendWOLMagicPacket(c *gin.Context) {
 	}
 
 	c.String(http.StatusOK, "WOL sent to %s ", macAddr)
+}
+
+func handleDiagnosticsDownload(c *gin.Context) {
+	pr, pw := io.Pipe()
+
+	go func() {
+		defer pw.Close()
+
+		zw := zip.NewWriter(pw)
+
+		// 1. Application log (full, no truncation)
+		if err := addFileToZip(zw, "app.log", supervisor.AppLogPath); err != nil {
+			logger.Warn().Err(err).Msg("failed to add app log to diagnostics zip")
+		}
+
+		// 2. System diagnostics
+		var diagBuf bytes.Buffer
+		diag := diagnostics.New(diagnostics.Options{
+			Writer: &diagBuf,
+			GetSessionInfo: func() diagnostics.SessionInfo {
+				info := diagnostics.SessionInfo{
+					ActiveSessions:    getActiveSessions(),
+					HasCurrentSession: currentSession != nil,
+				}
+				if currentSession != nil {
+					sessionInfo := currentSession.GetDiagnosticsInfo()
+					info.ICEConnectionState = sessionInfo.ICEConnectionState
+					info.SignalingState = sessionInfo.SignalingState
+					info.ConnectionState = sessionInfo.ConnectionState
+					info.DataChannels = sessionInfo.DataChannels
+				}
+				return info
+			},
+		})
+		diag.LogAll("download")
+		if err := addBytesToZip(zw, "system-diagnostics.txt", diagBuf.Bytes()); err != nil {
+			logger.Warn().Err(err).Msg("failed to add system diagnostics to zip")
+		}
+
+		// 3. All crash dumps (full content)
+		if entries, err := filepath.Glob(filepath.Join(supervisor.ErrorDumpDir, "jetkvm-*.log")); err == nil {
+			for _, path := range entries {
+				if err := addFileToZip(zw, "crashes/"+filepath.Base(path), path); err != nil {
+					logger.Warn().Err(err).Str("path", path).Msg("failed to add crash dump to zip")
+				}
+			}
+		}
+
+		// 4. Configuration
+		if configData, err := json.MarshalIndent(config, "", "  "); err == nil {
+			if err := addBytesToZip(zw, "config.json", configData); err != nil {
+				logger.Warn().Err(err).Msg("failed to add config to zip")
+			}
+		}
+
+		// Close ZIP writer to write central directory (required for valid ZIP)
+		if err := zw.Close(); err != nil {
+			logger.Error().Err(err).Msg("failed to finalize diagnostics zip")
+		}
+	}()
+
+	filename := fmt.Sprintf("jetkvm-diagnostics-%s.zip", time.Now().Format("20060102-150405"))
+	extraHeaders := map[string]string{
+		"Content-Disposition": fmt.Sprintf("attachment; filename=%s", filename),
+	}
+
+	c.DataFromReader(http.StatusOK, -1, "application/zip", pr, extraHeaders)
+}
+
+func addFileToZip(zw *zip.Writer, name, srcPath string) error {
+	f, err := os.Open(srcPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+
+	_, err = io.Copy(w, f)
+	return err
+}
+
+func addBytesToZip(zw *zip.Writer, name string, data []byte) error {
+	w, err := zw.Create(name)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
 }


### PR DESCRIPTION
### Summary
- Append exit code and signal when supervisor detects crash
- Disable mDNS logs as they are causing extremely large logs (>100mb)
- Move to HTTP downloads instead of over WebRTC data channel
- When failsafe is triggered we don't load the entire log file into memory, just read the last 50kb to check if we can infer the reason for failing

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
- [x] Tricky parts are commented in code
