### PR TITLE
fix: replace hardcoded English strings with i18n message functions (#1162)

### DIFF
--- a/ui/localization/messages/cy.json
+++ b/ui/localization/messages/cy.json
@@ -106,6 +106,7 @@
     "advanced_update_ssh_key_button": "Diweddaru Allwedd SSH",
     "advanced_usb_emulation_description": "Rheoli cyflwr efelychu USB",
     "advanced_usb_emulation_title": "Efelychu USB",
+    "advanced_version_change_acknowledged_label": "Rwy'n deall y gall newidiadau fersiwn dorri fy nyfais a bod angen ailosodiad ffatri",
     "advanced_version_update_app_label": "Fersiwn yr Ap",
     "advanced_version_update_button": "Diweddaru i Fersiwn",
     "advanced_version_update_description": "Gosod fersiwn benodol o ryddhiadau GitHub",
@@ -467,6 +468,8 @@
     "macro_at_least_one_step_required": "Mae angen o leiaf un cam",
     "macro_max_steps_error": "Gallwch ychwanegu uchafswm o {max} cam fesul macro yn unig.",
     "macro_max_steps_reached": "({max} uchafswm)",
+    "macro_modifier_left": "Chwith",
+    "macro_modifier_right": "De",
     "macro_name_label": "Enw Macro",
     "macro_name_required": "Mae angen enw",
     "macro_name_too_long": "Rhaid i'r enw fod yn llai na 50 nod",
@@ -962,8 +965,5 @@
     "wake_on_lan_invalid_mac": "Cyfeiriad MAC annilys",
     "wake_on_lan_magic_sent_success": "Pecyn Hud wedi'i anfon yn llwyddiannus",
     "welcome_to_jetkvm": "Croeso i JetKVM",
-    "welcome_to_jetkvm_description": "Rheoli unrhyw gyfrifiadur o bell",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Rheoli unrhyw gyfrifiadur o bell"
 }

--- a/ui/localization/messages/cy.json
+++ b/ui/localization/messages/cy.json
@@ -962,5 +962,8 @@
     "wake_on_lan_invalid_mac": "Cyfeiriad MAC annilys",
     "wake_on_lan_magic_sent_success": "Pecyn Hud wedi'i anfon yn llwyddiannus",
     "welcome_to_jetkvm": "Croeso i JetKVM",
-    "welcome_to_jetkvm_description": "Rheoli unrhyw gyfrifiadur o bell"
+    "welcome_to_jetkvm_description": "Rheoli unrhyw gyfrifiadur o bell",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Ugyldig MAC-adresse",
     "wake_on_lan_magic_sent_success": "Magisk pakke sendt",
     "welcome_to_jetkvm": "Velkommen til JetKVM",
-    "welcome_to_jetkvm_description": "Styr enhver computer eksternt"
+    "welcome_to_jetkvm_description": "Styr enhver computer eksternt",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Tilføj din offentlige SSH-nøgle for at aktivere sikker fjernadgang til enheden",
     "advanced_ssh_access_title": "SSH-adgang",
     "advanced_ssh_default_user": "Standard SSH-brugeren er",
+    "advanced_ssh_key_required_warning": "En offentlig nøgle er påkrævet for SSH-adgang. Uden en vil du ikke kunne oprette forbindelse.",
     "advanced_ssh_public_key_label": "Offentlig SSH-nøgle",
     "advanced_ssh_public_key_placeholder": "Indtast din offentlige SSH-nøgle",
     "advanced_success_download_diagnostics": "Diagnostik blev downloadet",
-    "advanced_ssh_key_required_warning": "En offentlig nøgle er påkrævet for SSH-adgang. Uden en vil du ikke kunne oprette forbindelse.",
     "advanced_success_loopback_disabled": "Kun loopback-tilstand er deaktiveret. Genstart din enhed for at anvende den.",
     "advanced_success_loopback_enabled": "Kun loopback-tilstand aktiveret. Genstart din enhed for at anvende den.",
     "advanced_success_reset_config": "Konfigurationen er nulstillet til standard",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Opdater SSH-nøgle",
     "advanced_usb_emulation_description": "Styr USB-emuleringstilstanden",
     "advanced_usb_emulation_title": "USB-emulering",
+    "advanced_version_change_acknowledged_label": "Jeg forstår, at versionsændringer kan ødelægge min enhed og kræve fabriksnulstilling",
     "advanced_version_update_app_label": "App-version",
     "advanced_version_update_button": "Opdatering til version",
     "advanced_version_update_description": "Installer en specifik version fra GitHub-udgivelser",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Mindst ét trin er påkrævet",
     "macro_max_steps_error": "Du kan maksimalt tilføje {max} trin pr. makro.",
     "macro_max_steps_reached": "( {max} maks)",
+    "macro_modifier_left": "Venstre",
+    "macro_modifier_right": "Højre",
     "macro_name_label": "Makronavn",
     "macro_name_required": "Navn er påkrævet",
     "macro_name_too_long": "Navnet skal være mindre end 50 tegn",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Ugyldig MAC-adresse",
     "wake_on_lan_magic_sent_success": "Magisk pakke sendt",
     "welcome_to_jetkvm": "Velkommen til JetKVM",
