### PR TITLE
fix(security): persist session token to disk on login

### DIFF
--- a/web.go
+++ b/web.go
@@ -512,6 +512,11 @@ func handleLogin(c *gin.Context) {
 
 	config.LocalAuthToken = uuid.New().String()
 
+	if err := SaveConfig(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to save configuration"})
+		return
+	}
+
 	// Set the cookie
 	c.SetCookie("authToken", config.LocalAuthToken, 7*24*60*60, "/", "", false, true)
 


### PR DESCRIPTION
## Problem

`handleLogin` generates a new `LocalAuthToken` UUID (line 513) but does not call `SaveConfig()` to persist it to disk. Every other auth handler in the file does:

- `handleCreatePassword` — line 686 ✓
- `handleUpdatePassword` — line 740 ✓
- `handleLogout` — line 523 ✓
- `handleSetup` — line 872 ✓
- `handleLogin` — **missing**

If the device reboots after login but before any other config-saving operation, the in-memory token is lost. On restart, the previous token from disk is reloaded. The user's session cookie (containing the new token) becomes invalid. The stale on-disk token — which may belong to a previous session — is now the valid credential.

## Fix

Add `SaveConfig()` after token generation in `handleLogin`, matching the pattern used by every other auth handler.