### PR TITLE
Fix nil pointer dereference in handleSerialChannel

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -290,6 +290,10 @@ func handleSerialChannel(d *webrtc.DataChannel) {
 
 	d.OnOpen(func() {
 		go func() {
+			if port == nil {
+				return
+			}
+
 			buf := make([]byte, 1024)
 			for {
 				n, err := port.Read(buf)


### PR DESCRIPTION
### Summary
- If Serial Port isn't ready before the WebRTC connected start

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