-    "welcome_to_jetkvm_description": "Styr enhver computer eksternt",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Styr enhver computer eksternt"
 }

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Ungültige MAC-Adresse",
     "wake_on_lan_magic_sent_success": "Magic Packet erfolgreich gesendet",
     "welcome_to_jetkvm": "Willkommen bei JetKVM",
-    "welcome_to_jetkvm_description": "Steuern Sie jeden Computer aus der Ferne"
+    "welcome_to_jetkvm_description": "Steuern Sie jeden Computer aus der Ferne",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Fügen Sie Ihren öffentlichen SSH-Schlüssel hinzu, um einen sicheren Fernzugriff auf das Gerät zu ermöglichen",
     "advanced_ssh_access_title": "SSH-Zugriff",
     "advanced_ssh_default_user": "Der Standard-SSH-Benutzer ist",
+    "advanced_ssh_key_required_warning": "Ein öffentlicher Schlüssel ist für den SSH-Zugang erforderlich. Ohne diesen können Sie keine Verbindung herstellen.",
     "advanced_ssh_public_key_label": "Öffentlicher SSH-Schlüssel",
     "advanced_ssh_public_key_placeholder": "Geben Sie Ihren öffentlichen SSH-Schlüssel ein",
     "advanced_success_download_diagnostics": "Diagnosedaten erfolgreich heruntergeladen",
-    "advanced_ssh_key_required_warning": "Ein öffentlicher Schlüssel ist für den SSH-Zugang erforderlich. Ohne diesen können Sie keine Verbindung herstellen.",
     "advanced_success_loopback_disabled": "Nur-Loopback-Modus deaktiviert. Starten Sie Ihr Gerät neu, um die Funktion anzuwenden.",
     "advanced_success_loopback_enabled": "Nur-Loopback-Modus aktiviert. Starten Sie Ihr Gerät neu, um die Funktion anzuwenden.",
     "advanced_success_reset_config": "Konfiguration erfolgreich auf Standard zurückgesetzt",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "SSH-Schlüssel aktualisieren",
     "advanced_usb_emulation_description": "Steuern des USB-Emulationsstatus",
     "advanced_usb_emulation_title": "USB-Emulation",
+    "advanced_version_change_acknowledged_label": "Ich verstehe, dass Versionsänderungen mein Gerät beschädigen und einen Werksreset erfordern können",
     "advanced_version_update_app_label": "App-Version",
     "advanced_version_update_button": "Aktualisierung auf Version",
     "advanced_version_update_description": "Installieren Sie eine bestimmte Version aus den GitHub-Releases.",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Mindestens ein Schritt ist erforderlich",
     "macro_max_steps_error": "Sie können pro Makro maximal {max} Schritte hinzufügen.",
     "macro_max_steps_reached": "( {max} max)",
+    "macro_modifier_left": "Links",
+    "macro_modifier_right": "Rechts",
     "macro_name_label": "Makroname",
     "macro_name_required": "Name ist erforderlich",
     "macro_name_too_long": "Der Name muss weniger als 50 Zeichen lang sein",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Ungültige MAC-Adresse",
     "wake_on_lan_magic_sent_success": "Magic Packet erfolgreich gesendet",
     "welcome_to_jetkvm": "Willkommen bei JetKVM",
-    "welcome_to_jetkvm_description": "Steuern Sie jeden Computer aus der Ferne",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Steuern Sie jeden Computer aus der Ferne"
 }

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -94,9 +94,9 @@
     "advanced_ssh_access_description": "Add your SSH public key to enable secure remote access to the device",
     "advanced_ssh_access_title": "SSH Access",
     "advanced_ssh_default_user": "The default SSH user is",
+    "advanced_ssh_key_required_warning": "A public key is required for SSH access. Without one, you will not be able to connect.",
     "advanced_ssh_public_key_label": "SSH Public Key",
     "advanced_ssh_public_key_placeholder": "Enter your SSH public key",
-    "advanced_ssh_key_required_warning": "A public key is required for SSH access. Without one, you will not be able to connect.",
     "advanced_success_download_diagnostics": "Diagnostics downloaded successfully",
     "advanced_success_loopback_disabled": "Loopback-only mode disabled. Restart your device to apply.",
     "advanced_success_loopback_enabled": "Loopback-only mode enabled. Restart your device to apply.",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Update SSH Key",
     "advanced_usb_emulation_description": "Control the USB emulation state",
     "advanced_usb_emulation_title": "USB Emulation",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
     "advanced_version_update_app_label": "App Version",
     "advanced_version_update_button": "Update to Version",
     "advanced_version_update_description": "Install a specific version from GitHub releases",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "At least one step is required",
     "macro_max_steps_error": "You can only add a maximum of {max} steps per macro.",
     "macro_max_steps_reached": "({max} max)",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right",
     "macro_name_label": "Macro Name",
     "macro_name_required": "Name is required",
     "macro_name_too_long": "Name must be less than 50 characters",
@@ -973,8 +976,5 @@
     "wake_on_lan_invalid_mac": "Invalid MAC address",
     "wake_on_lan_magic_sent_success": "Magic Packet sent successfully",
     "welcome_to_jetkvm": "Welcome to JetKVM",
-    "welcome_to_jetkvm_description": "Control any computer remotely",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Control any computer remotely"
 }

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -973,5 +973,8 @@
     "wake_on_lan_invalid_mac": "Invalid MAC address",
     "wake_on_lan_magic_sent_success": "Magic Packet sent successfully",
     "welcome_to_jetkvm": "Welcome to JetKVM",
