### PR TITLE
UI/split button clipboard

### DIFF
--- a/ui/src/components/ActionBar.tsx
+++ b/ui/src/components/ActionBar.tsx
@@ -5,6 +5,12 @@ import { FaKeyboard } from "react-icons/fa6";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { CommandLineIcon } from "@heroicons/react/20/solid";
 
+import {
+  SplitButtonGroup,
+  SplitButtonPrimary,
+  SplitButtonCaret,
+} from "@components/SplitButton";
+
 import { cx } from "@/cva.config";
 import {
   useHidStore,
@@ -76,26 +82,26 @@ export default function Actionbar({
               onClick={() => setTerminalType(terminalType === "kvm" ? "none" : "kvm")}
             />
           )}
-          <Button
-            size="XS"
-            theme={isOcrMode ? "primary" : "light"}
-            text={m.action_bar_copy_text()}
-            LeadingIcon={LuScanText}
-            disabled={videoWidth === 0 || videoHeight === 0}
-            onClick={() => setOcrMode(!isOcrMode)}
-          />
           <Popover>
-            <PopoverButton as={Fragment}>
-              <Button
-                size="XS"
-                theme="light"
-                text={m.paste_text()}
-                LeadingIcon={MdOutlineContentPasteGo}
-                onClick={() => {
-                  setDisableVideoFocusTrap(true);
-                }}
+            <SplitButtonGroup>
+              <PopoverButton
+                as={SplitButtonPrimary}
+                icon={MdOutlineContentPasteGo}
+                label={m.paste_text()}
+                onClick={() => setDisableVideoFocusTrap(true)}
               />
-            </PopoverButton>
+              <SplitButtonCaret
+                menuItems={[
+                  {
+                    label: m.action_bar_copy_text(),
+                    icon: LuScanText,
+                    onClick: () => setOcrMode(!isOcrMode),
+                    active: isOcrMode,
+                    disabled: videoWidth === 0 || videoHeight === 0,
+                  },
+                ]}
+              />
+            </SplitButtonGroup>
             <PopoverPanel
               anchor="bottom start"
               transition

--- a/ui/src/components/ActionBar.tsx
+++ b/ui/src/components/ActionBar.tsx
@@ -5,11 +5,7 @@ import { FaKeyboard } from "react-icons/fa6";
 import { Popover, PopoverButton, PopoverPanel } from "@headlessui/react";
 import { CommandLineIcon } from "@heroicons/react/20/solid";
 
-import {
-  SplitButtonGroup,
-  SplitButtonPrimary,
-  SplitButtonCaret,
-} from "@components/SplitButton";
+import { SplitButtonGroup, SplitButtonPrimary, SplitButtonCaret } from "@components/SplitButton";
 
 import { cx } from "@/cva.config";
 import {

--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -168,6 +168,7 @@ type ButtonPropsType = Pick<
     fetcher?: FetcherWithComponents<unknown>;
   };
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const Button = React.forwardRef<HTMLButtonElement, ButtonPropsType>(
   ({ type, disabled, onClick, formNoValidate, loading, fetcher, ...props }, ref) => {
     const classes = cx(

--- a/ui/src/components/SplitButton.tsx
+++ b/ui/src/components/SplitButton.tsx
@@ -1,0 +1,147 @@
+import React from "react";
+import { Menu, MenuButton, MenuItem, MenuItems } from "@headlessui/react";
+import { ChevronDownIcon } from "@heroicons/react/16/solid";
+
+import { cx } from "@/cva.config";
+
+export interface SplitButtonMenuItem {
+  label: string;
+  icon?: React.FC<{ className: string | undefined }>;
+  onClick: () => void;
+  active?: boolean;
+  disabled?: boolean;
+}
+
+const baseStyles = cx(
+  "h-[28px] font-display text-xs leading-tight font-medium select-none",
+  "outline-hidden transition-all duration-200",
+);
+
+const lightTheme = cx(
+  "border border-slate-800/30 bg-white text-black shadow-xs",
+  "dark:border-slate-300/20 dark:bg-slate-800 dark:text-white",
+);
+
+const lightHover = cx(
+  "hover:bg-blue-50/80 dark:hover:bg-slate-700",
+  "active:bg-blue-100/60 dark:active:bg-slate-600",
+);
+
+const primaryClass = cx(
+  baseStyles,
+  lightTheme,
+  lightHover,
+  "inline-flex cursor-pointer items-center gap-x-1.5 rounded-l-sm border-r-0 px-2",
+  "disabled:pointer-events-none disabled:opacity-50",
+);
+
+const iconClass = "h-3.5 shrink-0 text-black dark:text-white";
+
+export const SplitButtonPrimary = React.forwardRef<
+  HTMLButtonElement,
+  {
+    icon?: React.FC<{ className: string | undefined }>;
+    label: string;
+  } & React.ButtonHTMLAttributes<HTMLButtonElement>
+>(({ icon: Icon, label, ...props }, ref) => (
+  <button ref={ref} type="button" {...props} className={primaryClass}>
+    {Icon && <Icon className={iconClass} />}
+    <span className="truncate">{label}</span>
+  </button>
+));
+
+SplitButtonPrimary.displayName = "SplitButtonPrimary";
+
+export function SplitButtonGroup({
+  children,
+  className,
+}: {
+  children: React.ReactNode;
+  className?: string;
+}) {
+  return <div className={cx("inline-flex", className)}>{children}</div>;
+}
+
+export function SplitButtonCaret({ menuItems }: { menuItems: SplitButtonMenuItem[] }) {
+  return (
+    <Menu as="div" className="relative">
+      <MenuButton
+        className={cx(
+          baseStyles,
+          lightTheme,
+          lightHover,
+          "inline-flex cursor-pointer items-center rounded-r-sm px-1",
+          "border-l-slate-800/15 dark:border-l-slate-300/10",
+        )}
+      >
+        <ChevronDownIcon className="size-3.5 text-black dark:text-white" />
+      </MenuButton>
+
+      <MenuItems
+        anchor="bottom end"
+        transition
+        className={cx(
+          "z-20 mt-1 min-w-[160px] origin-top-right rounded-md",
+          "border border-slate-800/20 bg-white shadow-lg dark:border-slate-300/20 dark:bg-slate-800",
+          "transition duration-200 ease-out data-closed:scale-95 data-closed:opacity-0",
+        )}
+      >
+        <div className="p-1">
+          {menuItems.map(item => (
+            <MenuItem key={item.label}>
+              <button
+                type="button"
+                className={cx(
+                  "flex w-full items-center gap-x-2 rounded-sm px-2 py-1.5 text-xs font-medium",
+                  "text-slate-700 dark:text-slate-200",
+                  "data-focus:bg-blue-50 dark:data-focus:bg-slate-700",
+                  item.active && "bg-blue-50 text-blue-700 dark:bg-slate-700 dark:text-blue-400",
+                  item.disabled && "pointer-events-none opacity-50",
+                )}
+                disabled={item.disabled}
+                onClick={item.onClick}
+              >
+                {item.icon && (
+                  <item.icon
+                    className={cx(
+                      "h-3.5 shrink-0",
+                      item.active
+                        ? "text-blue-700 dark:text-blue-400"
+                        : "text-slate-500 dark:text-slate-400",
+                    )}
+                  />
+                )}
+                <span>{item.label}</span>
+              </button>
+            </MenuItem>
+          ))}
+        </div>
+      </MenuItems>
+    </Menu>
+  );
+}
+
+interface SplitButtonProps {
+  primaryItem: {
+    label: string;
+    icon?: React.FC<{ className: string | undefined }>;
+    onClick: () => void;
+    disabled?: boolean;
+  };
+  menuItems: SplitButtonMenuItem[];
+  className?: string;
+}
+
+export function SplitButton({ primaryItem, menuItems, className }: SplitButtonProps) {
+  return (
+    <SplitButtonGroup className={className}>
+      <SplitButtonPrimary
+        icon={primaryItem.icon}
+        label={primaryItem.label}
+        disabled={primaryItem.disabled}
+        onClick={primaryItem.onClick}
+      />
+      <SplitButtonCaret menuItems={menuItems} />
+    </SplitButtonGroup>
+  );
+}

--- a/ui/src/components/SplitButton.tsx
+++ b/ui/src/components/SplitButton.tsx
@@ -37,11 +37,13 @@ const primaryClass = cx(
 
 const iconClass = "h-3.5 shrink-0 text-black dark:text-white";
 
+// eslint-disable-next-line react-refresh/only-export-components
 export const SplitButtonPrimary = React.forwardRef<
   HTMLButtonElement,
   {
     icon?: React.FC<{ className: string | undefined }>;
     label: string;
+    className?: string;
   } & React.ButtonHTMLAttributes<HTMLButtonElement>
 >(({ icon: Icon, label, className, ...props }, ref) => (
   <button ref={ref} type="button" {...props} className={cx(primaryClass, className)}>

--- a/ui/src/components/SplitButton.tsx
+++ b/ui/src/components/SplitButton.tsx
@@ -43,8 +43,8 @@ export const SplitButtonPrimary = React.forwardRef<
     icon?: React.FC<{ className: string | undefined }>;
     label: string;
   } & React.ButtonHTMLAttributes<HTMLButtonElement>
->(({ icon: Icon, label, ...props }, ref) => (
-  <button ref={ref} type="button" {...props} className={primaryClass}>
+>(({ icon: Icon, label, className, ...props }, ref) => (
+  <button ref={ref} type="button" {...props} className={cx(primaryClass, className)}>
     {Icon && <Icon className={iconClass} />}
     <span className="truncate">{label}</span>
   </button>
@@ -118,30 +118,5 @@ export function SplitButtonCaret({ menuItems }: { menuItems: SplitButtonMenuItem
         </div>
       </MenuItems>
     </Menu>
-  );
-}
-
-interface SplitButtonProps {
-  primaryItem: {
-    label: string;
-    icon?: React.FC<{ className: string | undefined }>;
-    onClick: () => void;
-    disabled?: boolean;
-  };
-  menuItems: SplitButtonMenuItem[];
-  className?: string;
-}
-
-export function SplitButton({ primaryItem, menuItems, className }: SplitButtonProps) {
-  return (
-    <SplitButtonGroup className={className}>
-      <SplitButtonPrimary
-        icon={primaryItem.icon}
-        label={primaryItem.label}
-        disabled={primaryItem.disabled}
-        onClick={primaryItem.onClick}
-      />
-      <SplitButtonCaret menuItems={menuItems} />
-    </SplitButtonGroup>
   );
 }

--- a/ui/src/components/Terminal.tsx
+++ b/ui/src/components/Terminal.tsx
@@ -190,7 +190,15 @@ function Terminal({
       onDataHandler.dispose();
       onKeyHandler.dispose();
     };
-  }, [dataChannel, instance, readyState, setDisableVideoFocusTrap, setTerminalType, terminator]);
+  }, [
+    dataChannel,
+    instance,
+    readyState,
+    setDisableVideoFocusTrap,
+    setTerminalType,
+    terminator,
+    type,
+  ]);
 
   useEffect(() => {
     if (!instance) return;

--- a/ui/src/test/testHooks.ts
+++ b/ui/src/test/testHooks.ts
@@ -111,7 +111,9 @@ export function initTestHooks(): void {
             dc.removeEventListener("message", handler);
             callback(resp);
           }
-        } catch { /* ignore non-JSON */ }
+        } catch {
+          /* ignore non-JSON */
+        }
       };
       const timer = setTimeout(() => {
         if (!settled) {


### PR DESCRIPTION
Closes #<issue-number>

### Summary

- Replaces the separate Copy and Paste buttons in the action bar with a single split button group - Paste as the primary action with a dropdown caret that reveals the Copy Text (OCR) option. This reduces toolbar clutter while keeping both actions easily accessible.

### Checklist

- [x] Ran `make test_e2e` locally and passed
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
- [x] Tricky parts are commented in code
