### PR TITLE
fix: gate public IP check behind cloud adoption status

### DIFF
--- a/network.go
+++ b/network.go
@@ -373,7 +373,9 @@ func rpcGetPublicIPAddresses(refresh bool) ([]myip.PublicIP, error) {
 		return nil, fmt.Errorf("public IP state not initialized")
 	}
 
-	if refresh {
+	// Only allow refresh when cloud is adopted, to avoid sending requests
+	// to api.jetkvm.com when the user has not opted into cloud features.
+	if refresh && config.CloudToken != "" && config.CloudURL != "" {
 		if err := publicIPState.ForceUpdate(); err != nil {
 			return nil, err
 		}
@@ -385,6 +387,11 @@ func rpcGetPublicIPAddresses(refresh bool) ([]myip.PublicIP, error) {
 func rpcCheckPublicIPAddresses() error {
 	if publicIPState == nil {
 		return fmt.Errorf("public IP state not initialized")
+	}
+
+	// Only check public IPs when cloud is adopted.
+	if config.CloudToken == "" || config.CloudURL == "" {
+		return fmt.Errorf("cloud is not enabled")
 	}
 
 	return publicIPState.ForceUpdate()

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -8,7 +8,7 @@ import validator from "validator";
 import PublicIPCard from "@components/PublicIPCard";
 import TailscaleCard from "@components/TailscaleCard";
 import { NetworkSettings, NetworkState, useNetworkStateStore, useRTCStore } from "@hooks/stores";
-import { useJsonRpc } from "@hooks/useJsonRpc";
+import { JsonRpcResponse, useJsonRpc } from "@hooks/useJsonRpc";
 import AutoHeight from "@components/AutoHeight";
 import { Button } from "@components/Button";
 import { ConfirmDialog } from "@components/ConfirmDialog";
@@ -91,6 +91,7 @@ export default function SettingsNetworkRoute() {
   const [customDomain, setCustomDomain] = useState<string>("");
 
   // Confirm dialog
+  const [isCloudAdopted, setIsCloudAdopted] = useState(false);
   const [showRenewLeaseConfirm, setShowRenewLeaseConfirm] = useState(false);
 
   // We use this to determine whether the settings have changed
@@ -148,6 +149,15 @@ export default function SettingsNetworkRoute() {
       throw err;
     }
   }, [setNetworkState, setCustomDomain]);
+
+  useEffect(() => {
+    send("getCloudState", {}, (resp: JsonRpcResponse) => {
+      if ("result" in resp) {
+        const state = resp.result as { connected: boolean };
+        setIsCloudAdopted(state.connected);
+      }
+    });
+  }, [send]);
 
   const formMethods = useForm<NetworkSettings>({
     mode: "onBlur",
@@ -517,7 +527,7 @@ export default function SettingsNetworkRoute() {
                 />
               </SettingsItem>
 
-              <PublicIPCard />
+              {isCloudAdopted && <PublicIPCard />}
 
               <TailscaleCard />
 


### PR DESCRIPTION
## Summary
- Gates `rpcGetPublicIPAddresses` refresh and `rpcCheckPublicIPAddresses` behind `config.CloudToken != ""` checks, preventing HTTP requests to `api.jetkvm.com` when cloud is not adopted
- Conditionally renders `PublicIPCard` only when cloud is adopted

Closes #1146

## Test plan
- [x] With cloud disabled: visit Settings > Network, verify no requests to `api.jetkvm.com` and no PublicIPCard shown
- [x] With cloud enabled: verify PublicIPCard renders and shows public IP as before