-    "welcome_to_jetkvm_description": "Control any computer remotely"
+    "welcome_to_jetkvm_description": "Control any computer remotely",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Agregue su clave pública SSH para habilitar el acceso remoto seguro al dispositivo",
     "advanced_ssh_access_title": "Acceso SSH",
     "advanced_ssh_default_user": "El usuario SSH predeterminado es",
+    "advanced_ssh_key_required_warning": "Se requiere una clave pública para el acceso SSH. Sin ella, no podrá conectarse.",
     "advanced_ssh_public_key_label": "Clave pública SSH",
     "advanced_ssh_public_key_placeholder": "Ingrese su clave pública SSH",
     "advanced_success_download_diagnostics": "Diagnóstico descargado exitosamente",
-    "advanced_ssh_key_required_warning": "Se requiere una clave pública para el acceso SSH. Sin ella, no podrá conectarse.",
     "advanced_success_loopback_disabled": "El modo de solo bucle invertido está deshabilitado. Reinicie el dispositivo para aplicarlo.",
     "advanced_success_loopback_enabled": "Modo de solo bucle invertido habilitado. Reinicie el dispositivo para aplicarlo.",
     "advanced_success_reset_config": "La configuración se restableció a los valores predeterminados correctamente",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Actualizar clave SSH",
     "advanced_usb_emulation_description": "Controlar el estado de emulación USB",
     "advanced_usb_emulation_title": "Emulación USB",
+    "advanced_version_change_acknowledged_label": "Entiendo que los cambios de versión pueden dañar mi dispositivo y requerir un restablecimiento de fábrica",
     "advanced_version_update_app_label": "Versión de la aplicación",
     "advanced_version_update_button": "Actualización a la versión",
     "advanced_version_update_description": "Instala una versión específica desde las versiones de GitHub.",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Se requiere al menos un paso",
     "macro_max_steps_error": "Solo puede agregar un máximo de {max} pasos por macro.",
     "macro_max_steps_reached": "( {max} máx.)",
+    "macro_modifier_left": "Izquierda",
+    "macro_modifier_right": "Derecha",
     "macro_name_label": "Nombre de la macro",
     "macro_name_required": "El nombre es obligatorio",
     "macro_name_too_long": "El nombre debe tener menos de 50 caracteres.",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Dirección MAC no válida",
     "wake_on_lan_magic_sent_success": "Paquete mágico enviado con éxito",
     "welcome_to_jetkvm": "Bienvenido a JetKVM",
-    "welcome_to_jetkvm_description": "Controla cualquier computadora de forma remota",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Controla cualquier computadora de forma remota"
 }

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Dirección MAC no válida",
     "wake_on_lan_magic_sent_success": "Paquete mágico enviado con éxito",
     "welcome_to_jetkvm": "Bienvenido a JetKVM",
-    "welcome_to_jetkvm_description": "Controla cualquier computadora de forma remota"
+    "welcome_to_jetkvm_description": "Controla cualquier computadora de forma remota",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Adresse MAC invalide",
     "wake_on_lan_magic_sent_success": "Paquet magique envoyé avec succès",
     "welcome_to_jetkvm": "Bienvenue chez JetKVM",
-    "welcome_to_jetkvm_description": "Contrôlez n'importe quel ordinateur à distance"
+    "welcome_to_jetkvm_description": "Contrôlez n'importe quel ordinateur à distance",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Ajoutez votre clé publique SSH pour activer l'accès à distance sécurisé à l'appareil",
     "advanced_ssh_access_title": "Accès SSH",
     "advanced_ssh_default_user": "L'utilisateur SSH par défaut est",
+    "advanced_ssh_key_required_warning": "Une clé publique est requise pour l'accès SSH. Sans celle-ci, vous ne pourrez pas vous connecter.",
     "advanced_ssh_public_key_label": "Clé publique SSH",
     "advanced_ssh_public_key_placeholder": "Entrez votre clé publique SSH",
     "advanced_success_download_diagnostics": "Diagnostics téléchargés avec succès",
-    "advanced_ssh_key_required_warning": "Une clé publique est requise pour l'accès SSH. Sans celle-ci, vous ne pourrez pas vous connecter.",
     "advanced_success_loopback_disabled": "Mode de bouclage désactivé. Redémarrez votre appareil pour appliquer le mode de bouclage.",
     "advanced_success_loopback_enabled": "Mode de bouclage activé. Redémarrez votre appareil pour appliquer la fonction.",
     "advanced_success_reset_config": "La configuration par défaut a été réinitialisée avec succès",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Mettre à jour la clé SSH",
     "advanced_usb_emulation_description": "Contrôler l'état de l'émulation USB",
     "advanced_usb_emulation_title": "Émulation USB",
+    "advanced_version_change_acknowledged_label": "Je comprends que les changements de version peuvent endommager mon appareil et nécessiter une réinitialisation d'usine",
     "advanced_version_update_app_label": "Version de l'application",
     "advanced_version_update_button": "Mise à jour vers la version",
     "advanced_version_update_description": "Installer une version spécifique à partir des versions GitHub",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Au moins une étape est requise",
     "macro_max_steps_error": "Vous ne pouvez ajouter qu'un maximum de {max} étapes par macro.",
     "macro_max_steps_reached": "( {max} max)",
