### PR TITLE
fix(security): require authentication on /metrics endpoint

### DIFF
--- a/web.go
+++ b/web.go
@@ -142,7 +142,9 @@ func setupRouter() *gin.Engine {
 	r.POST("/device/setup", handleSetup)
 
 	// A Prometheus metrics endpoint.
-	r.GET("/metrics", gin.WrapH(promhttp.Handler()))
+	// Requires auth (cookie or basic auth) when password mode is enabled,
+	// open when localAuthMode is noPassword (consistent with other endpoints).
+	r.GET("/metrics", metricsAuthMiddleware(), gin.WrapH(promhttp.Handler()))
 
 	// Developer mode protected routes
 	developerModeRouter := r.Group("/developer/")
@@ -551,6 +553,39 @@ func protectedMiddleware() gin.HandlerFunc {
 func sendErrorJsonThenAbort(c *gin.Context, status int, message string) {
 	c.JSON(status, gin.H{"error": message})
 	c.Abort()
+}
+
+// metricsAuthMiddleware authenticates the /metrics endpoint using either the
+// session cookie or HTTP basic auth (for Prometheus scrape configs). When
+// localAuthMode is noPassword, all requests are allowed through — consistent
+// with every other endpoint on the device.
+func metricsAuthMiddleware() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		if config.LocalAuthMode == "noPassword" {
+			c.Next()
+			return
+		}
+
+		// Try cookie auth first (browser access)
+		authToken, err := c.Cookie("authToken")
+		if err == nil && authToken == config.LocalAuthToken && authToken != "" {
+			c.Next()
+			return
+		}
+
+		// Fall back to basic auth (Prometheus scraper)
+		_, password, ok := c.Request.BasicAuth()
+		if ok {
+			if err := bcrypt.CompareHashAndPassword([]byte(config.HashedPassword), []byte(password)); err == nil {
+				c.Next()
+				return
+			}
+		}
+
+		c.Header("WWW-Authenticate", `Basic realm="JetKVM Metrics"`)
+		c.JSON(http.StatusUnauthorized, gin.H{"error": "Unauthorized"})
+		c.Abort()
+	}
 }
 
 func basicAuthProtectedMiddleware(requireDeveloperMode bool) gin.HandlerFunc {


### PR DESCRIPTION
Alternative approach to #299 that addresses the security concern without disabling the endpoint.

## Problem

`/metrics` is the only endpoint on the device with no authentication. Every other route is either public-by-design (`/device/status`, `/auth/login-local`) or behind `protectedMiddleware` (cookie auth) or `basicAuthProtectedMiddleware` (basic auth). The metrics endpoint sits outside all route groups with no auth at all.

## Why #299 stalled

PR #299 proposed a config toggle to disable metrics entirely. This drew pushback from @SuperQ who correctly pointed out that disabling metrics does not improve security — the endpoint should simply require the same auth as everything else. @IDisposable raised a CPU overhead concern, but gathering only happens on scrape so a toggle does not help there either. The PR has been in draft with `needs-rework` since March 2025.

## What this PR does instead

Add a `metricsAuthMiddleware` that accepts authentication via two methods:

1. **Session cookie** (`authToken`) — same as `protectedMiddleware`. Browser access to `/metrics` works if logged in.

2. **HTTP basic auth** — same password verification as `basicAuthProtectedMiddleware`. This is how Prometheus scrape configs authenticate:

   ```yaml
   scrape_configs:
     - job_name: jetkvm
       basic_auth:
         username: admin  # username is ignored, only password is checked
         password: <device-password>
       static_configs:
         - targets: ['192.168.1.100']
   ```

3. **No-password mode passthrough** — when `localAuthMode` is `noPassword`, the middleware passes all requests through. Consistent with every other protected endpoint on the device.

## What this does NOT do

- No config toggle. The endpoint is always available. Monitoring setups do not break.
- No new config fields. No UI changes. No migration needed.
- No change for no-password mode users. Their scrape configs keep working as-is.

## How it addresses each concern from #299

| Concern | #299 approach | This PR |
|---------|--------------|---------|
| @ym: metrics endpoint is unauthenticated | Disable by default | Require auth (cookie or basic auth) |
| @SuperQ: do not disable metrics | Disabled by default | Always available, just authenticated |
| @IDisposable: CPU overhead | Config toggle | Not relevant — gathering only on scrape regardless |