### PR TITLE
fix: write embedded CA bundle to disk for child process TLS validation

### DIFF
--- a/main.go
+++ b/main.go
@@ -2,6 +2,7 @@ package kvm
 
 import (
 	"context"
+	"encoding/pem"
 	"fmt"
 	"net/http"
 	"os"
@@ -16,8 +17,28 @@ import (
 	"github.com/rs/zerolog"
 )
 
+// caCertBundlePath is the path where the embedded CA certificate bundle is
+// written at startup so that child processes (e.g. tailscale) can validate TLS
+// certificates even though the device rootfs ships no system CA store.
+const caCertBundlePath = "/tmp/jetkvm-cacerts.pem"
+
 var appCtx context.Context
 var procPrefix string = "jetkvm: [app]"
+
+// writeCABundleFile converts the embedded rootcerts DER certificates to PEM
+// and writes them to caCertBundlePath. This allows child processes to use the
+// bundle via the SSL_CERT_FILE environment variable.
+func writeCABundleFile() error {
+	var bundle []byte
+	for _, c := range rootcerts.CertsByTrust(rootcerts.ServerTrustedDelegator) {
+		block := &pem.Block{
+			Type:  "CERTIFICATE",
+			Bytes: c.DER,
+		}
+		bundle = append(bundle, pem.EncodeToMemory(block)...)
+	}
+	return os.WriteFile(caCertBundlePath, bundle, 0644) //nolint:gosec
+}
 
 func setProcTitle(status string) {
 	if status != "" {
@@ -80,6 +101,12 @@ func Main() {
 	logger.Info().
 		Int("ca_certs_loaded", len(rootcerts.Certs())).
 		Msg("loaded Root CA certificates")
+
+	// Write the embedded CA bundle to disk so child processes (tailscale, etc.)
+	// can validate TLS certificates via SSL_CERT_FILE.
+	if werr := writeCABundleFile(); werr != nil {
+		logger.Warn().Err(werr).Msg("failed to write CA certificate bundle to disk")
+	}
 
 	initOta()
 

--- a/tailscale.go
+++ b/tailscale.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
 	"time"
@@ -54,11 +55,20 @@ func isTailscaleInstalled() bool {
 
 // execTailscaleStatus runs `tailscale status --json` and returns the raw output.
 // This is a package-level var to allow test substitution.
+// newTailscaleCommand creates an exec.Cmd for a tailscale subcommand with the
+// SSL_CERT_FILE environment variable set so that the tailscale binary can
+// validate TLS certificates using the embedded CA bundle written at startup.
+func newTailscaleCommand(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "tailscale", args...)
+	cmd.Env = append(os.Environ(), "SSL_CERT_FILE="+caCertBundlePath)
+	return cmd
+}
+
 var execTailscaleStatus = func() ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), tailscaleCommandTimeout)
 	defer cancel()
 
-	output, err := exec.CommandContext(ctx, "tailscale", "status", "--json").CombinedOutput()
+	output, err := newTailscaleCommand(ctx, "status", "--json").CombinedOutput()
 	if err != nil {
 		return nil, fmt.Errorf("tailscale status: %w: %s", err, strings.TrimSpace(string(output)))
 	}


### PR DESCRIPTION
## Summary
- Writes the embedded `rootcerts` CA bundle to `/tmp/jetkvm-cacerts.pem` at startup so child processes can validate TLS certificates
- Adds `newTailscaleCommand()` helper that injects `SSL_CERT_FILE` into tailscale subprocess environment
- Fixes TLS failures (`x509: certificate signed by unknown authority`) for tailscale operations on a device that ships no system CA store

Closes #1321
Closes #1096

> [!NOTE]
> This branch predates #1318 which moved tailscale logic into `internal/tailscale/`. The new `runTailscaleCommand()` in `internal/tailscale/tailscale.go:63` also spawns tailscale subprocesses via `exec.CommandContext` without `SSL_CERT_FILE` — needs to be updated to use the same pattern before this PR is marked ready.

## Test plan
- [ ] Deploy to device, verify `/tmp/jetkvm-cacerts.pem` exists after boot
- [ ] Run `tailscale update` and confirm TLS validation succeeds
- [ ] Verify no regression in tailscale status/connect flows
- [ ] Update `internal/tailscale/tailscale.go` to inject `SSL_CERT_FILE` in its subprocess calls