### PR TITLE
fix(ota): return only the matched entity from parseAndValidateKeyring

### DIFF
--- a/internal/ota/gpg.go
+++ b/internal/ota/gpg.go
@@ -195,7 +195,7 @@ func (g *GPGVerifier) parseAndValidateKeyring(key []byte) (openpgp.EntityList, e
 
 		fp := normalizeFingerprint(hex.EncodeToString(entity.PrimaryKey.Fingerprint[:]))
 		if fp == expected {
-			return keyring, nil
+			return openpgp.EntityList{entity}, nil
 		}
 	}
 

--- a/internal/ota/gpg_test.go
+++ b/internal/ota/gpg_test.go
@@ -302,6 +302,43 @@ func TestFetchPublicKey_CachedKeyIsValid(t *testing.T) {
 	assert.Equal(t, int32(1), callCount.Load(), "VerifySignature should use cached key")
 }
 
+func TestParseAndValidateKeyring_FiltersRogueKeys(t *testing.T) {
+	// Generate the trusted key and a rogue key
+	trustedEntity, err := openpgp.NewEntity("Trusted", "", "trusted@example.com", nil)
+	require.NoError(t, err)
+	rogueEntity, err := openpgp.NewEntity("Rogue", "", "rogue@example.com", nil)
+	require.NoError(t, err)
+
+	// Armor both keys into a single keyring (as a malicious keyserver would)
+	var buf bytes.Buffer
+	w, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	require.NoError(t, err)
+	require.NoError(t, trustedEntity.Serialize(w))
+	require.NoError(t, rogueEntity.Serialize(w))
+	require.NoError(t, w.Close())
+
+	trustedFP := strings.ToUpper(hex.EncodeToString(trustedEntity.PrimaryKey.Fingerprint[:]))
+
+	v := newTestGPGVerifier()
+	v.rootKeyFP = trustedFP
+
+	keyring, err := v.parseAndValidateKeyring(buf.Bytes())
+	require.NoError(t, err)
+	require.Len(t, keyring, 1, "keyring must contain only the trusted key, not the rogue key")
+
+	returnedFP := strings.ToUpper(hex.EncodeToString(keyring[0].PrimaryKey.Fingerprint[:]))
+	assert.Equal(t, trustedFP, returnedFP)
+
+	// Sign data with the rogue key — verification must fail
+	testData := []byte("payload")
+	var sigBuf bytes.Buffer
+	err = openpgp.DetachSign(&sigBuf, rogueEntity, bytes.NewReader(testData), nil)
+	require.NoError(t, err)
+
+	_, err = openpgp.CheckDetachedSignature(keyring, bytes.NewReader(testData), bytes.NewReader(sigBuf.Bytes()), nil)
+	assert.Error(t, err, "signature from rogue key must not verify against filtered keyring")
+}
+
 func TestFetchPublicKey_RejectsFingerprintMismatch(t *testing.T) {
 	expectedKey := generateTestArmoredKey(t)
 	servedKey := generateTestArmoredKey(t)


### PR DESCRIPTION
`parseAndValidateKeyring` validates that at least one entity in a fetched keyring matches the pinned root key fingerprint, but on match it returns the entire keyring — including any additional entities the keyserver included in its response.

`openpgp.CheckDetachedSignature` accepts a signature from any key in the provided keyring. A compromised or malicious keyserver could return a response containing the legitimate JetKVM release key (satisfying the fingerprint check) alongside an attacker-controlled key. A binary signed with the attacker key would then pass signature verification in both `VerifySignature` and `VerifySignatureFromFile`.

### What changed

Single-line fix in `internal/ota/gpg.go`: `parseAndValidateKeyring` now returns `openpgp.EntityList{entity}` (only the matched entity) instead of the full keyring.

New test `TestParseAndValidateKeyring_FiltersRogueKeys` in `internal/ota/gpg_test.go` constructs a two-entity armored keyring (trusted + rogue), asserts only the trusted key survives filtering, and confirms `CheckDetachedSignature` rejects a signature produced by the rogue key.

### What this does not change

The keyserver fetch logic, caching behaviour, and fingerprint matching are all untouched. The fix is narrowly scoped to the return value.

Credit to @equinox0815 for identifying this in https://github.com/jetkvm/kvm/issues/96#issuecomment-4103220615.