+    "macro_modifier_left": "Gauche",
+    "macro_modifier_right": "Droite",
     "macro_name_label": "Nom de la macro",
     "macro_name_required": "Le nom est obligatoire",
     "macro_name_too_long": "Le nom doit comporter moins de 50 caractères",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Adresse MAC invalide",
     "wake_on_lan_magic_sent_success": "Paquet magique envoyé avec succès",
     "welcome_to_jetkvm": "Bienvenue chez JetKVM",
-    "welcome_to_jetkvm_description": "Contrôlez n'importe quel ordinateur à distance",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Contrôlez n'importe quel ordinateur à distance"
 }

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Indirizzo MAC non valido",
     "wake_on_lan_magic_sent_success": "Pacchetto magico inviato con successo",
     "welcome_to_jetkvm": "Benvenuti a JetKVM",
-    "welcome_to_jetkvm_description": "Controlla qualsiasi computer da remoto"
+    "welcome_to_jetkvm_description": "Controlla qualsiasi computer da remoto",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Aggiungi la tua chiave pubblica SSH per abilitare l'accesso remoto sicuro al dispositivo",
     "advanced_ssh_access_title": "Accesso SSH",
     "advanced_ssh_default_user": "L'utente SSH predefinito è",
+    "advanced_ssh_key_required_warning": "Una chiave pubblica è necessaria per l'accesso SSH. Senza di essa, non sarà possibile connettersi.",
     "advanced_ssh_public_key_label": "Chiave pubblica SSH",
     "advanced_ssh_public_key_placeholder": "Inserisci la tua chiave pubblica SSH",
     "advanced_success_download_diagnostics": "Diagnostica scaricata correttamente",
-    "advanced_ssh_key_required_warning": "Una chiave pubblica è necessaria per l'accesso SSH. Senza di essa, non sarà possibile connettersi.",
     "advanced_success_loopback_disabled": "Modalità loopback-only disattivata. Riavvia il dispositivo per applicare la modifica.",
     "advanced_success_loopback_enabled": "Modalità loopback abilitata. Riavvia il dispositivo per applicare la modifica.",
     "advanced_success_reset_config": "Configurazione ripristinata ai valori predefiniti con successo",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Aggiorna la chiave SSH",
     "advanced_usb_emulation_description": "Controlla lo stato di emulazione USB",
     "advanced_usb_emulation_title": "Emulazione USB",
+    "advanced_version_change_acknowledged_label": "Capisco che i cambiamenti di versione possono danneggiare il mio dispositivo e richiedere un ripristino delle impostazioni di fabbrica",
     "advanced_version_update_app_label": "Versione dell'app",
     "advanced_version_update_button": "Aggiorna alla versione",
     "advanced_version_update_description": "Installa una versione specifica dalle versioni di GitHub",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "È richiesto almeno un passaggio",
     "macro_max_steps_error": "È possibile aggiungere al massimo {max} passaggi per macro.",
     "macro_max_steps_reached": "( {max} max)",
+    "macro_modifier_left": "Sinistra",
+    "macro_modifier_right": "Destra",
     "macro_name_label": "Nome macro",
     "macro_name_required": "Il nome è obbligatorio",
     "macro_name_too_long": "Il nome deve contenere meno di 50 caratteri",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Indirizzo MAC non valido",
     "wake_on_lan_magic_sent_success": "Pacchetto magico inviato con successo",
     "welcome_to_jetkvm": "Benvenuti a JetKVM",
-    "welcome_to_jetkvm_description": "Controlla qualsiasi computer da remoto",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Controlla qualsiasi computer da remoto"
 }

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "無効なMACアドレス",
     "wake_on_lan_magic_sent_success": "マジックパケットが正常に送信されました",
     "welcome_to_jetkvm": "JetKVMへようこそ",
-    "welcome_to_jetkvm_description": "あらゆるコンピュータをリモート制御"
+    "welcome_to_jetkvm_description": "あらゆるコンピュータをリモート制御",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -94,9 +94,9 @@
     "advanced_ssh_access_description": "SSH公開鍵を追加して、デバイスへの安全なリモートアクセスを有効にします",
     "advanced_ssh_access_title": "SSHアクセス",
     "advanced_ssh_default_user": "デフォルトのSSHユーザーは",
+    "advanced_ssh_key_required_warning": "SSHアクセスには公開鍵が必要です。公開鍵がないと接続できません。",
     "advanced_ssh_public_key_label": "SSH公開鍵",
     "advanced_ssh_public_key_placeholder": "SSH公開鍵を入力してください",
-    "advanced_ssh_key_required_warning": "SSHアクセスには公開鍵が必要です。公開鍵がないと接続できません。",
     "advanced_success_download_diagnostics": "診断データが正常にダウンロードされました",
     "advanced_success_loopback_disabled": "ループバック専用モードが無効になりました。適用するにはデバイスを再起動してください。",
     "advanced_success_loopback_enabled": "ループバック専用モードが有効になりました。適用するにはデバイスを再起動してください。",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "SSHキーを更新",
     "advanced_usb_emulation_description": "USBエミュレーションの状態を制御します",
     "advanced_usb_emulation_title": "USBエミュレーション",
