### PR TITLE
feat(e2e): add OTA upgrade-from-stable test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test_e2e:
 	cd ui && npx playwright install chromium
 	cd ui && $(call OTA_ENV,$(TEST_VERSION)) \
 		$(if $(JETKVM_REMOTE_HOST),JETKVM_REMOTE_HOST=$(JETKVM_REMOTE_HOST)) \
-		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned
+		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-upgrade-from-stable
 
 # Production release validation lane
 test_production_release:
@@ -275,7 +275,7 @@ dev_release: git_check_dev check_r2
 	cd ui && npx playwright install --with-deps chromium
 	cd ui && $(call OTA_ENV,$(VERSION_DEV)) \
 		JETKVM_REMOTE_HOST=$(JETKVM_REMOTE_HOST) \
-		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-prerelease-rejected --project=ota-specific-version
+		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-prerelease-rejected --project=ota-specific-version --project=ota-upgrade-from-stable
 
 	@echo "───────────────────────────────────────────────────────"
 	@echo "  All tests completed. Everything is tested and ready for release."

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -1,4 +1,5 @@
 import * as http from "http";
+import * as https from "https";
 import * as fs from "fs";
 import * as crypto from "crypto";
 import * as os from "os";
@@ -1081,6 +1082,62 @@ export function getLocalNetworkIP(): string {
     }
   }
   throw new Error("Could not detect local network IP address");
+}
+
+// ── OTA: Production Release Fetching ──
+
+export interface StableReleaseInfo {
+  appVersion: string;
+  appUrl: string;
+  appHash: string;
+}
+
+export async function fetchLatestStableRelease(): Promise<StableReleaseInfo> {
+  const url = "https://api.jetkvm.com/releases?deviceId=e2e-test";
+  const body = await new Promise<string>((resolve, reject) => {
+    https.get(url, res => {
+      if (res.statusCode !== 200) {
+        reject(new Error(`Release API returned ${res.statusCode}`));
+        res.resume();
+        return;
+      }
+      let data = "";
+      res.on("data", chunk => (data += chunk));
+      res.on("end", () => resolve(data));
+      res.on("error", reject);
+    }).on("error", reject);
+  });
+
+  const json = JSON.parse(body);
+  if (!json.appVersion || !json.appUrl || !json.appHash) {
+    throw new Error(`Unexpected release API response: ${body}`);
+  }
+  return { appVersion: json.appVersion, appUrl: json.appUrl, appHash: json.appHash };
+}
+
+export async function downloadFile(url: string, destPath: string): Promise<void> {
+  const proto = url.startsWith("https") ? https : http;
+  const file = fs.createWriteStream(destPath);
+
+  await new Promise<void>((resolve, reject) => {
+    const request = (requestUrl: string) => {
+      proto.get(requestUrl, res => {
+        if (res.statusCode && res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
+          request(res.headers.location);
+          return;
+        }
+        if (res.statusCode !== 200) {
+          reject(new Error(`Download failed: ${res.statusCode} for ${requestUrl}`));
+          res.resume();
+          return;
+        }
+        res.pipe(file);
+        file.on("finish", () => file.close(() => resolve()));
+        res.on("error", reject);
+      }).on("error", reject);
+    };
+    request(url);
+  });
 }
 
 // ── OTA: Test Helpers ──

