### PR TITLE
fix(ui): add warning when SSH public key is empty in developer mode

### DIFF
--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "Standard SSH-brugeren er",
     "advanced_ssh_public_key_label": "Offentlig SSH-nøgle",
     "advanced_ssh_public_key_placeholder": "Indtast din offentlige SSH-nøgle",
+    "advanced_ssh_key_required_warning": "En offentlig nøgle er påkrævet for SSH-adgang. Uden en vil du ikke kunne oprette forbindelse.",
     "advanced_success_loopback_disabled": "Kun loopback-tilstand er deaktiveret. Genstart din enhed for at anvende den.",
     "advanced_success_loopback_enabled": "Kun loopback-tilstand aktiveret. Genstart din enhed for at anvende den.",
     "advanced_success_reset_config": "Konfigurationen er nulstillet til standard",

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "Der Standard-SSH-Benutzer ist",
     "advanced_ssh_public_key_label": "Öffentlicher SSH-Schlüssel",
     "advanced_ssh_public_key_placeholder": "Geben Sie Ihren öffentlichen SSH-Schlüssel ein",
+    "advanced_ssh_key_required_warning": "Ein öffentlicher Schlüssel ist für den SSH-Zugang erforderlich. Ohne diesen können Sie keine Verbindung herstellen.",
     "advanced_success_loopback_disabled": "Nur-Loopback-Modus deaktiviert. Starten Sie Ihr Gerät neu, um die Funktion anzuwenden.",
     "advanced_success_loopback_enabled": "Nur-Loopback-Modus aktiviert. Starten Sie Ihr Gerät neu, um die Funktion anzuwenden.",
     "advanced_success_reset_config": "Konfiguration erfolgreich auf Standard zurückgesetzt",

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -95,6 +95,7 @@
     "advanced_ssh_default_user": "The default SSH user is",
     "advanced_ssh_public_key_label": "SSH Public Key",
     "advanced_ssh_public_key_placeholder": "Enter your SSH public key",
+    "advanced_ssh_key_required_warning": "A public key is required for SSH access. Without one, you will not be able to connect.",
     "advanced_success_download_diagnostics": "Diagnostics downloaded successfully",
     "advanced_success_loopback_disabled": "Loopback-only mode disabled. Restart your device to apply.",
     "advanced_success_loopback_enabled": "Loopback-only mode enabled. Restart your device to apply.",

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "El usuario SSH predeterminado es",
     "advanced_ssh_public_key_label": "Clave pública SSH",
     "advanced_ssh_public_key_placeholder": "Ingrese su clave pública SSH",
+    "advanced_ssh_key_required_warning": "Se requiere una clave pública para el acceso SSH. Sin ella, no podrá conectarse.",
     "advanced_success_loopback_disabled": "El modo de solo bucle invertido está deshabilitado. Reinicie el dispositivo para aplicarlo.",
     "advanced_success_loopback_enabled": "Modo de solo bucle invertido habilitado. Reinicie el dispositivo para aplicarlo.",
     "advanced_success_reset_config": "La configuración se restableció a los valores predeterminados correctamente",

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "L'utilisateur SSH par défaut est",
     "advanced_ssh_public_key_label": "Clé publique SSH",
     "advanced_ssh_public_key_placeholder": "Entrez votre clé publique SSH",
+    "advanced_ssh_key_required_warning": "Une clé publique est requise pour l'accès SSH. Sans celle-ci, vous ne pourrez pas vous connecter.",
     "advanced_success_loopback_disabled": "Mode de bouclage désactivé. Redémarrez votre appareil pour appliquer le mode de bouclage.",
     "advanced_success_loopback_enabled": "Mode de bouclage activé. Redémarrez votre appareil pour appliquer la fonction.",
     "advanced_success_reset_config": "La configuration par défaut a été réinitialisée avec succès",

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "L'utente SSH predefinito è",
     "advanced_ssh_public_key_label": "Chiave pubblica SSH",
     "advanced_ssh_public_key_placeholder": "Inserisci la tua chiave pubblica SSH",
+    "advanced_ssh_key_required_warning": "Una chiave pubblica è necessaria per l'accesso SSH. Senza di essa, non sarà possibile connettersi.",
     "advanced_success_loopback_disabled": "Modalità loopback-only disattivata. Riavvia il dispositivo per applicare la modifica.",
     "advanced_success_loopback_enabled": "Modalità loopback abilitata. Riavvia il dispositivo per applicare la modifica.",
     "advanced_success_reset_config": "Configurazione ripristinata ai valori predefiniti con successo",

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -95,6 +95,7 @@
     "advanced_ssh_default_user": "デフォルトのSSHユーザーは",
     "advanced_ssh_public_key_label": "SSH公開鍵",
     "advanced_ssh_public_key_placeholder": "SSH公開鍵を入力してください",
+    "advanced_ssh_key_required_warning": "SSHアクセスには公開鍵が必要です。公開鍵がないと接続できません。",
     "advanced_success_download_diagnostics": "診断データが正常にダウンロードされました",
     "advanced_success_loopback_disabled": "ループバック専用モードが無効になりました。適用するにはデバイスを再起動してください。",
     "advanced_success_loopback_enabled": "ループバック専用モードが有効になりました。適用するにはデバイスを再起動してください。",

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "Standard SSH-brukeren er",
     "advanced_ssh_public_key_label": "SSH offentlig nøkkel",
     "advanced_ssh_public_key_placeholder": "Skriv inn din offentlige SSH-nøkkel",