+    "advanced_version_change_acknowledged_label": "バージョン変更によりデバイスが破損し、工場出荷時のリセットが必要になる場合があることを理解しています",
     "advanced_version_update_app_label": "アプリバージョン",
     "advanced_version_update_button": "バージョンを更新",
     "advanced_version_update_description": "GitHubリリースから特定のバージョンをインストールします",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "少なくとも1つのステップが必要です",
     "macro_max_steps_error": "マクロごとに追加できるのは最大 {max} ステップまでです。",
     "macro_max_steps_reached": "(最大 {max})",
+    "macro_modifier_left": "左",
+    "macro_modifier_right": "右",
     "macro_name_label": "マクロ名",
     "macro_name_required": "名前が必要です",
     "macro_name_too_long": "名前は50文字以内である必要があります",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "無効なMACアドレス",
     "wake_on_lan_magic_sent_success": "マジックパケットが正常に送信されました",
     "welcome_to_jetkvm": "JetKVMへようこそ",
-    "welcome_to_jetkvm_description": "あらゆるコンピュータをリモート制御",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "あらゆるコンピュータをリモート制御"
 }

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Legg til din offentlige SSH-nøkkel for å aktivere sikker ekstern tilgang til enheten",
     "advanced_ssh_access_title": "SSH-tilgang",
     "advanced_ssh_default_user": "Standard SSH-brukeren er",
+    "advanced_ssh_key_required_warning": "En offentlig nøkkel er påkrevd for SSH-tilgang. Uten en vil du ikke kunne koble til.",
     "advanced_ssh_public_key_label": "SSH offentlig nøkkel",
     "advanced_ssh_public_key_placeholder": "Skriv inn din offentlige SSH-nøkkel",
     "advanced_success_download_diagnostics": "Diagnostikken er lastet ned",
-    "advanced_ssh_key_required_warning": "En offentlig nøkkel er påkrevd for SSH-tilgang. Uten en vil du ikke kunne koble til.",
     "advanced_success_loopback_disabled": "Kun tilbakekoblingsmodus deaktivert. Start enheten på nytt for å bruke den.",
     "advanced_success_loopback_enabled": "Kun tilbakekoblingsmodus aktivert. Start enheten på nytt for å bruke den.",
     "advanced_success_reset_config": "Konfigurasjonen ble tilbakestilt til standard",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Oppdater SSH-nøkkel",
     "advanced_usb_emulation_description": "Kontroller USB-emuleringstilstanden",
     "advanced_usb_emulation_title": "USB-emulering",
+    "advanced_version_change_acknowledged_label": "Jeg forstår at versjonsendringer kan ødelegge enheten min og kreve tilbakestilling til fabrikkinnstillinger",
     "advanced_version_update_app_label": "Appversjon",
     "advanced_version_update_button": "Oppdater til versjon",
     "advanced_version_update_description": "Installer en spesifikk versjon fra GitHub-utgivelser",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Minst ett trinn er nødvendig",
     "macro_max_steps_error": "Du kan bare legge til maksimalt {max} trinn per makro.",
     "macro_max_steps_reached": "( {max} maks)",
+    "macro_modifier_left": "Venstre",
+    "macro_modifier_right": "Høyre",
     "macro_name_label": "Makronavn",
     "macro_name_required": "Navn er obligatorisk",
     "macro_name_too_long": "Navnet må være mindre enn 50 tegn",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Ugyldig MAC-adresse",
     "wake_on_lan_magic_sent_success": "Magisk pakke sendt",
     "welcome_to_jetkvm": "Velkommen til JetKVM",
-    "welcome_to_jetkvm_description": "Fjernstyr enhver datamaskin",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Fjernstyr enhver datamaskin"
 }

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Ugyldig MAC-adresse",
     "wake_on_lan_magic_sent_success": "Magisk pakke sendt",
     "welcome_to_jetkvm": "Velkommen til JetKVM",
-    "welcome_to_jetkvm_description": "Fjernstyr enhver datamaskin"
+    "welcome_to_jetkvm_description": "Fjernstyr enhver datamaskin",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Endereço MAC inválido",
     "wake_on_lan_magic_sent_success": "Pacote Mágico enviado com sucesso",
     "welcome_to_jetkvm": "Bem-vindo ao JetKVM",
-    "welcome_to_jetkvm_description": "Controle qualquer computador remotamente"
+    "welcome_to_jetkvm_description": "Controle qualquer computador remotamente",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -94,9 +94,9 @@
     "advanced_ssh_access_description": "Adicione sua chave pública SSH para habilitar acesso remoto seguro ao dispositivo",
     "advanced_ssh_access_title": "Acesso SSH",
     "advanced_ssh_default_user": "O usuário SSH padrão é",
+    "advanced_ssh_key_required_warning": "Uma chave pública é necessária para acesso SSH. Sem ela, você não conseguirá se conectar.",
     "advanced_ssh_public_key_label": "Chave Pública SSH",
     "advanced_ssh_public_key_placeholder": "Digite sua chave pública SSH",
-    "advanced_ssh_key_required_warning": "Uma chave pública é necessária para acesso SSH. Sem ela, você não conseguirá se conectar.",
     "advanced_success_download_diagnostics": "Diagnósticos baixados com sucesso",
     "advanced_success_loopback_disabled": "Modo somente loopback desativado. Reinicie seu dispositivo para aplicar.",
     "advanced_success_loopback_enabled": "Modo somente loopback ativado. Reinicie seu dispositivo para aplicar.",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Atualizar Chave SSH",
     "advanced_usb_emulation_description": "Controle o estado da emulação USB",
     "advanced_usb_emulation_title": "Emulação USB",