--- a/ui/e2e/ota-upgrade-from-stable.spec.ts
+++ b/ui/e2e/ota-upgrade-from-stable.spec.ts
@@ -1,0 +1,122 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  getCurrentVersion,
+  rebootDeviceViaSSH,
+  ensureLocalAuthMode,
+  verifyHidAndVideo,
+  createMockUpdateServer,
+  deployBinaryToDevice,
+  configureDeviceUpdateUrl,
+  restoreDeviceUpdateUrl,
+  getOTAEnvVars,
+  fetchLatestStableRelease,
+  downloadFile,
+  waitForDeviceReady,
+  getDeviceHost,
+  type MockUpdateServer,
+  type StableReleaseInfo,
+  type OTAEnvVars,
+} from "./helpers";
+
+/**
+ * Validates that a device running the latest stable production release can
+ * OTA-upgrade to the locally-built binary with a config reset, simulating
+ * a real major-version upgrade path.
+ *
+ * Uses custom_app_version to bypass GPG signature checks (the locally-built
+ * binary is unsigned). This mirrors the customVersionUpdate code path.
+ */
+test.describe("OTA Upgrade from Latest Stable", () => {
+  test.setTimeout(420000);
+
+  let mockServer: MockUpdateServer;
+  let stableRelease: StableReleaseInfo;
+  let downloadedBinaryPath: string;
+  let env: OTAEnvVars;
+
+  test.beforeAll(async ({ browser }) => {
+    env = getOTAEnvVars();
+    stableRelease = await fetchLatestStableRelease();
+
+    downloadedBinaryPath = path.join(os.tmpdir(), `jetkvm_stable_${stableRelease.appVersion}`);
+    await downloadFile(stableRelease.appUrl, downloadedBinaryPath);
+
+    const context = await browser.newContext({ baseURL: process.env.JETKVM_URL });
+    const page = await context.newPage();
+    try {
+      await ensureLocalAuthMode(page, { mode: "noPassword" });
+    } finally {
+      await page.close();
+      await context.close();
+    }
+
+    await deployBinaryToDevice(downloadedBinaryPath);
+    await rebootDeviceViaSSH();
+
+    mockServer = await createMockUpdateServer({
+      binaryPath: env.releasePath,
+      version: env.releaseVersion,
+    });
+
+    await configureDeviceUpdateUrl(mockServer.url);
+    await rebootDeviceViaSSH();
+  });
+
+  test("upgrade from latest stable succeeds with config reset", async ({ page }) => {
+    await test.step("Trigger update with config reset", async () => {
+      await page.goto(
+        `/settings/general/update?custom_app_version=${env.releaseVersion}&reset_config=true`,
+      );
+      await page.waitForLoadState("networkidle");
+
+      const initialVersion = await getCurrentVersion(page);
+      expect(initialVersion).not.toBeNull();
+      expect(initialVersion, "Baseline should be production version").toBe(
+        stableRelease.appVersion,
+      );
+
+      const updateButton = page.locator('[data-testid="update-now-button"]');
+      await expect(updateButton).toBeVisible({ timeout: 20000 });
+      await updateButton.click();
+
+      await expect(
+        page.getByText(/downloading|verifying|installing|awaiting reboot/i),
+      ).toBeVisible({ timeout: 30000 });
+    });
+
+    await test.step("Wait for device to come back after reboot", async () => {
+      await page.waitForTimeout(35000);
+      await waitForDeviceReady(getDeviceHost(), 60000);
+    });
+
+    await test.step("Re-setup device after config reset", async () => {
+      await ensureLocalAuthMode(page, { mode: "noPassword" });
+    });
+
+    await test.step("Verify version changed", async () => {
+      await page.goto("/");
+      await page.waitForLoadState("networkidle");
+
+      const finalVersion = await getCurrentVersion(page);
+      expect(finalVersion).not.toBeNull();
+      expect(finalVersion).not.toBe(stableRelease.appVersion);
+    });
+
+    await test.step("Verify HID and video", async () => {
+      await verifyHidAndVideo(page);
+    });
+  });
+
+  test.afterAll(async () => {
+    await restoreDeviceUpdateUrl();
+    await mockServer?.close();
+
+    if (downloadedBinaryPath && fs.existsSync(downloadedBinaryPath)) {
+      fs.unlinkSync(downloadedBinaryPath);
+    }
+  });
+});

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -31,5 +31,6 @@ export default defineConfig({
     { name: "ota-prerelease-unsigned", testMatch: /ota-prerelease-unsigned\.spec\.ts/, dependencies: ["remote-agent"] },
     { name: "ota-prerelease-rejected", testMatch: /ota-prerelease-rejected\.spec\.ts/, dependencies: ["remote-agent"] },
     { name: "ota-specific-version", testMatch: /ota-specific-version-unsigned\.spec\.ts/, dependencies: ["remote-agent"] },
+    { name: "ota-upgrade-from-stable", testMatch: /ota-upgrade-from-stable\.spec\.ts/, dependencies: ["remote-agent"] },
   ],
 });


### PR DESCRIPTION
## Summary

- Adds a new E2E OTA test that downloads the latest stable production binary from `api.jetkvm.com/releases`, deploys it to the device as the baseline, then OTA-upgrades to the locally-built binary with `reset_config=true`
- This is the only OTA test that uses a real production binary as the baseline, catching cross-version upgrade regressions (config migrations, schema changes, renamed RPC methods) that mock-only tests cannot detect
- Also the only test exercising the `reset_config=true` code path, verifying the new binary boots cleanly from a fresh config

## Test plan

- [x] Ran the test locally against a real device — passed all 5 steps in 41s
- [x] Verified no lint errors in new/modified files
- [x] Confirmed existing OTA tests are unaffected (new project is additive)