### PR TITLE
fix: missing PWA icon on macOS Safari & MSEdge cased by  no "any" purpose icons in the web manifest

### DIFF
--- a/ui/public/site.webmanifest
+++ b/ui/public/site.webmanifest
@@ -13,6 +13,18 @@
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"
+    },
+    {
+      "src": "/web-app-manifest-192x192.png",
+      "sizes": "192x192",
+      "type": "image/png",
+      "purpose": "any"
+    },
+    {
+      "src": "/web-app-manifest-512x512.png",
+      "sizes": "512x512",
+      "type": "image/png",
+      "purpose": "any"
     }
   ],
   "theme_color": "#002b36",


### PR DESCRIPTION
When installing JetKVM as a desktop app via Safari's "Add to Dock" or Edge's "Add this site as app" on macOS, the app icon appears as a generic/missing icon instead of the JetKVM logo.

### Summary

The [`./ui/public/site.webmanifest`](./ui/public/site.webmanifest) only declared icons with `"purpose": "maskable"`.
Maskable icons are designed for Android's adaptive icon system and include safe-area padding.

Safari and Edge on macOS require icons with `"purpose": "any"` to correctly display the app icon.

Core Change: Added icon entries in `site.webmanifest ` with `"purpose": "any"` for the existing 192x192 and 512x512 PNG icons, so browsers that don't support maskable icons can still display the correct logo.

Fixes #816.

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green