+    "advanced_version_change_acknowledged_label": "Eu entendo que mudanças de versão podem danificar meu dispositivo e exigir redefinição de fábrica",
     "advanced_version_update_app_label": "Versão do Aplicativo",
     "advanced_version_update_button": "Atualizar para Versão",
     "advanced_version_update_description": "Instale uma versão específica dos lançamentos do GitHub",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Pelo menos uma etapa é necessária",
     "macro_max_steps_error": "Você só pode adicionar no máximo {max} etapas por macro.",
     "macro_max_steps_reached": "({max} máx.)",
+    "macro_modifier_left": "Esquerda",
+    "macro_modifier_right": "Direita",
     "macro_name_label": "Nome do Macro",
     "macro_name_required": "Nome é obrigatório",
     "macro_name_too_long": "O nome deve ter menos de 50 caracteres",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Endereço MAC inválido",
     "wake_on_lan_magic_sent_success": "Pacote Mágico enviado com sucesso",
     "welcome_to_jetkvm": "Bem-vindo ao JetKVM",
-    "welcome_to_jetkvm_description": "Controle qualquer computador remotamente",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Controle qualquer computador remotamente"
 }

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -93,9 +93,9 @@
     "advanced_ssh_access_description": "Добавьте ваш публичный SSH-ключ для безопасного удалённого доступа к устройству",
     "advanced_ssh_access_title": "SSH-доступ",
     "advanced_ssh_default_user": "Пользователь по умолчанию для SSH:",
+    "advanced_ssh_key_required_warning": "Для SSH-доступа необходим публичный ключ. Без него подключение будет невозможно.",
     "advanced_ssh_public_key_label": "Публичный SSH-ключ",
     "advanced_ssh_public_key_placeholder": "Введите ваш публичный SSH-ключ",
-    "advanced_ssh_key_required_warning": "Для SSH-доступа необходим публичный ключ. Без него подключение будет невозможно.",
     "advanced_success_download_diagnostics": "Диагностика успешно скачана",
     "advanced_success_loopback_disabled": "Режим только loopback отключён. Перезапустите устройство для применения.",
     "advanced_success_loopback_enabled": "Режим только loopback включён. Перезапустите устройство для применения.",
@@ -107,6 +107,7 @@
     "advanced_update_ssh_key_button": "Обновить SSH-ключ",
     "advanced_usb_emulation_description": "Управление состоянием эмуляции USB",
     "advanced_usb_emulation_title": "Эмуляция USB",
+    "advanced_version_change_acknowledged_label": "Я понимаю, что изменение версии может повредить моё устройство и потребовать сброса к заводским настройкам",
     "advanced_version_update_app_label": "Версия приложения",
     "advanced_version_update_button": "Обновить до версии",
     "advanced_version_update_description": "Установить определённую версию из релизов GitHub",
@@ -469,6 +470,8 @@
     "macro_at_least_one_step_required": "Требуется хотя бы один шаг",
     "macro_max_steps_error": "Вы можете добавить максимум {max} шагов на макрос.",
     "macro_max_steps_reached": "({max} максимум)",
+    "macro_modifier_left": "Левый",
+    "macro_modifier_right": "Правый",
     "macro_name_label": "Имя макроса",
     "macro_name_required": "Имя обязательно",
     "macro_name_too_long": "Имя должно быть менее 50 символов",
@@ -964,8 +967,5 @@
     "wake_on_lan_invalid_mac": "Недопустимый MAC-адрес",
     "wake_on_lan_magic_sent_success": "Magic Packet успешно отправлен",
     "welcome_to_jetkvm": "Добро пожаловать в JetKVM",
-    "welcome_to_jetkvm_description": "Управляйте любым компьютером удалённо",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Управляйте любым компьютером удалённо"
 }

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -964,5 +964,8 @@
     "wake_on_lan_invalid_mac": "Недопустимый MAC-адрес",
     "wake_on_lan_magic_sent_success": "Magic Packet успешно отправлен",
     "welcome_to_jetkvm": "Добро пожаловать в JetKVM",
-    "welcome_to_jetkvm_description": "Управляйте любым компьютером удалённо"
+    "welcome_to_jetkvm_description": "Управляйте любым компьютером удалённо",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "Ogiltig MAC-adress",
     "wake_on_lan_magic_sent_success": "Magiskt paket skickades",
     "welcome_to_jetkvm": "Välkommen till JetKVM",
-    "welcome_to_jetkvm_description": "Styr vilken dator som helst på distans"
+    "welcome_to_jetkvm_description": "Styr vilken dator som helst på distans",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "Lägg till din offentliga SSH-nyckel för att aktivera säker fjärråtkomst till enheten",
     "advanced_ssh_access_title": "SSH-åtkomst",
     "advanced_ssh_default_user": "Standard SSH-användaren är",
+    "advanced_ssh_key_required_warning": "En offentlig nyckel krävs för SSH-åtkomst. Utan en kommer du inte att kunna ansluta.",
     "advanced_ssh_public_key_label": "SSH-publik nyckel",
     "advanced_ssh_public_key_placeholder": "Ange din offentliga SSH-nyckel",
     "advanced_success_download_diagnostics": "Diagnostiken har laddats ner",
