### PR TITLE
feat: display hostname in browser tab and nav bar

### DIFF
--- a/ui/src/components/Header.tsx
+++ b/ui/src/components/Header.tsx
@@ -24,6 +24,7 @@ interface NavbarProps {
   showConnectionStatus?: boolean;
   picture?: string;
   kvmName?: string;
+  hostname?: string | null;
 }
 
 export default function DashboardNavbar({
@@ -33,6 +34,7 @@ export default function DashboardNavbar({
   userEmail,
   picture,
   kvmName,
+  hostname,
 }: NavbarProps) {
   const peerConnectionState = useRTCStore(state => state.peerConnectionState);
   const setUser = useUserStore(state => state.setUser);
@@ -62,6 +64,11 @@ export default function DashboardNavbar({
               <img src={LogoBlueIcon} alt="" className="h-6 dark:hidden" />
               <img src={LogoWhiteIcon} alt="" className="hidden h-6 dark:block" />
             </div>
+            {hostname && (
+              <span className="text-sm font-medium text-slate-600 dark:text-slate-300">
+                {hostname}
+              </span>
+            )}
 
             <div className="flex gap-x-2">
               {primaryLinks.map(({ title, to }, i) => {

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -141,6 +141,7 @@ export default function KvmIdRoute() {
   const location = useLocation();
   const isLegacySignalingEnabled = useRef(false);
   const [connectionFailed, setConnectionFailed] = useState(false);
+  const [displayHostname, setDisplayHostname] = useState<string | null>(null);
 
   const navigate = useNavigate();
   const { otaState, setOtaState, setModalView } = useUpdateStore();
@@ -773,6 +774,17 @@ export default function KvmIdRoute() {
       console.debug("Setting HDMI state", hdmiState);
       setHdmiState(hdmiState);
     });
+
+    console.log("Requesting network settings");
+    send("getNetworkSettings", {}, (resp: JsonRpcResponse) => {
+      if ("error" in resp) return;
+      const result = resp.result as { hostname?: string };
+      if (result.hostname) {
+        setDisplayHostname(result.hostname);
+      } else {
+        setDisplayHostname(null);
+      }
+    });
   }, [rpcDataChannel?.readyState, send, setHdmiState]);
 
   const [needLedState, setNeedLedState] = useState(true);
@@ -935,6 +947,7 @@ export default function KvmIdRoute() {
 
   return (
     <FeatureFlagProvider appVersion={appVersion}>
+      <title>{displayHostname ? `${displayHostname} - JetKVM` : "JetKVM"}</title>
       {!outlet && otaState.updating && (
         <AnimatePresence>
           <motion.div
@@ -970,6 +983,7 @@ export default function KvmIdRoute() {
             userEmail={user?.email}
             picture={user?.picture}
             kvmName={deviceName ?? m.jetkvm_device()}
+            hostname={displayHostname}
           />
 
           <div className="relative flex h-full w-full overflow-hidden">


### PR DESCRIPTION
Closes #83 #528 

### Summary

This feature helps users with multiple JetKVM devices quickly identify which device a browser tab belongs to. The hostname appears in the browser tab title (format: "{hostname} - JetKVM") and in the navigation bar next to the logo. Users can enable this via a checkbox in Network settings, which is off by default to avoid disrupting existing workflows.

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
- [x] Tricky parts are commented in code


<img width="396" height="212" alt="Image" src="https://github.com/user-attachments/assets/39b86f1b-0a30-4845-9c52-9979a558c1b5" />
<img width="658" height="229" alt="Screenshot 2026-01-27 at 8 55 18 PM" src="https://github.com/user-attachments/assets/4f0e7b64-7c14-4d4f-988a-cb34f7a67310" />
