### PR TITLE
Change production LOGLEVEL

### DIFF
--- a/config.go
+++ b/config.go
@@ -195,7 +195,7 @@ func getDefaultConfig() Config {
 			_ = confparser.SetDefaultsAndValidate(c)
 			return c
 		}(),
-		DefaultLogLevel:    "INFO",
+		DefaultLogLevel:    "WARN",
 		VideoQualityFactor: 1.0,
 	}
 }
@@ -270,6 +270,11 @@ func LoadConfig() {
 	// fixup old keyboard layout value
 	if loadedConfig.KeyboardLayout == "en_US" {
 		loadedConfig.KeyboardLayout = "en-US"
+	}
+
+	// Migrate old verbose log level to sensible default
+	if loadedConfig.DefaultLogLevel == "INFO" {
+		loadedConfig.DefaultLogLevel = "WARN"
 	}
 
 	config = &loadedConfig


### PR DESCRIPTION
### Summary
- Change default loglevel from INF to WARN in production as this could cause insanely large log files
- Migrate old configurations

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