-    "advanced_ssh_key_required_warning": "En offentlig nyckel krävs för SSH-åtkomst. Utan en kommer du inte att kunna ansluta.",
     "advanced_success_loopback_disabled": "Endast loopback-läge inaktiverat. Starta om enheten för att tillämpa det.",
     "advanced_success_loopback_enabled": "Endast loopback-läge aktiverat. Starta om enheten för att tillämpa.",
     "advanced_success_reset_config": "Konfigurationen återställdes till standardinställningarna",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "Uppdatera SSH-nyckel",
     "advanced_usb_emulation_description": "Kontrollera USB-emuleringsstatusen",
     "advanced_usb_emulation_title": "USB-emulering",
+    "advanced_version_change_acknowledged_label": "Jag förstår att versionsändringar kan skada min enhet och kräva fabriksåterställning",
     "advanced_version_update_app_label": "Appversion",
     "advanced_version_update_button": "Uppdatera till version",
     "advanced_version_update_description": "Installera en specifik version från GitHub-utgåvor",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "Minst ett steg krävs",
     "macro_max_steps_error": "Du kan bara lägga till maximalt {max} steg per makro.",
     "macro_max_steps_reached": "( {max} max)",
+    "macro_modifier_left": "Vänster",
+    "macro_modifier_right": "Höger",
     "macro_name_label": "Makronamn",
     "macro_name_required": "Namn krävs",
     "macro_name_too_long": "Namnet måste vara kortare än 50 tecken",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "Ogiltig MAC-adress",
     "wake_on_lan_magic_sent_success": "Magiskt paket skickades",
     "welcome_to_jetkvm": "Välkommen till JetKVM",
-    "welcome_to_jetkvm_description": "Styr vilken dator som helst på distans",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "Styr vilken dator som helst på distans"
 }

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -94,9 +94,9 @@
     "advanced_ssh_access_description": "新增您的 SSH 公鑰以啟用對裝置的安全遠端存取",
     "advanced_ssh_access_title": "SSH 存取",
     "advanced_ssh_default_user": "預設 SSH 使用者為",
+    "advanced_ssh_key_required_warning": "SSH 存取需要公鑰。沒有公鑰將無法連線。",
     "advanced_ssh_public_key_label": "SSH 公鑰",
     "advanced_ssh_public_key_placeholder": "輸入您的 SSH 公鑰",
-    "advanced_ssh_key_required_warning": "SSH 存取需要公鑰。沒有公鑰將無法連線。",
     "advanced_success_download_diagnostics": "診斷資料下載成功",
     "advanced_success_loopback_disabled": "單機回送模式已停用。請重新啟動您的裝置以套用。",
     "advanced_success_loopback_enabled": "單機回送模式已啟用。請重新啟動您的裝置以套用。",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "更新 SSH 金鑰",
     "advanced_usb_emulation_description": "控制 USB 模擬狀態",
     "advanced_usb_emulation_title": "USB 模擬",
+    "advanced_version_change_acknowledged_label": "我了解版本變更可能會損壞我的裝置並需要恢復出廠設定",
     "advanced_version_update_app_label": "App 版本",
     "advanced_version_update_button": "更新至版本",
     "advanced_version_update_description": "從 GitHub Releases 安裝特定版本",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "至少需要一個步驟",
     "macro_max_steps_error": "每個巨集最多只能新增 {max} 個步驟。",
     "macro_max_steps_reached": "(上限 {max})",
+    "macro_modifier_left": "左",
+    "macro_modifier_right": "右",
     "macro_name_label": "巨集名稱",
     "macro_name_required": "名稱為必填",
     "macro_name_too_long": "名稱必須少於 50 個字元",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "無效的 MAC 位址",
     "wake_on_lan_magic_sent_success": "Magic Packet 傳送成功",
     "welcome_to_jetkvm": "歡迎使用 JetKVM",
-    "welcome_to_jetkvm_description": "遠端控制任何電腦",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "遠端控制任何電腦"
 }

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "無效的 MAC 位址",
     "wake_on_lan_magic_sent_success": "Magic Packet 傳送成功",
     "welcome_to_jetkvm": "歡迎使用 JetKVM",
-    "welcome_to_jetkvm_description": "遠端控制任何電腦"
+    "welcome_to_jetkvm_description": "遠端控制任何電腦",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -94,10 +94,10 @@
     "advanced_ssh_access_description": "添加您的 SSH 公钥以启用对设备的安全远程访问。",
     "advanced_ssh_access_title": "SSH 访问",
     "advanced_ssh_default_user": "默认 SSH 用户为",
+    "advanced_ssh_key_required_warning": "SSH 访问需要公钥。没有公钥将无法连接。",
     "advanced_ssh_public_key_label": "SSH 公钥",
     "advanced_ssh_public_key_placeholder": "请输入您的 SSH 公钥",
     "advanced_success_download_diagnostics": "诊断文件已成功下载",
-    "advanced_ssh_key_required_warning": "SSH 访问需要公钥。没有公钥将无法连接。",
     "advanced_success_loopback_disabled": "环回模式已禁用。请重启设备以应用更改。",
     "advanced_success_loopback_enabled": "环回模式已启用。请重启设备以应用更改。",
     "advanced_success_reset_config": "配置已成功恢复为默认设置。",
@@ -108,6 +108,7 @@
     "advanced_update_ssh_key_button": "更新 SSH 密钥",
     "advanced_usb_emulation_description": "控制 USB 模拟的状态。",
     "advanced_usb_emulation_title": "USB 模拟",
