### PR TITLE
fix(ui): use consistent name for KVM terminal across action bar and panel

### DIFF
--- a/ui/src/components/ActionBar.tsx
+++ b/ui/src/components/ActionBar.tsx
@@ -58,7 +58,7 @@ export default function Actionbar({
             <Button
               size="XS"
               theme="light"
-              text={m.action_bar_web_terminal()}
+              text={m.kvm_terminal()}
               LeadingIcon={({ className }) => <CommandLineIcon className={className} />}
               onClick={() => setTerminalType(terminalType === "kvm" ? "none" : "kvm")}
             />


### PR DESCRIPTION
Fixes #391

The action bar button says "Web Terminal" (`action_bar_web_terminal`) while the terminal panel header says "KVM Terminal" (`kvm_terminal`) for the same feature. Replace the action bar reference with `kvm_terminal` so both locations use the same localized string.