### PR TITLE
fix(security): redact secrets from diagnostics ZIP export

### DIFF
--- a/web.go
+++ b/web.go
@@ -924,8 +924,13 @@ func handleDiagnosticsDownload(c *gin.Context) {
 			}
 		}
 
-		// 4. Configuration
-		if configData, err := json.MarshalIndent(config, "", "  "); err == nil {
+		// 4. Configuration (with secrets redacted)
+		redactedConfig := *config
+		redactedConfig.CloudToken = ""
+		redactedConfig.LocalAuthToken = ""
+		redactedConfig.HashedPassword = ""
+		redactedConfig.GoogleIdentity = ""
+		if configData, err := json.MarshalIndent(redactedConfig, "", "  "); err == nil {
 			if err := addBytesToZip(zw, "config.json", configData); err != nil {
 				logger.Warn().Err(err).Msg("failed to add config to zip")
 			}


### PR DESCRIPTION
## Problem

`GET /diagnostics` serializes the entire `Config` struct into `config.json` inside the ZIP archive. This includes:

- `CloudToken` — bearer token granting full cloud API access
- `LocalAuthToken` — session authentication credential
- `HashedPassword` — bcrypt hash (crackable offline)
- `GoogleIdentity` — user identity string

Users download this ZIP for troubleshooting and share it in GitHub issues or support channels. Anyone who receives the ZIP can extract these credentials.

## Fix

Copy the config struct and zero the four sensitive fields before serialization. The diagnostics ZIP retains all non-secret configuration (network settings, display settings, USB config, etc.) for debugging purposes.