### PR TITLE
fix(hid): skip mouse reports when mouse device is disabled

### DIFF
--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -86,6 +86,10 @@ func (u *UsbGadget) absMouseWriteHidFile(data []byte) error {
 }
 
 func (u *UsbGadget) AbsMouseReport(x int, y int, buttons uint8) error {
+	if !u.enabledDevices.AbsoluteMouse {
+		return nil
+	}
+
 	u.absMouseLock.Lock()
 	defer u.absMouseLock.Unlock()
 
@@ -106,6 +110,10 @@ func (u *UsbGadget) AbsMouseReport(x int, y int, buttons uint8) error {
 }
 
 func (u *UsbGadget) AbsMouseWheelReport(wheelY int8) error {
+	if !u.enabledDevices.AbsoluteMouse {
+		return nil
+	}
+
 	u.absMouseLock.Lock()
 	defer u.absMouseLock.Unlock()
 

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -76,6 +76,10 @@ func (u *UsbGadget) relMouseWriteHidFile(data []byte) error {
 }
 
 func (u *UsbGadget) RelMouseReport(mx int8, my int8, buttons uint8) error {
+	if !u.enabledDevices.RelativeMouse {
+		return nil
+	}
+
 	u.relMouseLock.Lock()
 	defer u.relMouseLock.Unlock()
 


### PR DESCRIPTION
Fixes #546

## Problem

With USB mouse disabled in device settings, every mouse movement over the video still sends an RPC to the backend, which tries to open `/dev/hidg1`, fails (device file does not exist), and returns an error to the client. This happens on every mouse event, wasting CPU on both sides and flooding the console with errors:

```
{ code: -32603, data: "failed to open hidg1: open /dev/hidg1: no such file or directory", message: "Internal error" }
```

## Fix

Add an early return in `AbsMouseReport`, `AbsMouseWheelReport`, and `RelMouseReport` when the corresponding device (`enabledDevices.AbsoluteMouse` / `enabledDevices.RelativeMouse`) is disabled. The check is outside the mutex lock since `enabledDevices` is set at construction and not mutated at runtime.

2 files, 12 lines added.