### PR TITLE
fix(e2e): re-read caps_lock LED state each retry iteration

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -280,18 +280,21 @@ test.describe("Remote Host Agent", () => {
 
     const initialState = await getLedState(sharedPage);
     expect(initialState).not.toBeNull();
-    const initialCaps = initialState!.caps_lock;
 
-    // EDID restore may still be in-flight; retry until full HID stack (including LED reports) stabilizes
+    // EDID restore may still be in-flight; retry until full HID stack (including LED reports) stabilizes.
+    // Re-read caps_lock each iteration so a failed-try + successful-undo doesn't leave us
+    // permanently toggling in the wrong direction.
     const deadline = Date.now() + 15000;
     let capsToggled = false;
+    let capsBeforeToggle = initialState!.caps_lock;
     while (Date.now() < deadline) {
+      capsBeforeToggle = (await getLedState(sharedPage))!.caps_lock;
       await agent!.clearKeyboardEvents();
       try {
         await agent!.expectKeyPress(KEY.CAPS_LOCK, async () => {
           await tapKey(sharedPage, HID_KEY.CAPS_LOCK);
         }, 3000);
-        await waitForLedState(sharedPage, "caps_lock", !initialCaps, 2000);
+        await waitForLedState(sharedPage, "caps_lock", !capsBeforeToggle, 2000);
         capsToggled = true;
         break;
       } catch {
@@ -301,13 +304,13 @@ test.describe("Remote Host Agent", () => {
       }
     }
     expect(capsToggled, "CAPS_LOCK LED should toggle").toBe(true);
-    expect((await getLedState(sharedPage))!.caps_lock).toBe(!initialCaps);
+    expect((await getLedState(sharedPage))!.caps_lock).toBe(!capsBeforeToggle);
 
     // Restore CAPS_LOCK
     await agent!.expectKeyPress(KEY.CAPS_LOCK, async () => {
       await tapKey(sharedPage, HID_KEY.CAPS_LOCK);
     });
-    await waitForLedState(sharedPage, "caps_lock", initialCaps);
+    await waitForLedState(sharedPage, "caps_lock", capsBeforeToggle);
 
     // NUM_LOCK: same round-trip verification
     const initialNum = initialState!.num_lock;


### PR DESCRIPTION
## Summary
- The CAPS_LOCK LED retry loop read `initialCaps` once before entering the loop. If a try-tap failed (HID temporarily unavailable from in-flight EDID restore) but the catch-block's undo-tap succeeded, the host's actual state diverged from `initialCaps` — every subsequent iteration toggled the wrong direction, exhausting the 15s deadline.
- Fix: re-read LED state at the top of each iteration so the expected value tracks reality.

## Test plan
- [x] Run `make test_e2e` and confirm `keyboard: toggle keys with LED round-trip` passes

Made with [Cursor](https://cursor.com)