### PR TITLE
fix(network): restore IPv6 disabled option in network settings

### DIFF
--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -565,7 +565,7 @@ export default function SettingsNetworkRoute() {
                 <SelectMenuBasic
                   size="SM"
                   options={[
-                    //{ value: "disabled", label: m.network_ipv6_mode_disabled() },
+                    { value: "disabled", label: m.network_ipv6_mode_disabled() },
                     { value: "slaac", label: m.network_ipv6_mode_slaac() },
                     //{ value: "dhcpv6", label: m.network_ipv6_mode_dhcpv6() },
                     //{ value: "slaac_and_dhcpv6", label: m.network_ipv6_mode_slaac_dhcpv6() },


### PR DESCRIPTION
Fixes #1039

## Problem

The IPv6 mode dropdown in Settings > Network has no Disabled option, so users cannot run IPv4-only. This was previously available but dropped during the network stack rewrite in PR #878 (the new UI was built from scratch and the option was not carried over). PR #864 re-added the line during localization work but left it commented out.

## Backend support

The full backend path for `disabled` is already implemented:

- `internal/network/types/config.go` — `"disabled"` is in the `one_of` validation for IPv6Mode
- `pkg/nmlite/interface.go:457` — `case "disabled": return im.disableIPv6()`
- `pkg/nmlite/static.go:145` — calls `DisableIPv6()` on the static config manager
- `pkg/nmlite/link/sysctl.go:32` — writes `net.ipv6.conf.<iface>.disable_ipv6 = 1` via sysctl
- `internal/network/types/config.go:69` — mDNS listen options correctly set to false for disabled mode

## Fix

Uncomment the disabled option in the IPv6 mode select menu (1 line). The localization string `m.network_ipv6_mode_disabled()` already exists.

IPv4 mode does not expose a disabled option in the UI, so there is no path to disabling both stacks simultaneously through the settings page.