### PR TITLE
fix: update stale Debian 13 and Ubuntu 24.04 ISO URLs

### DIFF
--- a/ui/src/routes/devices.$id.mount.tsx
+++ b/ui/src/routes/devices.$id.mount.tsx
@@ -331,12 +331,12 @@ function UrlView({
   const popularImages = [
     {
       name: "Ubuntu 24.04 LTS",
-      url: "https://releases.ubuntu.com/24.04.3/ubuntu-24.04.3-desktop-amd64.iso",
+      url: "https://releases.ubuntu.com/24.04.4/ubuntu-24.04.4-desktop-amd64.iso",
       icon: UbuntuIcon,
     },
     {
       name: "Debian 13 Trixie",
-      url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.0.0-amd64-netinst.iso",
+      url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.4.0-amd64-netinst.iso",
       icon: DebianIcon,
     },
     {


### PR DESCRIPTION
## Summary
- Update Debian 13 Trixie netinst ISO URL from `debian-13.0.0` to `debian-13.4.0` (old URL returns 404)
- Update Ubuntu 24.04 LTS desktop ISO URL from `24.04.3` to `24.04.4` (old URL returns 403)

Closes #1315

## Test plan
- [x] Verify both URLs return 200/302 via HTTP HEAD
- [x] Open Mount Media page, click Debian 13 and Ubuntu 24.04 shortcuts, confirm URLs populate correctly