### PR TITLE
fix: prevent overscroll bounce on Safari

### DIFF
--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -158,6 +158,7 @@ body {
   height: 100%;
   width: 100%;
   overflow: auto;
+  overscroll-behavior: none;
 }
 
 @property --grid-color-start {


### PR DESCRIPTION
⏺ Fixes #1191                                                                                                                                                                                                         
                                                                      
  ### Summary                                                                                                                                                                                                         
  - Adds `overscroll-behavior: none` to the `html, body` CSS rule in `ui/src/index.css` to prevent the elastic bounce ("earthquake scrolling") effect in Safari when using a trackpad or Magic Mouse.
                                                                                                                                                                                                                      
  ### Checklist                                                                          
  - [ ] Ran `make test_e2e` locally and passed
  - [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
  - [x] One problem per PR (no unrelated changes)
  - [x] Lints pass; CI green