+    "advanced_ssh_key_required_warning": "En offentlig nøkkel er påkrevd for SSH-tilgang. Uten en vil du ikke kunne koble til.",
     "advanced_success_loopback_disabled": "Kun tilbakekoblingsmodus deaktivert. Start enheten på nytt for å bruke den.",
     "advanced_success_loopback_enabled": "Kun tilbakekoblingsmodus aktivert. Start enheten på nytt for å bruke den.",
     "advanced_success_reset_config": "Konfigurasjonen ble tilbakestilt til standard",

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -95,6 +95,7 @@
     "advanced_ssh_default_user": "O usuário SSH padrão é",
     "advanced_ssh_public_key_label": "Chave Pública SSH",
     "advanced_ssh_public_key_placeholder": "Digite sua chave pública SSH",
+    "advanced_ssh_key_required_warning": "Uma chave pública é necessária para acesso SSH. Sem ela, você não conseguirá se conectar.",
     "advanced_success_download_diagnostics": "Diagnósticos baixados com sucesso",
     "advanced_success_loopback_disabled": "Modo somente loopback desativado. Reinicie seu dispositivo para aplicar.",
     "advanced_success_loopback_enabled": "Modo somente loopback ativado. Reinicie seu dispositivo para aplicar.",

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -95,6 +95,7 @@
     "advanced_ssh_default_user": "Пользователь по умолчанию для SSH:",
     "advanced_ssh_public_key_label": "Публичный SSH-ключ",
     "advanced_ssh_public_key_placeholder": "Введите ваш публичный SSH-ключ",
+    "advanced_ssh_key_required_warning": "Для SSH-доступа необходим публичный ключ. Без него подключение будет невозможно.",
     "advanced_success_download_diagnostics": "Диагностика успешно скачана",
     "advanced_success_loopback_disabled": "Режим только loopback отключён. Перезапустите устройство для применения.",
     "advanced_success_loopback_enabled": "Режим только loopback включён. Перезапустите устройство для применения.",

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "Standard SSH-användaren är",
     "advanced_ssh_public_key_label": "SSH-publik nyckel",
     "advanced_ssh_public_key_placeholder": "Ange din offentliga SSH-nyckel",
+    "advanced_ssh_key_required_warning": "En offentlig nyckel krävs för SSH-åtkomst. Utan en kommer du inte att kunna ansluta.",
     "advanced_success_loopback_disabled": "Endast loopback-läge inaktiverat. Starta om enheten för att tillämpa det.",
     "advanced_success_loopback_enabled": "Endast loopback-läge aktiverat. Starta om enheten för att tillämpa.",
     "advanced_success_reset_config": "Konfigurationen återställdes till standardinställningarna",

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -95,6 +95,7 @@
     "advanced_ssh_default_user": "預設 SSH 使用者為",
     "advanced_ssh_public_key_label": "SSH 公鑰",
     "advanced_ssh_public_key_placeholder": "輸入您的 SSH 公鑰",
+    "advanced_ssh_key_required_warning": "SSH 存取需要公鑰。沒有公鑰將無法連線。",
     "advanced_success_download_diagnostics": "診斷資料下載成功",
     "advanced_success_loopback_disabled": "單機回送模式已停用。請重新啟動您的裝置以套用。",
     "advanced_success_loopback_enabled": "單機回送模式已啟用。請重新啟動您的裝置以套用。",

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -91,6 +91,7 @@
     "advanced_ssh_default_user": "默认 SSH 用户为",
     "advanced_ssh_public_key_label": "SSH 公钥",
     "advanced_ssh_public_key_placeholder": "请输入您的 SSH 公钥",
+    "advanced_ssh_key_required_warning": "SSH 访问需要公钥。没有公钥将无法连接。",
     "advanced_success_loopback_disabled": "环回模式已禁用。请重启设备以应用更改。",
     "advanced_success_loopback_enabled": "环回模式已启用。请重启设备以应用更改。",
     "advanced_success_reset_config": "配置已成功恢复为默认设置。",

--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -331,6 +331,11 @@ export default function SettingsAdvancedRoute() {
                   {m.advanced_ssh_default_user()}
                   <strong>root</strong>.
                 </p>
+                {!sshKey?.trim() && (
+                  <p className="text-xs text-amber-600 dark:text-amber-500">
+                    {m.advanced_ssh_key_required_warning()}
+                  </p>
+                )}
                 <div className="flex items-center gap-x-2">
                   <Button
                     size="SM"


### PR DESCRIPTION
Fixes #1051

## Problem

The SSH public key field in Settings > Advanced does not indicate that a key is required for SSH to work. Users enable developer mode, skip the key field, save, and then cannot connect via SSH. The existing helper text only mentions the default user is root.

## Fix

Add an amber warning below the SSH key field that appears when the field is empty. Uses the same `text-amber-600` style already used by the developer mode warning icon on the same page. The warning disappears once a key is entered.

The save button remains functional with an empty key so users can intentionally clear their key to revoke SSH access.

Translations added for all 13 supported languages: da, de, en, es, fr, it, ja, nb, pt, ru, sv, zh, zh-tw.