### PR TITLE
fix(security): enforce bcrypt 72-byte password length limit

### DIFF
--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Indtast venligst en ny adgangskode",
     "local_auth_error_enter_old_password": "Indtast venligst din gamle adgangskode",
     "local_auth_error_enter_password": "Indtast venligst en adgangskode",
+    "local_auth_error_password_too_long": "Adgangskode må højst være 72 tegn",
     "local_auth_error_password_too_short": "Adgangskoden skal være mindst 8 tegn",
     "local_auth_error_passwords_not_match": "Adgangskoderne stemmer ikke overens",
     "local_auth_error_rate_limited": "For mange mislykkede forsøg. Prøv igen om {minutes} minutter.",

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Bitte geben Sie ein neues Passwort ein",
     "local_auth_error_enter_old_password": "Bitte geben Sie Ihr altes Passwort ein",
     "local_auth_error_enter_password": "Bitte geben Sie ein Passwort ein",
+    "local_auth_error_password_too_long": "Passwort darf höchstens 72 Zeichen lang sein",
     "local_auth_error_password_too_short": "Das Passwort muss mindestens 8 Zeichen lang sein",
     "local_auth_error_passwords_not_match": "Passwörter stimmen nicht überein",
     "local_auth_error_rate_limited": "Zu viele fehlgeschlagene Versuche. Bitte versuchen Sie es in {minutes} Minuten erneut.",

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -425,6 +425,7 @@
     "local_auth_error_enter_new_password": "Please enter a new password",
     "local_auth_error_enter_old_password": "Please enter your old password",
     "local_auth_error_enter_password": "Please enter a password",
+    "local_auth_error_password_too_long": "Password must be at most 72 characters",
     "local_auth_error_password_too_short": "Password must be at least 8 characters",
     "local_auth_error_passwords_not_match": "Passwords do not match",
     "local_auth_error_rate_limited": "Too many failed attempts. Please try again in {minutes} minutes.",

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Por favor, introduzca una nueva contraseña",
     "local_auth_error_enter_old_password": "Por favor, introduzca su contraseña anterior",
     "local_auth_error_enter_password": "Por favor, introduzca una contraseña",
+    "local_auth_error_password_too_long": "La contraseña debe tener como máximo 72 caracteres",
     "local_auth_error_password_too_short": "La contraseña debe tener al menos 8 caracteres",
     "local_auth_error_passwords_not_match": "Las contraseñas no coinciden",
     "local_auth_error_rate_limited": "Demasiados intentos fallidos. Por favor, inténtelo de nuevo en {minutes} minutos.",

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Veuillez entrer un nouveau mot de passe",
     "local_auth_error_enter_old_password": "Veuillez saisir votre ancien mot de passe",
     "local_auth_error_enter_password": "Veuillez entrer un mot de passe",
+    "local_auth_error_password_too_long": "Le mot de passe doit contenir au maximum 72 caractères",
     "local_auth_error_password_too_short": "Le mot de passe doit contenir au moins 8 caractères",
     "local_auth_error_passwords_not_match": "Les mots de passe ne correspondent pas",
     "local_auth_error_rate_limited": "Trop de tentatives échouées. Veuillez réessayer dans {minutes} minutes.",

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Inserisci una nuova password",
     "local_auth_error_enter_old_password": "Inserisci la tua vecchia password",
     "local_auth_error_enter_password": "Inserisci una password",
+    "local_auth_error_password_too_long": "La password deve contenere al massimo 72 caratteri",
     "local_auth_error_password_too_short": "La password deve contenere almeno 8 caratteri",
     "local_auth_error_passwords_not_match": "Le password non corrispondono",
     "local_auth_error_rate_limited": "Troppi tentativi falliti. Riprova tra {minutes} minuti.",

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -425,6 +425,7 @@
     "local_auth_error_enter_new_password": "新しいパスワードを入力してください",
     "local_auth_error_enter_old_password": "古いパスワードを入力してください",
     "local_auth_error_enter_password": "パスワードを入力してください",
+    "local_auth_error_password_too_long": "パスワードは72文字以内にしてください",
     "local_auth_error_password_too_short": "パスワードは8文字以上である必要があります",
     "local_auth_error_passwords_not_match": "パスワードが一致しません",
     "local_auth_error_rate_limited": "試行回数が多すぎます。{minutes}分後に再試行してください。",

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Vennligst skriv inn et nytt passord",
     "local_auth_error_enter_old_password": "Vennligst skriv inn det gamle passordet ditt",
     "local_auth_error_enter_password": "Vennligst skriv inn et passord",
