### PR TITLE
fix(timesync): remove pool.ntp.org from default NTP servers

### DIFF
--- a/internal/timesync/ntp.go
+++ b/internal/timesync/ntp.go
@@ -29,13 +29,11 @@ var DefaultNTPServerIPs = []string{
 }
 
 var DefaultNTPServerHostnames = []string{
-	// should use something from https://github.com/jauderho/public-ntp-servers
 	"time.apple.com",
 	"time.aws.com",
 	"time.windows.com",
 	"time.google.com",
 	"time.cloudflare.com",
-	"pool.ntp.org",
 }
 
 func (t *TimeSync) filterNTPServers(ntpServers []string) ([]string, error) {


### PR DESCRIPTION
Closes #698

## Problem

`pool.ntp.org` is hardcoded in `DefaultNTPServerHostnames` as a
fallback NTP server. The NTP Pool project's vendor policy
(https://www.ntppool.org/en/vendors.html) prohibits using the
default `pool.ntp.org` zone names in software or appliances
without a registered vendor zone. JetKVM does not have one.

## Fix

Remove `pool.ntp.org` from the fallback hostname list. The
remaining entries — five vendor-operated NTP services (Apple,
AWS, Microsoft, Google, Cloudflare) plus 12 static IPs for
Google and Cloudflare — provide sufficient redundancy. The sync
loop tries IPs first (no DNS dependency), then falls through to
hostnames, so removing one hostname from the end of the list has
negligible impact on sync reliability.

## What this does NOT do

This does not register a vendor zone with the NTP Pool project.
If the maintainers want to use pool.ntp.org in future, they can
apply for a zone at https://manage.ntppool.org/manage/vendor and
add something like `0.jetkvm.pool.ntp.org` back to the list.