### PR TITLE
fix(security): sanitize filename in rpcMountBuiltInImage

### DIFF
--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -103,6 +103,11 @@ func rpcMountBuiltInImage(filename string) error {
 		return err
 	}
 
+	filename, err := sanitizeFilename(filename)
+	if err != nil {
+		return fmt.Errorf("invalid filename: %w", err)
+	}
+
 	imagePath := filepath.Join(imagesFolder, filename)
 
 	// Check if the file exists in the imagesFolder


### PR DESCRIPTION
## Problem

`rpcMountBuiltInImage` passes the user-provided `filename` parameter directly to `filepath.Join` (line 106) and `resource.ResourceFS.Open` (line 114) without sanitization. A crafted filename containing path traversal sequences (e.g. `../../etc/shadow`) can access files outside the images directory.

The `sanitizeFilename()` function already exists in the same file (line 403) and is used by every other file operation — `rpcDeleteStorageFile`, `rpcStartStorageFileUpload`, `rpcMountWithStorage` — but `rpcMountBuiltInImage` was missed.

## Fix

Call `sanitizeFilename()` before using the filename. Rejects absolute paths and `..` sequences, extracts `filepath.Base`. Same validation applied to all other storage operations in the file.