### PR TITLE
feat(ui): add "Try Wake Host" button to no-signal overlay

### DIFF
--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -9,8 +9,9 @@ type gadgetConfigItem struct {
 	order       uint
 	device      string
 	path        []string
-	attrs       gadgetAttributes
-	configAttrs gadgetAttributes
+	attrs         gadgetAttributes
+	optionalAttrs gadgetAttributes // written with IgnoreErrors; for kernel features that may not exist
+	configAttrs   gadgetAttributes
 	configPath  []string
 	reportDesc  []byte
 }

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -34,7 +34,7 @@ var defaultGadgetConfig = map[string]gadgetConfigItem{
 			"bcdDevice": "0x0100", // USB2
 		},
 		configAttrs: gadgetAttributes{
-			"MaxPower":     "250",  // in unit of 2mA
+			"MaxPower":      "250", // in unit of 2mA
 			"bmAttributes": "0xa0", // bus-powered + remote wakeup
 		},
 	},

--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -221,6 +221,16 @@ func (tx *UsbGadgetTransaction) writeGadgetItemConfig(item gadgetConfigItem, dep
 		)...)
 	}
 
+	if len(item.optionalAttrs) > 0 {
+		// write optional attributes (IgnoreErrors=true for backward compat with older kernels)
+		files = append(files, tx.writeGadgetAttrsOptional(
+			gadgetItemPath,
+			item.optionalAttrs,
+			component,
+			beforeChange,
+		)...)
+	}
+
 	// write report descriptor if available
 	reportDescPath := path.Join(gadgetItemPath, "report_desc")
 	if item.reportDesc != nil {
@@ -289,6 +299,24 @@ func (tx *UsbGadgetTransaction) writeGadgetAttrs(basePath string, attrs gadgetAt
 			DependsOn:       []string{basePath},
 			BeforeChange:    beforeChange,
 			IgnoreErrors:    key == "wakeup_on_write", // optional kernel feature (rv1106-system#57)
+		})
+		files = append(files, filePath)
+	}
+	return files
+}
+
+func (tx *UsbGadgetTransaction) writeGadgetAttrsOptional(basePath string, attrs gadgetAttributes, component string, beforeChange []string) (files []string) {
+	files = make([]string, 0)
+	for key, val := range attrs {
+		filePath := filepath.Join(basePath, key)
+		tx.addFileChange(component, RequestedFileChange{
+			Path:            filePath,
+			ExpectedState:   FileStateFileContentMatch,
+			ExpectedContent: []byte(val),
+			Description:     "write optional gadget attribute",
+			DependsOn:       []string{basePath},
+			BeforeChange:    beforeChange,
+			IgnoreErrors:    true,
 		})
 		files = append(files, filePath)
 	}

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -23,6 +23,8 @@ var keyboardConfig = gadgetConfigItem{
 		"subclass":        "1",
 		"report_length":   "8",
 		"no_out_endpoint": "0",
+	},
+	optionalAttrs: gadgetAttributes{
 		"wakeup_on_write": "1",
 	},
 	reportDesc: keyboardReportDesc,

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -15,6 +15,8 @@ var absoluteMouseConfig = gadgetConfigItem{
 		"subclass":        "0",
 		"report_length":   "6",
 		"no_out_endpoint": "1",
+	},
+	optionalAttrs: gadgetAttributes{
 		"wakeup_on_write": "1",
 	},
 	reportDesc: absoluteMouseCombinedReportDesc,

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -15,6 +15,8 @@ var relativeMouseConfig = gadgetConfigItem{
 		"subclass":        "1",
 		"report_length":   "5",
 		"no_out_endpoint": "1",
+	},
+	optionalAttrs: gadgetAttributes{
 		"wakeup_on_write": "1",
 	},
 	reportDesc: relativeMouseCombinedReportDesc,

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -1093,5 +1093,8 @@
     "wake_on_lan_invalid_mac": "Invalid MAC address",
     "wake_on_lan_magic_sent_success": "Magic Packet sent successfully",
     "welcome_to_jetkvm": "Welcome to JetKVM",
-    "welcome_to_jetkvm_description": "Control any computer remotely"
+    "welcome_to_jetkvm_description": "Control any computer remotely",
+    "video_overlay_no_hdmi_try_wake": "If the target computer is sleeping, you can try waking it with a simulated keyboard press",
+    "video_overlay_no_hdmi_wake_host": "Try Wake Host",
+    "video_overlay_no_hdmi_wake_host_sending": "Sending wake signal..."
 }

