### PR TITLE
fix(webrtc): stop restricting ICE candidate gathering to mDNS net types

### DIFF
--- a/webrtc.go
+++ b/webrtc.go
@@ -253,16 +253,7 @@ func newSession(config SessionConfig) (*Session, error) {
 		LoggerFactory: logging.GetPionDefaultLoggerFactory(),
 	}
 
-	mDNSNetworkTypes := make([]webrtc.NetworkType, 0)
-	if config.MDNSMode == "auto" || config.MDNSMode == "ipv4_only" {
-		mDNSNetworkTypes = append(mDNSNetworkTypes, webrtc.NetworkTypeUDP4)
-	}
-	if config.MDNSMode == "auto" || config.MDNSMode == "ipv6_only" {
-		mDNSNetworkTypes = append(mDNSNetworkTypes, webrtc.NetworkTypeUDP6)
-	}
-
-	if len(mDNSNetworkTypes) > 0 {
-		webrtcSettingEngine.SetNetworkTypes(mDNSNetworkTypes)
+	if config.MDNSMode != "" && config.MDNSMode != "disabled" {
 		webrtcSettingEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeQueryOnly)
 	} else {
 		webrtcSettingEngine.SetICEMulticastDNSMode(ice.MulticastDNSModeDisabled)


### PR DESCRIPTION
### Summary

SetNetworkTypes() controls which network types the ICE agent uses for ALL candidate gathering, not just mDNS. When `mdns_mode` was `ipv6_only`" only UDP6 candidates were gathered - if IPv6 wasn't working, no candidates were gathered at all, making WebRTC connections impossible.

Decouple mDNS mode from ICE network types so candidates are gathered on all available networks regardless of the mDNS configuration.

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
