### PR TITLE
refactor: move tailscale logic into internal/tailscale package

### DIFF
--- a/internal/tailscale/tailscale.go
+++ b/internal/tailscale/tailscale.go
@@ -1,0 +1,194 @@
+package tailscale
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+const commandTimeout = 10 * time.Second
+
+const DefaultControlURL = "https://controlplane.tailscale.com"
+
+type Status struct {
+	Installed    bool     `json:"installed"`
+	Running      bool     `json:"running"`
+	BackendState string   `json:"backendState,omitempty"`
+	AuthURL      string   `json:"authURL,omitempty"`
+	ControlURL   string   `json:"controlURL,omitempty"`
+	Self         *Peer    `json:"self,omitempty"`
+	Health       []string `json:"health,omitempty"`
+}
+
+type Peer struct {
+	HostName     string   `json:"hostName"`
+	DNSName      string   `json:"dnsName"`
+	TailscaleIPs []string `json:"tailscaleIPs"`
+	Online       bool     `json:"online"`
+	OS           string   `json:"os"`
+}
+
+type rawStatus struct {
+	BackendState string   `json:"BackendState"`
+	AuthURL      string   `json:"AuthURL"`
+	Self         *rawPeer `json:"Self"`
+	Health       []string `json:"Health"`
+}
+
+type rawPeer struct {
+	HostName     string   `json:"HostName"`
+	DNSName      string   `json:"DNSName"`
+	TailscaleIPs []string `json:"TailscaleIPs"`
+	Online       bool     `json:"Online"`
+	OS           string   `json:"OS"`
+}
+
+func isInstalled() bool {
+	_, err := exec.LookPath("tailscale")
+	return err == nil
+}
+
+// Package-level vars for deterministic unit tests.
+var (
+	CheckInstalled = isInstalled
+	ExecCommand    = func(args ...string) ([]byte, error) {
+		ctx, cancel := context.WithTimeout(context.Background(), commandTimeout)
+		defer cancel()
+
+		output, err := exec.CommandContext(ctx, "tailscale", args...).CombinedOutput()
+		if err != nil {
+			cmd := "tailscale " + strings.Join(args, " ")
+			return nil, fmt.Errorf("%s: %w: %s", cmd, err, strings.TrimSpace(string(output)))
+		}
+
+		return output, nil
+	}
+)
+
+func NormalizeControlURL(controlURL string) (string, error) {
+	trimmed := strings.TrimSpace(controlURL)
+	if trimmed == "" {
+		return "", nil
+	}
+
+	parsed, err := url.Parse(trimmed)
+	if err != nil {
+		return "", fmt.Errorf("invalid control URL: %w", err)
+	}
+
+	if parsed.Scheme != "https" && parsed.Scheme != "http" {
+		return "", errors.New("control URL must start with http:// or https://")
+	}
+	if parsed.Host == "" {
+		return "", errors.New("control URL must include a host")
+	}
+	if parsed.User != nil {
+		return "", errors.New("control URL must not include user info")
+	}
+	if parsed.RawQuery != "" || parsed.Fragment != "" {
+		return "", errors.New("control URL must not include query or fragment")
+	}
+	if parsed.Path != "" && parsed.Path != "/" {
+		return "", errors.New("control URL path is not supported")
+	}
+
+	parsed.Path = ""
+	parsed.RawPath = ""
+
+	return strings.TrimSuffix(parsed.String(), "/"), nil
+}
+
+func EffectiveControlURL(controlURL string) string {
+	if controlURL == "" {
+		return DefaultControlURL
+	}
+	return controlURL
+}
+
+func ApplyControlURL(controlURL string) error {
+	effectiveURL := EffectiveControlURL(controlURL)
+	loginServerFlag := "--login-server=" + effectiveURL
+
+	if _, err := ExecCommand("set", loginServerFlag); err != nil {
+		return fmt.Errorf("failed to apply login server (%s): %w", effectiveURL, err)
+	}
+
+	return nil
+}
+
+// SetControlURL validates, normalizes, and applies a control URL via the
+// tailscale CLI (when installed). It returns the normalized URL; the caller
+// is responsible for persisting it to config.
+func SetControlURL(controlURL string) (string, error) {
+	normalized, err := NormalizeControlURL(controlURL)
+	if err != nil {
+		return "", err
+	}
+
+	if CheckInstalled() {
+		if err := ApplyControlURL(normalized); err != nil {
+			return "", err
+		}
+	}
+
+	return normalized, nil
+}
+
+func ParseStatus(data []byte, controlURL string) (*Status, error) {
+	var raw rawStatus
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("failed to parse tailscale status: %w", err)
+	}
+
+	status := &Status{
+		Installed:    true,
+		Running:      raw.BackendState == "Running",
+		BackendState: raw.BackendState,
+		AuthURL:      raw.AuthURL,
+		ControlURL:   EffectiveControlURL(controlURL),
+		Health:       raw.Health,
+	}
+
+	if raw.Self != nil {
+		status.Self = &Peer{
+			HostName:     raw.Self.HostName,
+			DNSName:      raw.Self.DNSName,
+			TailscaleIPs: raw.Self.TailscaleIPs,
+			Online:       raw.Self.Online,
+			OS:           raw.Self.OS,
+		}
+	}
+
+	return status, nil
+}
+
+// GetStatus queries the Tailscale daemon for current status.
+// Returns a Status with Installed=false when the binary is not found.
+// The warn function is called when exec fails but tailscale is installed.
+func GetStatus(controlURL string, warn func(err error)) (*Status, error) {
+	if !CheckInstalled() {
+		return &Status{
+			Installed:  false,
+			ControlURL: EffectiveControlURL(controlURL),
+		}, nil
+	}
+
+	output, err := ExecCommand("status", "--json")
+	if err != nil {
+		if warn != nil {
+			warn(err)
+		}
+		return &Status{
+			Installed:  true,
+			Running:    false,
+			ControlURL: EffectiveControlURL(controlURL),
+		}, nil
+	}
+
+	return ParseStatus(output, controlURL)
+}