--- a/ui/src/components/VideoOverlay.tsx
+++ b/ui/src/components/VideoOverlay.tsx
@@ -216,9 +216,11 @@ export function PeerConnectionDisconnectedOverlay({ show }: PeerConnectionDiscon
 interface HDMIErrorOverlayProps {
   readonly show: boolean;
   readonly hdmiState: string;
+  readonly onWakeHost?: () => void;
+  readonly isWaking?: boolean;
 }
 
-export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
+export function HDMIErrorOverlay({ show, hdmiState, onWakeHost, isWaking }: HDMIErrorOverlayProps) {
   const isNoSignal = hdmiState === "no_signal";
   const isOtherError = hdmiState === "no_lock" || hdmiState === "out_of_range";
 
@@ -247,9 +249,10 @@ export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
                         <li>{m.video_overlay_no_hdmi_ensure_cable()}</li>
                         <li>{m.video_overlay_no_hdmi_ensure_power()}</li>
                         <li>{m.video_overlay_no_hdmi_adapter_compat()}</li>
+                        <li>{m.video_overlay_no_hdmi_try_wake()}</li>
                       </ul>
                     </div>
-                    <div>
+                    <div className="flex items-center gap-x-2">
                       <LinkButton
                         to={"https://jetkvm.com/docs/getting-started/troubleshooting"}
                         theme="light"
@@ -257,6 +260,19 @@ export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
                         TrailingIcon={ArrowRightIcon}
                         size="SM"
                       />
+                      {onWakeHost && (
+                        <Button
+                          onClick={onWakeHost}
+                          text={
+                            isWaking
+                              ? m.video_overlay_no_hdmi_wake_host_sending()
+                              : m.video_overlay_no_hdmi_wake_host()
+                          }
+                          size="SM"
+                          theme="primary"
+                          disabled={isWaking}
+                        />
+                      )}
                     </div>
                   </div>
                 </div>

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -6,6 +6,7 @@ import { isWindows } from "@/utils";
 import useKeyboard from "@hooks/useKeyboard";
 import useMouse from "@hooks/useMouse";
 import { useRTCStore, useSettingsStore, useUiStore, useVideoStore } from "@hooks/stores";
+import { useJsonRpc } from "@hooks/useJsonRpc";
 import VirtualKeyboard from "@components/VirtualKeyboard";
 import Actionbar from "@components/ActionBar";
 import MacroBar from "@components/MacroBar";
@@ -30,6 +31,8 @@ export default function WebRTCVideo({
 }) {
   // Video and stream related refs and states
   const videoElm = useRef<HTMLVideoElement>(null);
+  const [isWaking, setIsWaking] = useState(false);
+  const { send } = useJsonRpc();
   const fullscreenContainerRef = useRef<HTMLDivElement>(null);
   const { mediaStream, peerConnectionState } = useRTCStore();
   const [isPlaying, setIsPlaying] = useState(false);
@@ -38,6 +41,18 @@ export default function WebRTCVideo({
 
   const isPointerLockPossible =
     window.location.protocol === "https:" || window.location.hostname === "localhost";
+
+  // Wake host handler - sends a spacebar press+release to wake sleeping host
+  const handleWakeHost = useCallback(() => {
+    setIsWaking(true);
+    // Send spacebar (HID usage 0x2C) press
+    send("keyboardReport", { keys: [0x2c, 0, 0, 0, 0, 0], modifier: 0 }, () => {
+      // Send key release
+      send("keyboardReport", { keys: [0, 0, 0, 0, 0, 0], modifier: 0 }, () => {
+        setTimeout(() => setIsWaking(false), 3000);
+      });
+    });
+  }, [send]);
 
   // Store hooks
   const settings = useSettingsStore();
@@ -675,7 +690,12 @@ export default function WebRTCVideo({
                         >
                           <div className="relative h-full w-full rounded-md">
                             <LoadingVideoOverlay show={isVideoLoading} />
-                            <HDMIErrorOverlay show={hdmiError} hdmiState={hdmiState} />
+                            <HDMIErrorOverlay
+                              show={hdmiError}
+                              hdmiState={hdmiState}
+                              onWakeHost={handleWakeHost}
+                              isWaking={isWaking}
+                            />
                             <NoAutoplayPermissionsOverlay
                               show={hasNoAutoPlayPermissions}
                               onPlayClick={() => {


### PR DESCRIPTION
### Summary

When JetKVM shows "No HDMI signal detected", add a hint about sleeping hosts and a "Try Wake Host" button that sends a spacebar press/release to attempt waking the host via USB HID.

<img width="913" height="875" alt="image" src="https://github.com/user-attachments/assets/03e351e3-5970-4d25-8c51-4d6bfc1c0115" />

Builds on #1235 (USB remote wakeup backend) and jetkvm/rv1106-system#57 (kernel f_hid patch). With those in place, this button provides a one-click way to wake a sleeping host directly from the JetKVM web UI.

### Changes

- `VideoOverlay.tsx`: Add `onWakeHost` and `isWaking` props to `HDMIErrorOverlay`, render "Try Wake Host" button and sleep hint in the no-signal state
- `WebRTCVideo.tsx`: Add `handleWakeHost` callback that sends spacebar HID keypress via JSON-RPC, wire it to the overlay
- `en.json`: Add 3 localization strings (`video_overlay_no_hdmi_try_wake`, `video_overlay_no_hdmi_wake_host`, `video_overlay_no_hdmi_wake_host_sending`)

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new user-triggered HID key injection path from the UI and tweaks USB gadget config attribute writing to tolerate missing kernel features, which could affect input behavior or gadget initialization on some devices/kernels.
> 
> **Overview**
> Adds a **"Try Wake Host"** action to the *No HDMI signal* overlay that sends a spacebar press+release via JSON-RPC (`keyboardReport`), with a short in-flight/disabled state and new i18n strings.
> 
> On the backend USB gadget configuration side, introduces `optionalAttrs` for gadget items and a new writer that always sets `IgnoreErrors`, then moves HID `wakeup_on_write` into these optional attributes for keyboard/absolute mouse/relative mouse to improve compatibility with kernels that lack the feature.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9adfced0f9ee979330575d4f7ea8e1fc600fc756. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->