### PR TITLE
fix(ui): restore terminal focus after closing settings modal

### DIFF
--- a/ui/src/components/Terminal.tsx
+++ b/ui/src/components/Terminal.tsx
@@ -69,7 +69,8 @@ function Terminal({
   readonly dataChannel: RTCDataChannel;
   readonly type: AvailableTerminalTypes;
 }) {
-  const { terminalType, setTerminalType, setDisableVideoFocusTrap } = useUiStore();
+  const { terminalType, setTerminalType, setDisableVideoFocusTrap, disableVideoFocusTrap } =
+    useUiStore();
   const { terminator } = useTerminalStore();
   const { instance, ref } = useXTerm({ options: TERMINAL_CONFIG });
   const [terminalPaused, setTerminalPaused] = useState(false);
@@ -88,6 +89,14 @@ function Terminal({
       setDisableVideoFocusTrap(false);
     };
   }, [setDisableVideoFocusTrap, isTerminalTypeEnabled]);
+
+  // Re-focus xterm when the focus trap is released back to the terminal
+  // (e.g. after closing the Settings modal while a terminal is open)
+  useEffect(() => {
+    if (disableVideoFocusTrap && isTerminalTypeEnabled && instance) {
+      instance.focus();
+    }
+  }, [disableVideoFocusTrap, isTerminalTypeEnabled, instance]);
 
   const readyState = dataChannel.readyState;
 

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -115,8 +115,14 @@ export default function KvmIdRoute() {
   const authMode = "authMode" in loaderResp ? loaderResp.authMode : null;
 
   const params = useParams() as { id: string };
-  const { sidebarView, setSidebarView, disableVideoFocusTrap, rebootState, setRebootState } =
-    useUiStore();
+  const {
+    sidebarView,
+    setSidebarView,
+    disableVideoFocusTrap,
+    setDisableVideoFocusTrap,
+    rebootState,
+    setRebootState,
+  } = useUiStore();
   const [queryParams, setQueryParams] = useSearchParams();
 
   const {
@@ -867,7 +873,14 @@ export default function KvmIdRoute() {
   const outlet = useOutlet();
   const onModalClose = useCallback(() => {
     if (location.pathname !== "/other-session") navigateTo("/");
-  }, [navigateTo, location.pathname]);
+
+    // Re-disable the focus trap if a terminal is still active, otherwise
+    // FocusTrap reclaims focus and the terminal becomes unresponsive.
+    const { terminalType } = useUiStore.getState();
+    if (terminalType !== "none") {
+      setDisableVideoFocusTrap(true);
+    }
+  }, [navigateTo, location.pathname, setDisableVideoFocusTrap]);
 
   const { appVersion, getLocalVersion } = useVersion();
 


### PR DESCRIPTION
Fixes #390

## Problem

1. Open a terminal (KVM or serial)
2. Click Settings
3. Close Settings
4. Terminal cursor changes to outline (unfocused), keyboard input does not reach the terminal
5. Only fix is closing and reopening the terminal

## Root cause

When the settings modal closes, `FocusTrap` re-activates and grabs focus to its `#videoFocusTrap` fallback button. `onModalClose` does not check whether a terminal is still active, so `disableVideoFocusTrap` is not re-asserted. The xterm instance loses focus and has no mechanism to reclaim it.

## Fix

**devices.$id.tsx** — In `onModalClose`, read the current `terminalType` from `useUiStore`. If a terminal is active (`!= "none"`), re-set `disableVideoFocusTrap` to `true` so the FocusTrap stays paused.

**Terminal.tsx** — Add an effect that calls `instance.focus()` when `disableVideoFocusTrap` transitions to `true` while the terminal is visible. This re-focuses the xterm instance after the FocusTrap releases.