### PR TITLE
feat(usb): enable remote wakeup for HID devices

### DIFF
--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -34,7 +34,8 @@ var defaultGadgetConfig = map[string]gadgetConfigItem{
 			"bcdDevice": "0x0100", // USB2
 		},
 		configAttrs: gadgetAttributes{
-			"MaxPower": "250", // in unit of 2mA
+			"MaxPower":      "250", // in unit of 2mA
+			"bmAttributes": "0xa0", // bus-powered + remote wakeup
 		},
 	},
 	"base_info": {

--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -288,6 +288,7 @@ func (tx *UsbGadgetTransaction) writeGadgetAttrs(basePath string, attrs gadgetAt
 			Description:     "write gadget attribute",
 			DependsOn:       []string{basePath},
 			BeforeChange:    beforeChange,
+			IgnoreErrors:    key == "wakeup_on_write", // optional kernel feature (rv1106-system#57)
 		})
 		files = append(files, filePath)
 	}

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -23,6 +23,7 @@ var keyboardConfig = gadgetConfigItem{
 		"subclass":        "1",
 		"report_length":   "8",
 		"no_out_endpoint": "0",
+		"wakeup_on_write": "1",
 	},
 	reportDesc: keyboardReportDesc,
 }

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -15,6 +15,7 @@ var absoluteMouseConfig = gadgetConfigItem{
 		"subclass":        "0",
 		"report_length":   "6",
 		"no_out_endpoint": "1",
+		"wakeup_on_write": "1",
 	},
 	reportDesc: absoluteMouseCombinedReportDesc,
 }

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -15,6 +15,7 @@ var relativeMouseConfig = gadgetConfigItem{
 		"subclass":        "1",
 		"report_length":   "5",
 		"no_out_endpoint": "1",
+		"wakeup_on_write": "1",
 	},
 	reportDesc: relativeMouseCombinedReportDesc,
 }


### PR DESCRIPTION
Fixes #120 and #674.

### Summary

Enable USB remote wakeup so JetKVM can wake a sleeping host via keyboard or mouse input. 

**Requires** the kernel-side `wakeup_on_write` configfs attribute from jetkvm/rv1106-system#57 to work end to end.

Two changes:

1. Set `bmAttributes = 0xa0` (bus-powered + remote wakeup) in the USB configuration descriptor, advertising remote wakeup capability to the host during enumeration
2. Set `wakeup_on_write = 1` on all three HID functions (keyboard, absolute mouse, relative mouse), so the kernel calls `usb_gadget_wakeup()` before each HID report write

### Changes

- `config.go`: Add `bmAttributes: "0xa0"` to gadget config attributes
- `hid_keyboard.go`: Add `wakeup_on_write: "1"`
- `hid_mouse_absolute.go`: Add `wakeup_on_write: "1"`
- `hid_mouse_relative.go`: Add `wakeup_on_write: "1"`

### Testing

Tested on JetKVM v2 with patched kernel (rv1106-system#57). Host: Windows 11 (S3 sleep), Intel Z390 chipset, xHCI controller.

#### Test setup

- Host: Windows 11, Intel Z390, S3 (legacy suspend-to-RAM, not Modern Standby)
- "Allow this device to wake the computer" enabled on the USB hub in Device Manager (Windows default)
- JetKVM connected via HDMI (DP-to-HDMI adapter) + USB-C
- After deploying patched kernel + app, USB re-enumeration required (reconnect cable or reboot JetKVM)
- Each test started from confirmed cold sleep (100% ping packet loss verified before sending wake signal)

#### Descriptor verification

`lsusb -v` on host confirms the configuration descriptor advertises remote wakeup:

```
  Configuration Descriptor:
    bmAttributes         0xa0
      (Bus Powered)
      Remote Wakeup
```

#### Test 1: Direct HID write via SSH (measures raw PC wake time)

SSH into JetKVM and write a raw keyboard HID report to the gadget device:

```bash
# Press spacebar (usage 0x2c)
echo -ne '\x00\x00\x2c\x00\x00\x00\x00\x00' > /dev/hidg0
# Release
echo -ne '\x00\x00\x00\x00\x00\x00\x00\x00' > /dev/hidg0
```

Measurement: timed from HID write completion to first successful ping response from the host.

| Run | Wake time (HID write to first ping) |
|-----|--------------------------------------|
| 1   | 4,016ms                              |
| 2   | 4,015ms                              |
| 3   | 4,013ms                              |
| **Avg** | **4,015ms**                      |

`powercfg /lastwake` confirms wake source on every test:

```
Wake Source [0]:
  Type: Device
  Friendly Name: Intel(R) USB 3.1 eXtensible Host Controller
  Description: USB xHCI Compliant Host Controller
```

Note: the total SSH command time is dominated by SSH overhead to JetKVM's BusyBox shell on the RV1106. The actual HID write and USB wakeup are near-instant.

#### Test 2: Wake via JetKVM web UI (measures end-to-end user experience)

With the host asleep, pressed spacebar through the KVM web interface.

Measurement: JS polling `video.currentTime` every 50ms in headful Chromium, detecting when the video stream advances >0.05s from the frozen baseline. This measures the full pipeline: HID write, PC wake, GPU resume, HDMI signal, JetKVM capture, WebRTC stream.

| Run | Button click to first video frame |
|-----|-----------------------------------|
| 1   | 26,271ms                          |
| 2   | 26,200ms                          |
| 3   | 26,450ms                          |
| **Avg** | **26,307ms (~26s)**           |

The ~22s overhead beyond the raw 4s wake time is almost entirely Windows GPU resume (powering from D3, reinitializing display driver, outputting HDMI signal). This is outside JetKVM's control and will vary by GPU, driver version, and display configuration.

#### Test 3: Mouse input

Tested with both absolute and relative mouse movement through the web UI. Both wake the host successfully with the same timing.

#### Notes

- Wake works from all three HID functions: keyboard, absolute mouse, relative mouse
- The PC must have enumerated JetKVM's USB device *before* entering sleep. If JetKVM reboots while the host is asleep, wake won't work until the host is woken by other means (e.g. WoL) and re-enumerates the device.
- Modern Standby (S0ix) hosts may behave differently; only S3 was tested.
- Multiple sleep/wake cycles tested (3+) with consistent results.

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches USB gadget descriptor/configfs attributes used during enumeration and runtime HID writes; behavior depends on kernel support for `wakeup_on_write` and could affect host compatibility if misconfigured.
> 
> **Overview**
> Advertises USB **remote wakeup** support by setting `bmAttributes = 0xa0` on the base gadget configuration.
> 
> Enables kernel-triggered wakeups on input by writing `wakeup_on_write = 1` for keyboard and both mouse HID functions, and updates the configfs transaction writer to **ignore errors** when `wakeup_on_write` is unsupported (optional kernel feature).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 41c50f0f8588fb6b5394fe641610764f13d35fb5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->