+    "local_auth_error_password_too_long": "Passordet kan være maks 72 tegn",
     "local_auth_error_password_too_short": "Passordet må være minst 8 tegn",
     "local_auth_error_passwords_not_match": "Passordene stemmer ikke overens",
     "local_auth_error_rate_limited": "For mange mislykkede forsøk. Vennligst prøv igjen om {minutes} minutter.",

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -425,6 +425,7 @@
     "local_auth_error_enter_new_password": "Por favor, digite uma nova senha",
     "local_auth_error_enter_old_password": "Por favor, digite sua senha antiga",
     "local_auth_error_enter_password": "Por favor, digite uma senha",
+    "local_auth_error_password_too_long": "A senha deve ter no máximo 72 caracteres",
     "local_auth_error_password_too_short": "A senha deve ter pelo menos 8 caracteres",
     "local_auth_error_passwords_not_match": "As senhas não correspondem",
     "local_auth_error_rate_limited": "Muitas tentativas falhadas. Por favor, tente novamente em {minutes} minutos.",

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -425,6 +425,7 @@
     "local_auth_error_enter_new_password": "Пожалуйста, введите новый пароль",
     "local_auth_error_enter_old_password": "Пожалуйста, введите ваш старый пароль",
     "local_auth_error_enter_password": "Пожалуйста, введите пароль",
+    "local_auth_error_password_too_long": "Пароль должен содержать не более 72 символов",
     "local_auth_error_password_too_short": "Пароль должен быть не менее 8 символов",
     "local_auth_error_passwords_not_match": "Пароли не совпадают",
     "local_auth_error_rate_limited": "Слишком много неудачных попыток. Пожалуйста, попробуйте снова через {minutes} минут.",

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "Ange ett nytt lösenord",
     "local_auth_error_enter_old_password": "Ange ditt gamla lösenord",
     "local_auth_error_enter_password": "Ange ett lösenord",
+    "local_auth_error_password_too_long": "Lösenordet får vara högst 72 tecken",
     "local_auth_error_password_too_short": "Lösenordet måste vara minst 8 tecken",
     "local_auth_error_passwords_not_match": "Lösenorden matchar inte",
     "local_auth_error_rate_limited": "För många misslyckade försök. Försök igen om {minutes} minuter.",

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -425,6 +425,7 @@
     "local_auth_error_enter_new_password": "請輸入新密碼",
     "local_auth_error_enter_old_password": "請輸入您的舊密碼",
     "local_auth_error_enter_password": "請輸入密碼",
+    "local_auth_error_password_too_long": "密碼不能超過72個字元",
     "local_auth_error_password_too_short": "密碼必須至少8個字元",
     "local_auth_error_passwords_not_match": "密碼不相符",
     "local_auth_error_rate_limited": "嘗試次數過多。請在 {minutes} 分鐘後重試。",

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -420,6 +420,7 @@
     "local_auth_error_enter_new_password": "请输入新密码。",
     "local_auth_error_enter_old_password": "请输入您的旧密码。",
     "local_auth_error_enter_password": "请输入密码。",
+    "local_auth_error_password_too_long": "密码不能超过72个字符",
     "local_auth_error_password_too_short": "密码必须至少8个字符",
     "local_auth_error_passwords_not_match": "两次输入的密码不匹配。",
     "local_auth_error_rate_limited": "尝试次数过多。请在 {minutes} 分钟后重试。",

--- a/ui/src/routes/devices.$id.settings.access.local-auth.tsx
+++ b/ui/src/routes/devices.$id.settings.access.local-auth.tsx
@@ -9,6 +9,7 @@ import api from "@/api";
 import { m } from "@localizations/messages.js";
 
 export const MIN_PASSWORD_LENGTH = 8;
