### PR TITLE
chore: use consistent @/ import path for ru_RU keyboard layout

### DIFF
--- a/ui/src/keyboardLayouts.ts
+++ b/ui/src/keyboardLayouts.ts
@@ -40,7 +40,7 @@ import { ja_JP } from "@/keyboardLayouts/ja_JP";
 import { nb_NO } from "@/keyboardLayouts/nb_NO";
 import { sv_SE } from "@/keyboardLayouts/sv_SE";
 import { sl_SI } from "@/keyboardLayouts/sl_SI";
-import { ru_RU } from "./keyboardLayouts/ru_RU";
+import { ru_RU } from "@/keyboardLayouts/ru_RU";
 
 export const keyboards: KeyboardLayout[] = [
   cs_CZ,


### PR DESCRIPTION
The ru_RU keyboard layout import in `keyboardLayouts.ts` uses a relative path (`"./keyboardLayouts/ru_RU"`) while all other layout imports use the `@/` path alias. Align it with the rest.