### PR TITLE
fix: remove goroutine from HID message handler to prevent leak and disconnect race

### DIFF
--- a/hidrpc.go
+++ b/hidrpc.go
@@ -89,17 +89,13 @@ func onHidMessage(msg hidQueueMessage, session *Session) {
 	}
 
 	t := time.Now()
+	handleHidRPCMessage(message, session)
+	d := time.Since(t)
 
-	r := make(chan interface{}, 1)
-	go func() {
-		handleHidRPCMessage(message, session)
-		r <- nil
-	}()
-	select {
-	case <-time.After(200 * time.Millisecond):
-		scopedLogger.Warn().Msg("HID RPC message timed out")
-	case <-r:
-		scopedLogger.Debug().Dur("duration", time.Since(t)).Msg("HID RPC message handled")
+	if d > 200*time.Millisecond {
+		scopedLogger.Warn().Dur("duration", d).Msg("HID RPC message slow")
+	} else {
+		scopedLogger.Debug().Dur("duration", d).Msg("HID RPC message handled")
 	}
 }
 

--- a/hidrpc.go
+++ b/hidrpc.go
@@ -90,13 +90,13 @@ func onHidMessage(msg hidQueueMessage, session *Session) {
 
 	t := time.Now()
 
-	r := make(chan interface{})
+	r := make(chan interface{}, 1)
 	go func() {
 		handleHidRPCMessage(message, session)
 		r <- nil
 	}()
 	select {
-	case <-time.After(1 * time.Second):
+	case <-time.After(200 * time.Millisecond):
 		scopedLogger.Warn().Msg("HID RPC message timed out")
 	case <-r:
 		scopedLogger.Debug().Dur("duration", time.Since(t)).Msg("HID RPC message handled")


### PR DESCRIPTION
## Summary

- Fixes goroutine leak in HID report handler: when `onHidMessage` timed out, the handler goroutine blocked forever on an unbuffered channel (`r <- nil` with no reader), leaking one goroutine per timeout
- On the single-core RV1106, boot-time CPU contention (TLS handshakes, time sync, cloud connect) caused timeouts to cascade, and leaked goroutines compounded the problem — users saw 0.5–1s mouse latency that persisted until reboot

The fix removes the goroutine+select pattern entirely. HID messages are already processed sequentially per queue channel, and every code path inside `handleHidRPCMessage` is already bounded:
- HID chardev writes: 10ms kernel deadline via `SetWriteDeadline`  
- Keyboard macros: cancellable via context
- DataChannel sends: non-blocking (Pion buffers internally)

Processing synchronously eliminates both the goroutine leak and a race condition where a timed-out keypress goroutine could outlive session disconnect and overwrite the all-keys-up cleanup. Slow messages (>200ms) are still logged as warnings.

## Test plan

- [x] 3x full e2e suite passed (42/42) on device with this change
- [x] Verified the previously-failing `keyboard: all keys released when WebRTC session disconnects` test passes consistently
- [x] Confirmed all HID paths (keyboard, mouse, pointer, macros, keepalive) are bounded and cannot block the queue

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the HID input handling path; removing the 1s timeout/goroutine changes how backpressure and stalls behave and could affect responsiveness under load.
> 
> **Overview**
> `onHidMessage` no longer processes HID RPC messages in a separate goroutine with a 1s timeout; it now handles each message synchronously and measures elapsed time.
> 
> Logging is adjusted to warn when a message takes more than `200ms` ("HID RPC message slow") and otherwise debug-log the handled duration.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 631e82476105312f6df052ced3fae9549b529579. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->