### PR TITLE
fix(video): scale stream to fill available viewport

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -662,7 +662,7 @@ export default function WebRTCVideo({
                         controlsList="nofullscreen"
                         style={videoStyle}
                         className={cx(
-                          "max-h-full max-w-full object-contain transition-all duration-1000",
+                          "h-full w-full bg-black/50 object-contain transition-all duration-1000",
                           {
                             "bg-black/50 sm:min-h-[384px] sm:min-w-[512px]": !isDetachedWindow,
                             "cursor-none": settings.isCursorHidden,

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -628,7 +628,7 @@ export default function WebRTCVideo({
           {!isDetachedWindow && (
             <div
               className={cx(
-                "absolute inset-0 -z-0 bg-blue-50/40 opacity-80 dark:bg-slate-800/40",
+                "absolute inset-0 z-0 bg-blue-50/40 opacity-80 dark:bg-slate-800/40",
                 "bg-[radial-gradient(var(--color-blue-300)_0.5px,transparent_0.5px),radial-gradient(var(--color-blue-300)_0.5px,transparent_0.5px)] dark:bg-[radial-gradient(var(--color-slate-700)_0.5px,transparent_0.5px),radial-gradient(var(--color-slate-700)_0.5px,transparent_0.5px)]",
                 "bg-position-[0_0,10px_10px]",
                 "bg-size-[20px_20px]",
@@ -662,9 +662,8 @@ export default function WebRTCVideo({
                         controlsList="nofullscreen"
                         style={videoStyle}
                         className={cx(
-                          "h-full w-full bg-black/50 object-contain transition-all duration-1000",
+                          "h-full w-full object-contain transition-all duration-1000",
                           {
-                            "bg-black/50 sm:min-h-[384px] sm:min-w-[512px]": !isDetachedWindow,
                             "cursor-none": settings.isCursorHidden,
                             "pointer-events-none": isOcrMode,
                             "opacity-0!":
@@ -673,7 +672,7 @@ export default function WebRTCVideo({
                               hasConnectionIssues ||
                               peerConnectionState !== "connected",
                             "opacity-60!": showPointerLockBar,
-                            "animate-slideUpFade border border-slate-800/30 shadow-xs dark:border-slate-300/20":
+                            "animate-slideUpFade":
                               isPlaying && !isDetachedWindow,
                           },
                         )}


### PR DESCRIPTION
Fixes #121
Fixes #1147
Fixes #1323

## Problem

On monitors larger than the remote stream resolution, the video renders at its native pixel size with large margins. A 1920x1080 stream on a 5120x2160 monitor occupies roughly a third of the viewport. Reported on both Firefox and Chrome in windowed and fullscreen modes.

## Root cause

The video element uses `max-h-full max-w-full` which prevents overflow but never scales the video beyond its intrinsic resolution. These classes cap size at the container but do not stretch to fill it.

## Fix

Replace `max-h-full max-w-full` with `h-full w-full` so the video element fills its container. `object-contain` is retained so aspect ratio is preserved — letterboxing or pillarboxing appears as needed, but the video uses all available space.

Drop the `sm:min-h-[384px] sm:min-w-[512px]` minimum size constraints which are no longer needed.

## Mouse mapping

The absolute mouse coordinate math in `useMouse.ts` already accounts for `object-contain` scaling by computing the effective display area from `videoClientWidth/Height` vs `videoWidth/Height` and calculating pillarbox/letterbox offsets (lines 78-96). Mouse mapping remains correct at any scale factor.

Fixes #403

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CSS-only changes to `WebRTCVideo` layout/stacking; main impact is visual sizing and z-index behavior that could affect overlay layering in some browsers.
> 
> **Overview**
> Fixes video scaling on large viewports by changing the `<video>` sizing from `max-h-full max-w-full` to `h-full w-full` while keeping `object-contain`, so the stream expands to fill the available container space.
> 
> Adjusts presentation details by removing detached-window min-size constraints and dropping the border/shadow styling tied to the play animation, and tweaks the background layer from `-z-0` to `z-0` to alter stacking order.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f93748b0854ba135421a9458bd81a9bc35c42d1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->