--- a/internal/tailscale/tailscale_test.go
+++ b/internal/tailscale/tailscale_test.go
@@ -1,4 +1,4 @@
-package kvm
+package tailscale
 
 import (
 	"fmt"
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestParseTailscaleStatus(t *testing.T) {
+func TestParseStatus(t *testing.T) {
 	tests := []struct {
 		name         string
 		input        string
@@ -53,7 +53,7 @@ func TestParseTailscaleStatus(t *testing.T) {
 			wantRunning: false,
 			wantState:   "NeedsLogin",
 			wantAuthURL: "https://login.tailscale.com/a/abc123",
-			wantControl: tailscaleDefaultControlURL,
+			wantControl: DefaultControlURL,
 		},
 		{
 			name: "stopped",
@@ -77,7 +77,7 @@ func TestParseTailscaleStatus(t *testing.T) {
 			controlURL:  "",
 			wantRunning: false,
 			wantState:   "Starting",
-			wantControl: tailscaleDefaultControlURL,
+			wantControl: DefaultControlURL,
 		},
 		{
 			name:       "invalid json",
@@ -108,7 +108,7 @@ func TestParseTailscaleStatus(t *testing.T) {
 			controlURL:   "",
 			wantRunning:  true,
 			wantState:    "Running",
-			wantControl:  tailscaleDefaultControlURL,
+			wantControl:  DefaultControlURL,
 			wantHostName: "test-node",
 			wantIPs:      []string{},
 		},
@@ -116,7 +116,7 @@ func TestParseTailscaleStatus(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			status, err := parseTailscaleStatus([]byte(tt.input), tt.controlURL)
+			status, err := ParseStatus([]byte(tt.input), tt.controlURL)
 			if tt.wantErr {
 				assert.Error(t, err)
 				return
@@ -142,49 +142,46 @@ func TestParseTailscaleStatus(t *testing.T) {
 	}
 }
 
-func TestNormalizeTailscaleControlURL(t *testing.T) {
+func TestNormalizeControlURL(t *testing.T) {
 	t.Run("empty means default", func(t *testing.T) {
-		got, err := normalizeTailscaleControlURL("")
+		got, err := NormalizeControlURL("")
 		require.NoError(t, err)
 		assert.Equal(t, "", got)
 	})
 
 	t.Run("valid URL trimmed", func(t *testing.T) {
-		got, err := normalizeTailscaleControlURL(" https://headscale.example.com/ ")
+		got, err := NormalizeControlURL(" https://headscale.example.com/ ")
 		require.NoError(t, err)
 		assert.Equal(t, "https://headscale.example.com", got)
 	})
 
 	t.Run("rejects path", func(t *testing.T) {
-		_, err := normalizeTailscaleControlURL("https://headscale.example.com/api")
+		_, err := NormalizeControlURL("https://headscale.example.com/api")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "path")
 	})
 
 	t.Run("rejects invalid scheme", func(t *testing.T) {
-		_, err := normalizeTailscaleControlURL("ftp://headscale.example.com")
+		_, err := NormalizeControlURL("ftp://headscale.example.com")
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "http:// or https://")
 	})
 }
 
-func TestGetTailscaleStatus_NotInstalled(t *testing.T) {
-	origCheck := checkTailscaleInstalled
-	origExec := execTailscaleCommand
-	origConfig := config
+func TestGetStatus_NotInstalled(t *testing.T) {
+	origCheck := CheckInstalled
+	origExec := ExecCommand
 	defer func() {
-		checkTailscaleInstalled = origCheck
-		execTailscaleCommand = origExec
-		config = origConfig
+		CheckInstalled = origCheck
+		ExecCommand = origExec
 	}()
 
-	config = &Config{TailscaleControlURL: "https://headscale.example.com"}
-	checkTailscaleInstalled = func() bool { return false }
-	execTailscaleCommand = func(_ ...string) ([]byte, error) {
+	CheckInstalled = func() bool { return false }
+	ExecCommand = func(_ ...string) ([]byte, error) {
 		return nil, fmt.Errorf("should not be called")
 	}
 
-	status, err := getTailscaleStatus()
+	status, err := GetStatus("https://headscale.example.com", nil)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.False(t, status.Installed)
@@ -192,44 +189,38 @@ func TestGetTailscaleStatus_NotInstalled(t *testing.T) {
 	assert.Equal(t, "https://headscale.example.com", status.ControlURL)
 }
 
-func TestGetTailscaleStatus_ExecFailure(t *testing.T) {
-	origCheck := checkTailscaleInstalled
-	origExec := execTailscaleCommand
-	origConfig := config
+func TestGetStatus_ExecFailure(t *testing.T) {
+	origCheck := CheckInstalled
+	origExec := ExecCommand
 	defer func() {
-		checkTailscaleInstalled = origCheck
-		execTailscaleCommand = origExec
-		config = origConfig
+		CheckInstalled = origCheck
+		ExecCommand = origExec
 	}()
 
-	config = &Config{}
-	checkTailscaleInstalled = func() bool { return true }
-	execTailscaleCommand = func(args ...string) ([]byte, error) {
+	CheckInstalled = func() bool { return true }
+	ExecCommand = func(args ...string) ([]byte, error) {
 		require.Equal(t, []string{"status", "--json"}, args)
 		return nil, fmt.Errorf("connection refused")
 	}
 
-	status, err := getTailscaleStatus()
+	status, err := GetStatus("", nil)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.True(t, status.Installed)
 	assert.False(t, status.Running)
-	assert.Equal(t, tailscaleDefaultControlURL, status.ControlURL)
+	assert.Equal(t, DefaultControlURL, status.ControlURL)
 }
 
-func TestGetTailscaleStatus_ValidJSON(t *testing.T) {
-	origCheck := checkTailscaleInstalled
-	origExec := execTailscaleCommand
-	origConfig := config
+func TestGetStatus_ValidJSON(t *testing.T) {
+	origCheck := CheckInstalled
+	origExec := ExecCommand
 	defer func() {
-		checkTailscaleInstalled = origCheck
-		execTailscaleCommand = origExec
-		config = origConfig
+		CheckInstalled = origCheck
+		ExecCommand = origExec
 	}()
 
-	config = &Config{TailscaleControlURL: "https://headscale.example.com"}
-	checkTailscaleInstalled = func() bool { return true }
-	execTailscaleCommand = func(args ...string) ([]byte, error) {
+	CheckInstalled = func() bool { return true }
+	ExecCommand = func(args ...string) ([]byte, error) {
 		require.Equal(t, []string{"status", "--json"}, args)
 		return []byte(`{
 			"BackendState": "Running",
@@ -244,7 +235,7 @@ func TestGetTailscaleStatus_ValidJSON(t *testing.T) {
 		}`), nil
 	}
 
-	status, err := getTailscaleStatus()
+	status, err := GetStatus("https://headscale.example.com", nil)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 	assert.True(t, status.Installed)
@@ -255,122 +246,93 @@ func TestGetTailscaleStatus_ValidJSON(t *testing.T) {
 	assert.Equal(t, []string{"100.64.0.1"}, status.Self.TailscaleIPs)
 }
 
-func TestApplyTailscaleControlURL_SetOnly(t *testing.T) {
-	origExec := execTailscaleCommand
-	defer func() { execTailscaleCommand = origExec }()
+func TestApplyControlURL_SetOnly(t *testing.T) {
+	origExec := ExecCommand
+	defer func() { ExecCommand = origExec }()
 
 	var commands [][]string
-	execTailscaleCommand = func(args ...string) ([]byte, error) {
+	ExecCommand = func(args ...string) ([]byte, error) {
 		commands = append(commands, append([]string{}, args...))
 		return []byte("ok"), nil
 	}
 
-	err := applyTailscaleControlURL("https://headscale.example.com")
+	err := ApplyControlURL("https://headscale.example.com")
 	require.NoError(t, err)
 	require.Len(t, commands, 1)
 	assert.Equal(t, []string{"set", "--login-server=https://headscale.example.com"}, commands[0])
 }
 
-func TestApplyTailscaleControlURL_SetFailureReturnedWithoutFallback(t *testing.T) {
-	origExec := execTailscaleCommand
-	defer func() { execTailscaleCommand = origExec }()
+func TestApplyControlURL_SetFailure(t *testing.T) {
+	origExec := ExecCommand
+	defer func() { ExecCommand = origExec }()
 
 	var commands [][]string
-	execTailscaleCommand = func(args ...string) ([]byte, error) {
+	ExecCommand = func(args ...string) ([]byte, error) {
 		commands = append(commands, append([]string{}, args...))
 		return nil, fmt.Errorf("unknown command")
 	}
 
-	err := applyTailscaleControlURL("https://headscale.example.com")
+	err := ApplyControlURL("https://headscale.example.com")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "failed to apply login server")
 	require.Len(t, commands, 1)
 	assert.Equal(t, []string{"set", "--login-server=https://headscale.example.com"}, commands[0])
 }
 
-func TestRPCSetTailscaleControlURL_SaveAndApply(t *testing.T) {
-	origCheck := checkTailscaleInstalled
-	origExec := execTailscaleCommand
-	origSave := saveTailscaleConfig
-	origConfig := config
+func TestSetControlURL_InstalledAppliesAndReturnsNormalized(t *testing.T) {
+	origCheck := CheckInstalled
+	origExec := ExecCommand
 	defer func() {
-		checkTailscaleInstalled = origCheck
-		execTailscaleCommand = origExec
-		saveTailscaleConfig = origSave
-		config = origConfig
+		CheckInstalled = origCheck
+		ExecCommand = origExec
 	}()
 
-	config = &Config{}
-	checkTailscaleInstalled = func() bool { return true }
-	var callOrder []string
-	saveTailscaleConfig = func() error {
-		callOrder = append(callOrder, "save")
-		return nil
-	}
-
+	CheckInstalled = func() bool { return true }
 	var commands [][]string
-	execTailscaleCommand = func(args ...string) ([]byte, error) {
-		callOrder = append(callOrder, "apply")
+	ExecCommand = func(args ...string) ([]byte, error) {
 		commands = append(commands, append([]string{}, args...))
 		return []byte("ok"), nil
 	}
 
-	err := rpcSetTailscaleControlURL("https://headscale.example.com/")
+	normalized, err := SetControlURL("https://headscale.example.com/")
 	require.NoError(t, err)
-	assert.Equal(t, []string{"apply", "save"}, callOrder)
-	assert.Equal(t, "https://headscale.example.com", config.TailscaleControlURL)
+	assert.Equal(t, "https://headscale.example.com", normalized)
 	require.Len(t, commands, 1)
 	assert.Equal(t, []string{"set", "--login-server=https://headscale.example.com"}, commands[0])
 }
 
-func TestRPCSetTailscaleControlURL_ApplyFailureDoesNotSaveOrPersistConfig(t *testing.T) {
-	origCheck := checkTailscaleInstalled
-	origExec := execTailscaleCommand
-	origSave := saveTailscaleConfig
-	origConfig := config
+func TestSetControlURL_ApplyFailureReturnsError(t *testing.T) {
+	origCheck := CheckInstalled
+	origExec := ExecCommand
 	defer func() {
-		checkTailscaleInstalled = origCheck
-		execTailscaleCommand = origExec
-		saveTailscaleConfig = origSave
-		config = origConfig
+		CheckInstalled = origCheck
+		ExecCommand = origExec
 	}()
 
-	config = &Config{TailscaleControlURL: "https://previous.example.com"}
-	checkTailscaleInstalled = func() bool { return true }
-	saveTailscaleConfig = func() error {
-		t.Fatal("save should not be called when apply fails")
-		return nil
-	}
-	execTailscaleCommand = func(args ...string) ([]byte, error) {
-		require.Equal(t, []string{"set", "--login-server=https://headscale.example.com"}, args)
+	CheckInstalled = func() bool { return true }
+	ExecCommand = func(args ...string) ([]byte, error) {
 		return nil, fmt.Errorf("apply failed")
 	}
 
-	err := rpcSetTailscaleControlURL("https://headscale.example.com")
+	_, err := SetControlURL("https://headscale.example.com")
 	require.Error(t, err)
-	assert.Equal(t, "https://previous.example.com", config.TailscaleControlURL)
 }
 
-func TestRPCSetTailscaleControlURL_NotInstalledSkipsApply(t *testing.T) {
-	origCheck := checkTailscaleInstalled
-	origExec := execTailscaleCommand
-	origSave := saveTailscaleConfig
-	origConfig := config
+func TestSetControlURL_NotInstalledSkipsApply(t *testing.T) {
+	origCheck := CheckInstalled
+	origExec := ExecCommand
 	defer func() {
-		checkTailscaleInstalled = origCheck
-		execTailscaleCommand = origExec
-		saveTailscaleConfig = origSave
-		config = origConfig
+		CheckInstalled = origCheck
+		ExecCommand = origExec
 	}()
 
-	config = &Config{}
-	checkTailscaleInstalled = func() bool { return false }
-	saveTailscaleConfig = func() error { return nil }
-	execTailscaleCommand = func(_ ...string) ([]byte, error) {
-		return nil, fmt.Errorf("should not be called")
+	CheckInstalled = func() bool { return false }
+	ExecCommand = func(_ ...string) ([]byte, error) {
+		t.Fatal("exec should not be called when not installed")
+		return nil, nil
 	}
 
-	err := rpcSetTailscaleControlURL("")
+	normalized, err := SetControlURL("")
 	require.NoError(t, err)
-	assert.Equal(t, "", config.TailscaleControlURL)
+	assert.Equal(t, "", normalized)
 }

--- a/tailscale.go
+++ b/tailscale.go
@@ -1,225 +1,35 @@
 package kvm
 
 import (
-	"context"
-	"encoding/json"
-	"errors"
 	"fmt"
-	"net/url"
-	"os/exec"
-	"strings"
-	"time"
+
+	"github.com/jetkvm/kvm/internal/tailscale"
 )
 
-const tailscaleCommandTimeout = 10 * time.Second
-
-const tailscaleDefaultControlURL = "https://controlplane.tailscale.com"
-
-// TailscaleStatus represents the current state of Tailscale on the device.
-type TailscaleStatus struct {
-	Installed    bool           `json:"installed"`
-	Running      bool           `json:"running"`
-	BackendState string         `json:"backendState,omitempty"`
-	AuthURL      string         `json:"authURL,omitempty"`
-	ControlURL   string         `json:"controlURL,omitempty"`
-	Self         *TailscalePeer `json:"self,omitempty"`
-	Health       []string       `json:"health,omitempty"`
-}
-
-// TailscalePeer represents a Tailscale peer (including self).
-type TailscalePeer struct {
-	HostName     string   `json:"hostName"`
-	DNSName      string   `json:"dnsName"`
-	TailscaleIPs []string `json:"tailscaleIPs"`
-	Online       bool     `json:"online"`
-	OS           string   `json:"os"`
-}
-
-// tailscaleRawStatus represents the subset of fields we parse from `tailscale status --json`.
-type tailscaleRawStatus struct {
-	BackendState string            `json:"BackendState"`
-	AuthURL      string            `json:"AuthURL"`
-	Self         *tailscaleRawPeer `json:"Self"`
-	Health       []string          `json:"Health"`
-}
-
-type tailscaleRawPeer struct {
-	HostName     string   `json:"HostName"`
-	DNSName      string   `json:"DNSName"`
-	TailscaleIPs []string `json:"TailscaleIPs"`
-	Online       bool     `json:"Online"`
-	OS           string   `json:"OS"`
-}
-
-// isTailscaleInstalled checks if the tailscale binary is available on the system.
-func isTailscaleInstalled() bool {
-	_, err := exec.LookPath("tailscale")
-	return err == nil
-}
-
-// These package-level vars allow deterministic unit tests.
-var (
-	checkTailscaleInstalled = isTailscaleInstalled
-	saveTailscaleConfig     = SaveConfig
-	execTailscaleCommand    = func(args ...string) ([]byte, error) {
-		ctx, cancel := context.WithTimeout(context.Background(), tailscaleCommandTimeout)
-		defer cancel()
-
-		output, err := exec.CommandContext(ctx, "tailscale", args...).CombinedOutput()
-		if err != nil {
-			cmd := "tailscale " + strings.Join(args, " ")
-			return nil, fmt.Errorf("%s: %w: %s", cmd, err, strings.TrimSpace(string(output)))
-		}
-
-		return output, nil
-	}
-)
-
-// execTailscaleStatus runs `tailscale status --json` and returns the raw output.
-func execTailscaleStatus() ([]byte, error) {
-	return execTailscaleCommand("status", "--json")
-}
-
-func normalizeTailscaleControlURL(controlURL string) (string, error) {
-	trimmed := strings.TrimSpace(controlURL)
-	if trimmed == "" {
-		return "", nil
-	}
-
-	parsed, err := url.Parse(trimmed)
-	if err != nil {
-		return "", fmt.Errorf("invalid control URL: %w", err)
-	}
-
-	if parsed.Scheme != "https" && parsed.Scheme != "http" {
-		return "", errors.New("control URL must start with http:// or https://")
-	}
-	if parsed.Host == "" {
-		return "", errors.New("control URL must include a host")
-	}
-	if parsed.User != nil {
-		return "", errors.New("control URL must not include user info")
-	}
-	if parsed.RawQuery != "" || parsed.Fragment != "" {
-		return "", errors.New("control URL must not include query or fragment")
-	}
-	if parsed.Path != "" && parsed.Path != "/" {
-		return "", errors.New("control URL path is not supported")
-	}
-
-	parsed.Path = ""
-	parsed.RawPath = ""
-
-	return strings.TrimSuffix(parsed.String(), "/"), nil
-}
-
-func effectiveTailscaleControlURL(controlURL string) string {
-	if controlURL == "" {
-		return tailscaleDefaultControlURL
-	}
-	return controlURL
-}
-
-func applyTailscaleControlURL(controlURL string) error {
-	effectiveURL := effectiveTailscaleControlURL(controlURL)
-	loginServerFlag := "--login-server=" + effectiveURL
-
-	if _, err := execTailscaleCommand("set", loginServerFlag); err != nil {
-		return fmt.Errorf("failed to apply login server (%s): %w", effectiveURL, err)
-	}
-
-	return nil
-}
-
-// getTailscaleStatus queries the Tailscale daemon for current status.
-// Returns a TailscaleStatus with Installed=false when the binary is not found.
-func getTailscaleStatus() (*TailscaleStatus, error) {
+func rpcGetTailscaleStatus() (*tailscale.Status, error) {
 	ensureConfigLoaded()
-
-	controlURL := config.TailscaleControlURL
-	if !checkTailscaleInstalled() {
-		return &TailscaleStatus{
-			Installed:  false,
-			ControlURL: effectiveTailscaleControlURL(controlURL),
-		}, nil
-	}
-
-	output, err := execTailscaleStatus()
-	if err != nil {
+	return tailscale.GetStatus(config.TailscaleControlURL, func(err error) {
 		tailscaleLogger.Warn().Err(err).Msg("failed to get tailscale status")
-		return &TailscaleStatus{
-			Installed:  true,
-			Running:    false,
-			ControlURL: effectiveTailscaleControlURL(controlURL),
-		}, nil
-	}
-
-	return parseTailscaleStatus(output, controlURL)
-}
-
-// parseTailscaleStatus parses the JSON output from `tailscale status --json`.
-func parseTailscaleStatus(data []byte, controlURL string) (*TailscaleStatus, error) {
-	var raw tailscaleRawStatus
-	if err := json.Unmarshal(data, &raw); err != nil {
-		return nil, fmt.Errorf("failed to parse tailscale status: %w", err)
-	}
-
-	status := &TailscaleStatus{
-		Installed:    true,
-		Running:      raw.BackendState == "Running",
-		BackendState: raw.BackendState,
-		AuthURL:      raw.AuthURL,
-		ControlURL:   effectiveTailscaleControlURL(controlURL),
-		Health:       raw.Health,
-	}
-
-	if raw.Self != nil {
-		status.Self = &TailscalePeer{
-			HostName:     raw.Self.HostName,
-			DNSName:      raw.Self.DNSName,
-			TailscaleIPs: raw.Self.TailscaleIPs,
-			Online:       raw.Self.Online,
-			OS:           raw.Self.OS,
-		}
-	}
-
-	return status, nil
-}
-
-func rpcGetTailscaleStatus() (*TailscaleStatus, error) {
-	return getTailscaleStatus()
+	})
 }
 
 func rpcGetTailscaleControlURL() (string, error) {
 	ensureConfigLoaded()
-	return effectiveTailscaleControlURL(config.TailscaleControlURL), nil
+	return tailscale.EffectiveControlURL(config.TailscaleControlURL), nil
 }
 
 func rpcSetTailscaleControlURL(controlURL string) error {
 	ensureConfigLoaded()
 
-	normalizedURL, err := normalizeTailscaleControlURL(controlURL)
+	previousURL := config.TailscaleControlURL
+
+	normalized, err := tailscale.SetControlURL(controlURL)
 	if err != nil {
 		return err
 	}
 
-	previousURL := config.TailscaleControlURL
-	config.TailscaleControlURL = normalizedURL
-
-	if !checkTailscaleInstalled() {
-		if err := saveTailscaleConfig(); err != nil {
-			config.TailscaleControlURL = previousURL
-			return fmt.Errorf("failed to save tailscale control URL: %w", err)
-		}
-		return nil
-	}
-
-	if err := applyTailscaleControlURL(normalizedURL); err != nil {
-		config.TailscaleControlURL = previousURL
-		return err
-	}
-
-	if err := saveTailscaleConfig(); err != nil {
+	config.TailscaleControlURL = normalized
+	if err := SaveConfig(); err != nil {
 		config.TailscaleControlURL = previousURL
 		return fmt.Errorf("failed to save tailscale control URL: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Move tailscale types, parsing, and exec logic from the root `kvm` package into `internal/tailscale/`, fixing `go test ./...` on x86_64 hosts and CI
- The root package has no test files again, so it's no longer compiled/linked during `make check`

## Context
The root `kvm` package depends on ARM-only CGO native libraries (`libjknative.a`, `liblvgl.a`). Adding `tailscale_test.go` there in #1276 caused `go test ./...` to try linking those on x86_64, breaking both local `make check` and the [build workflow on dev](https://github.com/jetkvm/kvm/actions/runs/23207951682).

## Blocked on
Waiting for #1312 to merge first so we can rebase on top and resolve any conflicts here, rather than creating merge pain for that PR.

## Test plan
- [x] `make check` passes on x86_64 host
- [x] `go vet ./...` still checks all packages including root
- [x] Tailscale tests run and pass in `internal/tailscale/`