### PR TITLE
fix(devcontainer): make install-deps work on arm64/aarch64

### DIFF
--- a/.devcontainer/install-deps.sh
+++ b/.devcontainer/install-deps.sh
@@ -12,18 +12,43 @@ function sudo() {
 set -ex
 
 export DEBIAN_FRONTEND=noninteractive
+ARCH="$(dpkg --print-architecture)"
+APT_PACKAGES=(
+  iputils-ping
+  build-essential
+  device-tree-compiler
+  gperf
+  gdb-multiarch
+  libnl-3-dev
+  libdbus-1-dev
+  libelf-dev
+  libmpc-dev
+  dwarves
+  bc
+  openssl
+  flex
+  bison
+  libssl-dev
+  python3
+  python-is-python3
+  texinfo
+  kmod
+  cmake
+  wget
+  zstd
+  python3-venv
+  python3-kconfiglib
+)
+
+if [ "${ARCH}" = "amd64" ]; then
+  APT_PACKAGES+=(g++-multilib gcc-multilib)
+else
+  echo "Skipping gcc/g++ multilib packages on ${ARCH}."
+fi
+
 sudo apt-get update && \
-sudo apt-get install -y --no-install-recommends \
-  iputils-ping \
-  build-essential \
-  device-tree-compiler \
-  gperf g++-multilib gcc-multilib \
-  gdb-multiarch \
-  libnl-3-dev libdbus-1-dev libelf-dev libmpc-dev dwarves \
-  bc openssl flex bison libssl-dev python3 python-is-python3 texinfo kmod cmake \
-  wget zstd \
-  python3-venv python3-kconfiglib \
-  && sudo rm -rf /var/lib/apt/lists/*
+    sudo apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}" && \
+    sudo rm -rf /var/lib/apt/lists/*
 
 # Install buildkit
 BUILDKIT_VERSION="v0.2.5"


### PR DESCRIPTION
### Summary

Detect container architecture in `.devcontainer/install-deps.sh` and only install gcc/g++ multilib packages on amd64, where they are available.

- keep shared dependency set for all architectures
- skip gcc-multilib and g++-multilib on arm64 with a clear log message
- reformat install-deps.sh for readability
- document arm64 devcontainer behavior and current amd64-only build caveats

Closes #1216

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green
- [ ] Tricky parts are commented in code