+    "advanced_version_change_acknowledged_label": "我了解版本更改可能会损坏我的设备并需要恢复出厂设置",
     "advanced_version_update_app_label": "应用版本",
     "advanced_version_update_button": "更新至版本",
     "advanced_version_update_description": "从 GitHub Releases 安装指定版本。",
@@ -470,6 +471,8 @@
     "macro_at_least_one_step_required": "至少需要一个步骤。",
     "macro_max_steps_error": "每个宏最多只能添加 {max} 个步骤。",
     "macro_max_steps_reached": "({max} 为上限)",
+    "macro_modifier_left": "左",
+    "macro_modifier_right": "右",
     "macro_name_label": "宏名称",
     "macro_name_required": "名称为必填项。",
     "macro_name_too_long": "名称长度不能超过 50 个字符。",
@@ -947,8 +950,5 @@
     "wake_on_lan_invalid_mac": "无效的 MAC 地址。",
     "wake_on_lan_magic_sent_success": "“魔术包”发送成功。",
     "welcome_to_jetkvm": "欢迎使用 JetKVM",
-    "welcome_to_jetkvm_description": "远程控制您的任意计算机",
-    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
-    "macro_modifier_left": "Left",
-    "macro_modifier_right": "Right"
+    "welcome_to_jetkvm_description": "远程控制您的任意计算机"
 }

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -947,5 +947,8 @@
     "wake_on_lan_invalid_mac": "无效的 MAC 地址。",
     "wake_on_lan_magic_sent_success": "“魔术包”发送成功。",
     "welcome_to_jetkvm": "欢迎使用 JetKVM",
-    "welcome_to_jetkvm_description": "远程控制您的任意计算机"
+    "welcome_to_jetkvm_description": "远程控制您的任意计算机",
+    "advanced_version_change_acknowledged_label": "I understand version changes may break my device and require factory reset",
+    "macro_modifier_left": "Left",
+    "macro_modifier_right": "Right"
 }

--- a/ui/src/components/MacroStepCard.tsx
+++ b/ui/src/components/MacroStepCard.tsx
@@ -21,9 +21,7 @@ const directionLabels: Record<string, () => string> = {
 
 const modifierOptions = Object.keys(modifiers).map(modifier => {
   const match = modifier.match(/^(Control|Alt|Shift|Meta)(Left|Right)$/);
-  const label = match
-    ? `${match[1]} ${directionLabels[match[2]]()}`
-    : modifier;
+  const label = match ? `${match[1]} ${directionLabels[match[2]]()}` : modifier;
   return { value: modifier, label };
 });
 

--- a/ui/src/components/MacroStepCard.tsx
+++ b/ui/src/components/MacroStepCard.tsx
@@ -14,10 +14,18 @@ import { m } from "@localizations/messages.js";
 // Filter out modifier keys since they're handled in the modifiers section
 const modifierKeyPrefixes = ["Alt", "Control", "Shift", "Meta"];
 
-const modifierOptions = Object.keys(modifiers).map(modifier => ({
-  value: modifier,
-  label: modifier.replace(/^(Control|Alt|Shift|Meta)(Left|Right)$/, "$1 $2"),
-}));
+const directionLabels: Record<string, () => string> = {
+  Left: () => m.macro_modifier_left(),
+  Right: () => m.macro_modifier_right(),
+};
+
+const modifierOptions = Object.keys(modifiers).map(modifier => {
+  const match = modifier.match(/^(Control|Alt|Shift|Meta)(Left|Right)$/);
+  const label = match
+    ? `${match[1]} ${directionLabels[match[2]]()}`
+    : modifier;
+  return { value: modifier, label };
+});
 
 const groupedModifiers: Record<string, typeof modifierOptions> = {
   Control: modifierOptions.filter(mod => mod.value.startsWith("Control")),

--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -406,7 +406,7 @@ export default function SettingsAdvancedRoute() {
 
                 <div>
                   <CheckboxWithLabel
-                    label="I understand version changes may break my device and require factory reset"
+                    label={m.advanced_version_change_acknowledged_label()}
                     checked={versionChangeAcknowledged}
                     onChange={e => setVersionChangeAcknowledged(e.target.checked)}
                   />


### PR DESCRIPTION
## Summary
- Replace two hardcoded English strings that bypassed Paraglide i18n: modifier direction labels ("Left"/"Right") in `MacroStepCard.tsx` and the version-change acknowledgment checkbox in the Developer Settings page
- Add `macro_modifier_left`, `macro_modifier_right`, and `advanced_version_change_acknowledged_label` keys to all 14 locale files

Closes #1162

## Test plan
- [ ] Verify macro key modifier labels display correctly (e.g. "Control Left", "Shift Right")
- [ ] Verify the Developer Settings version-change checkbox label renders
- [ ] Switch language and confirm these strings update accordingly


Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: UI text-only changes that route previously hardcoded English strings through existing i18n message keys.
> 
> **Overview**
> Removes remaining hardcoded English strings that bypassed Paraglide i18n.
> 
> Macro modifier direction labels in `MacroStepCard.tsx` now use localized `macro_modifier_left`/`macro_modifier_right`, and the advanced settings version-change acknowledgement checkbox now uses `advanced_version_change_acknowledged_label`. Adds these new message keys across all locale JSON files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 87f8110423a24f72a2a6476f98572df47c4b1d83. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->