### PR TITLE
fix(display): prevent background events from resetting off timer

### DIFF
--- a/native.go
+++ b/native.go
@@ -38,7 +38,7 @@ func initNative(systemVersion *semver.Version, appVersion *semver.Version) {
 		OnVideoStateChange: func(state native.VideoState) {
 			lastVideoState = state
 			triggerVideoStateUpdate()
-			requestDisplayUpdate(true, "video_state_changed")
+			requestDisplayUpdate(false, "video_state_changed")
 		},
 		OnIndevEvent: func(event string) {
 			nativeLogger.Trace().Str("event", event).Msg("indev event received")

--- a/network.go
+++ b/network.go
@@ -120,7 +120,7 @@ func setPublicIPReadyState(ipv4Ready, ipv6Ready bool) {
 
 func networkStateChanged(_ string, state types.InterfaceState) {
 	// do not block the main thread
-	go waitCtrlAndRequestDisplayUpdate(true, "network_state_changed")
+	go waitCtrlAndRequestDisplayUpdate(false, "network_state_changed")
 
 	if currentSession != nil {
 		writeJSONRPCEvent("networkState", state.ToRpcInterfaceState(), currentSession)

--- a/usb.go
+++ b/usb.go
@@ -109,6 +109,6 @@ func checkUSBState() {
 	usbState = newState
 	usbLogger.Info().Str("from", usbState).Str("to", newState).Msg("USB state changed")
 
-	requestDisplayUpdate(true, "usb_state_changed")
+	requestDisplayUpdate(false, "usb_state_changed")
 	triggerUSBStateUpdate()
 }

--- a/webrtc.go
+++ b/webrtc.go
@@ -465,7 +465,7 @@ func newSession(config SessionConfig) (*Session, error) {
 
 func onActiveSessionsChanged() {
 	notifyFailsafeMode(currentSession)
-	requestDisplayUpdate(true, "active_sessions_changed")
+	requestDisplayUpdate(false, "active_sessions_changed")
 }
 
 func onFirstSessionConnected() {


### PR DESCRIPTION
Fixes #1133

## Problem

The "Turn Off Display After" timer never fires when a WebRTC session is active. The display dims correctly but never turns off.

## Root cause

Background system events — video state changes, active session count updates, USB state changes, network state changes — all call `requestDisplayUpdate(true, ...)`, which invokes `wakeDisplay`. Each wake resets both the dim and off tickers via `time.Ticker.Reset()`. With an active browser session, these events fire frequently enough that the off timer restarts from zero before it reaches its threshold.

One commenter confirmed: closing the browser (removing the active session) allows the timer to work, which matches this analysis — no more `active_sessions_changed` or `video_state_changed` events to reset the tickers.

## Fix

Pass `shouldWakeDisplay=false` in `requestDisplayUpdate` calls from background event handlers:

- `native.go` — `video_state_changed`
- `network.go` — `network_state_changed`
- `usb.go` — `usb_state_changed`
- `webrtc.go` — `active_sessions_changed`

These callers still update the LCD content but no longer reset the backlight timeout cycle.

Physical input device events (`indev_event` in native.go) continue to call `wakeDisplay` directly, which is the correct trigger for resetting the timers — a user physically tapped the screen.

Startup paths (`init_display`, `native_restart`) retain `shouldWakeDisplay=true`.