+export const MAX_PASSWORD_LENGTH = 72;
 
 export default function SecurityAccessLocalAuthRoute() {
   const { setModalView } = useLocalAuthModalStore();
@@ -40,6 +41,11 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
 
     if (password.length < MIN_PASSWORD_LENGTH) {
       setError(m.local_auth_error_password_too_short());
+      return;
+    }
+
+    if (password.length > MAX_PASSWORD_LENGTH) {
+      setError(m.local_auth_error_password_too_long());
       return;
     }
 
@@ -82,6 +88,11 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
     // Only validate length for new password, not old password (may be shorter from before this requirement)
     if (newPassword.length < MIN_PASSWORD_LENGTH) {
       setError(m.local_auth_error_password_too_short());
+      return;
+    }
+
+    if (newPassword.length > MAX_PASSWORD_LENGTH) {
+      setError(m.local_auth_error_password_too_long());
       return;
     }
 

--- a/ui/src/routes/welcome-local.password.tsx
+++ b/ui/src/routes/welcome-local.password.tsx
@@ -13,7 +13,10 @@ import { Button } from "@components/Button";
 import { DEVICE_API } from "@/ui.config";
 import api from "@/api";
 import { m } from "@localizations/messages.js";
-import { MIN_PASSWORD_LENGTH } from "@routes/devices.$id.settings.access.local-auth";
+import {
+  MIN_PASSWORD_LENGTH,
+  MAX_PASSWORD_LENGTH,
+} from "@routes/devices.$id.settings.access.local-auth";
 
 import { DeviceStatus } from "./welcome-local";
 
@@ -33,6 +36,10 @@ const action: ActionFunction = async ({ request }: ActionFunctionArgs) => {
 
   if (!password || password.length < MIN_PASSWORD_LENGTH) {
     return { error: m.local_auth_error_password_too_short() };
+  }
+
+  if (password.length > MAX_PASSWORD_LENGTH) {
+    return { error: m.local_auth_error_password_too_long() };
   }
 
   if (password !== confirmPassword) {

--- a/web.go
+++ b/web.go
@@ -83,6 +83,11 @@ var cachableFileExtensions = []string{
 // validating existing passwords (to maintain backward compatibility).
 const MinPasswordLength = 8
 
+// MaxPasswordLength is the maximum length bcrypt can hash. Go's bcrypt
+// implementation rejects passwords over 72 bytes rather than silently
+// truncating them.
+const MaxPasswordLength = 72
+
 func setupRouter() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DisableConsoleColor()
@@ -664,6 +669,11 @@ func handleCreatePassword(c *gin.Context) {
 		return
 	}
 
+	if len(req.Password) > MaxPasswordLength {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Password must be at most 72 characters"})
+		return
+	}
+
 	hashedPassword, err := bcrypt.GenerateFromPassword([]byte(req.Password), bcrypt.DefaultCost)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to hash password"})
@@ -706,6 +716,11 @@ func handleUpdatePassword(c *gin.Context) {
 	// Validate new password length (not old password - may be shorter from before this requirement)
 	if len(req.NewPassword) < MinPasswordLength {
 		c.JSON(http.StatusBadRequest, gin.H{"error": "Password must be at least 8 characters"})
+		return
+	}
+
+	if len(req.NewPassword) > MaxPasswordLength {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "Password must be at most 72 characters"})
 		return
 	}
 
@@ -828,6 +843,11 @@ func handleSetup(c *gin.Context) {
 
 		if len(req.Password) < MinPasswordLength {
 			c.JSON(http.StatusBadRequest, gin.H{"error": "Password must be at least 8 characters"})
+			return
+		}
+
+		if len(req.Password) > MaxPasswordLength {
+			c.JSON(http.StatusBadRequest, gin.H{"error": "Password must be at most 72 characters"})
 			return
 		}
 


### PR DESCRIPTION
Fixes #60

## Problem

Go's `bcrypt.GenerateFromPassword` rejects passwords over 72 bytes with an error. The code calls it without length checking in `handleSetup`, `handleCreatePassword`, and `handleUpdatePassword`. The error surfaces as "Failed to hash password" — a useless message that gives no indication of the actual cause. Multiple users report being unable to set passwords during initial setup, with some getting stuck in a state where the device asks for a password that was never successfully saved.

## Approach considered

Three options were discussed in the issue thread:

1. **Validate and reject** — add a 72-character max length check, return a clear error. No migration, no backwards compatibility issues, honest to the user about the limit. 72 characters of bcrypt is already far beyond what brute force can crack on a LAN device.

2. **Pre-hash with SHA-256** — `bcrypt(sha256(password))`, used by Dropbox/Django. SHA-256 produces 32 bytes regardless of input, removing the limit entirely. But this is a breaking change: existing hashed passwords are bcrypt-only, so all users would need to re-set passwords after upgrade. Requires a migration flag in config.

3. **Switch to argon2id** — current OWASP recommendation, no length limit. But a complete password hashing migration with dependency changes and backwards compatibility handling.

This PR implements option 1 as the minimal fix. Options 2 or 3 can be pursued separately if there is demand for passwords longer than 72 characters.

## Changes

**Backend (`web.go`):**
- Add `MaxPasswordLength = 72` constant
- Add length check before `bcrypt.GenerateFromPassword` in `handleSetup`, `handleCreatePassword`, `handleUpdatePassword`
- Clear error message: "Password must be at most 72 characters"

**Frontend:**
- Add `MAX_PASSWORD_LENGTH = 72` alongside existing `MIN_PASSWORD_LENGTH`
- Validate in `handleCreatePassword`, `handleUpdatePassword` (settings local-auth dialog)
- Validate in welcome password setup flow
- Localized `local_auth_error_password_too_long` in all 13 languages