### PR TITLE
fix(video): prevent space bar from pausing video in fullscreen

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -401,6 +401,15 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
     }
   }, []);
 
+  const videoKeyDownHandler = useCallback((e: KeyboardEvent) => {
+    // Prevent the browser's native <video> play/pause toggle on Space.
+    // The document-level keyDownHandler already calls preventDefault, but
+    // in fullscreen the video element receives the event first.
+    if (e.code === "Space") {
+      e.preventDefault();
+    }
+  }, []);
+
   const addStreamToVideoElm = useCallback(
     (mediaStream: MediaStream) => {
       if (!videoElm.current) return;
@@ -470,6 +479,7 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
       const signal = abortController.signal;
 
       // To prevent the video from being paused when the user presses a space in fullscreen mode
+      videoElmRefValue.addEventListener("keydown", videoKeyDownHandler, { signal });
       videoElmRefValue.addEventListener("keyup", videoKeyUpHandler, { signal });
 
       // We need to know when the video is playing to update state and video size
@@ -479,7 +489,7 @@ export default function WebRTCVideo({ hasConnectionIssues }: { hasConnectionIssu
         abortController.abort();
       };
     },
-    [onVideoPlaying, videoKeyUpHandler],
+    [onVideoPlaying, videoKeyDownHandler, videoKeyUpHandler],
   );
 
   // Setup Mouse Events


### PR DESCRIPTION
Fixes #265

## Problem

Pressing Space in fullscreen mode pauses the video stream. Reported across Chrome, Edge, and Safari. The stream resumes on the next Space press but this makes fullscreen unusable for typing.

## Root cause

Browsers treat `<video>` elements specially — Space toggles play/pause as a built-in behavior at the element level. The existing `keyDownHandler` on `document` calls `preventDefault()`, but DOM event propagation runs **element → parent → ... → document**. The video element processes the Space keydown and pauses playback before the document-level handler ever fires.

The existing workaround (`videoKeyUpHandler` at line 390) attaches a keyup listener on the video element that detects the pause and calls `.play()` to undo it, but:

1. There is a visible pause/unpause flicker on every Space press
2. It does not work in Safari (noted in the original code comment)

## Fix

Add a `keydown` listener directly on the `<video>` element that calls `preventDefault()` for Space. This intercepts the event at the element level before the browser's native toggle runs, so the pause never occurs.

The existing keyup force-play handler is retained as a safety net for any browser that still manages to pause the stream.