### PR TITLE
fix: modifier key auto-release and keyboard reset on disconnect (#641)

### DIFF
--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -226,10 +226,17 @@ func (u *UsbGadget) performAutoRelease(key byte) {
 	state := u.GetKeysDownState()
 	alreadyReleased := true
 
-	for i := range state.Keys {
-		if state.Keys[i] == key {
+	if mask, exists := KeyCodeToMaskMap[key]; exists {
+		// Modifier keys are tracked in state.Modifier bitmask, not in state.Keys
+		if state.Modifier&mask != 0 {
 			alreadyReleased = false
-			break
+		}
+	} else {
+		for i := range state.Keys {
+			if state.Keys[i] == key {
+				alreadyReleased = false
+				break
+			}
 		}
 	}
 

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -94,6 +94,19 @@ export async function getLedState(page: Page): Promise<KeyboardLedState | null> 
   });
 }
 
+export interface KeysDownState {
+  modifier: number;
+  keys: number[];
+}
+
+export async function getKeysDownState(page: Page): Promise<KeysDownState | null> {
+  return page.evaluate(() => {
+    const hooks = window.__kvmTestHooks;
+    if (!hooks) return null;
+    return hooks.getKeysDownState();
+  });
+}
+
 export async function waitForLedState(
   page: Page,
   ledName: keyof KeyboardLedState,

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -18,6 +18,7 @@ import {
   sshExec,
   getDeviceHost,
   getLedState,
+  getKeysDownState,
   waitForLedState,
   restartAppViaSSH,
 } from "../helpers";
@@ -389,6 +390,104 @@ test.describe("Remote Host Agent", () => {
     const cEvents = await agent!.getKeyboardEvents();
     const cPresses = cEvents.filter(ev => ev.code === KEY.C && ev.type === "key_press");
     expect(cPresses.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // ═══════════════════════════════════════════
+  // KEYBOARD: MODIFIER AUTO-RELEASE
+  // ═══════════════════════════════════════════
+
+  test("keyboard: modifier keys auto-release after timeout", async () => {
+    test.setTimeout(15_000);
+
+    const modifiers = [
+      { hid: 0xE0, linux: KEY.LEFT_CTRL, label: "LeftCtrl" },
+      { hid: 0xE1, linux: KEY.LEFT_SHIFT, label: "LeftShift" },
+      { hid: 0xE2, linux: KEY.LEFT_ALT, label: "LeftAlt" },
+    ];
+
+    for (const { hid, linux, label } of modifiers) {
+      await agent!.clearKeyboardEvents();
+
+      // Call keypressReport directly via JSON-RPC to bypass the browser's
+      // keepalive timer, which would otherwise extend the auto-release indefinitely.
+      await callJsonRpc(sharedPage, "keypressReport", { key: hid, press: true });
+      await new Promise(r => setTimeout(r, 300));
+
+      const events = await agent!.getKeyboardEvents();
+      const presses = events.filter(
+        ev => ev.code === linux && ev.type === "key_press",
+      );
+      const releases = events.filter(
+        ev => ev.code === linux && ev.type === "key_release",
+      );
+
+      expect(presses.length, `${label} press should be received`).toBeGreaterThanOrEqual(1);
+      expect(releases.length, `${label} should auto-release after timeout`).toBeGreaterThanOrEqual(1);
+    }
+  });
+
+  // ═══════════════════════════════════════════
+  // KEYBOARD: KEYS RELEASED ON DISCONNECT
+  // ═══════════════════════════════════════════
+
+  test("keyboard: all keys released when WebRTC session disconnects", async ({ browser }) => {
+    test.setTimeout(30_000);
+
+    // Opening a new page takes over currentSession (single-session device),
+    // kicking sharedPage. We'll reconnect sharedPage at the end.
+    const freshPage = await browser.newPage();
+    await freshPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(freshPage);
+
+    await agent!.clearKeyboardEvents();
+
+    // Hold down a modifier (LeftShift) and a regular key (Space) without releasing
+    await sendKeypress(freshPage, 0xE1, true);
+    await new Promise(r => setTimeout(r, 20));
+    await sendKeypress(freshPage, HID_KEY.SPACE, true);
+    await new Promise(r => setTimeout(r, 50));
+
+    // Verify the host received the presses before we disconnect
+    const preEvents = await agent!.getKeyboardEvents();
+    const shiftPresses = preEvents.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press",
+    );
+    expect(shiftPresses.length, "Host should see LeftShift press").toBeGreaterThanOrEqual(1);
+
+    // Close the page to sever the WebRTC session, triggering the all-keys-up report
+    await freshPage.close();
+    await new Promise(r => setTimeout(r, 1000));
+
+    // Verify the host received releases for both keys
+    const allEvents = await agent!.getKeyboardEvents();
+    const shiftReleases = allEvents.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    const spaceReleases = allEvents.filter(
+      ev => ev.code === KEY.SPACE && ev.type === "key_release",
+    );
+
+    expect(
+      shiftReleases.length,
+      "Host should see LeftShift release after disconnect",
+    ).toBeGreaterThanOrEqual(1);
+    expect(
+      spaceReleases.length,
+      "Host should see Space release after disconnect",
+    ).toBeGreaterThanOrEqual(1);
+
+    // Reconnect sharedPage so subsequent tests can use it
+    await sharedPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+
+    // Verify device-side keys-down state is clear
+    const state = await getKeysDownState(sharedPage);
+    expect(state, "Keys-down state should be available").not.toBeNull();
+    expect(state!.modifier, "Modifier byte should be 0 after disconnect").toBe(0);
+    expect(
+      state!.keys.every((k: number) => k === 0),
+      "All key slots should be clear after disconnect",
+    ).toBe(true);
   });
 
   // ═══════════════════════════════════════════

--- a/webrtc.go
+++ b/webrtc.go
@@ -423,6 +423,8 @@ func newSession(config SessionConfig) (*Session, error) {
 			if session == currentSession {
 				// Cancel any ongoing keyboard report multi when session closes
 				cancelKeyboardMacro()
+				// Release all keys to prevent stuck keys after disconnect
+				_ = rpcKeyboardReport(0, keyboardClearStateKeys)
 				currentSession = nil
 			}
 			// Stop RPC processor
@@ -473,6 +475,8 @@ func onFirstSessionConnected() {
 }
 
 func onLastSessionDisconnected() {
+	// Safety net: ensure all keys are released when the last session disconnects
+	_ = rpcKeyboardReport(0, keyboardClearStateKeys)
 	_ = nativeInstance.VideoStop()
 	startVideoSleepModeTicker()
 }


### PR DESCRIPTION
## Summary
- Fixed `performAutoRelease()` in `hid_keyboard.go` to check `state.Modifier & mask` for modifier keys (0xE0–0xE7) instead of only iterating `state.Keys`, which never contains modifiers
- Added keyboard state reset (`rpcKeyboardReport(0, keyboardClearStateKeys)`) on session disconnect and in `onLastSessionDisconnected()` safety net

Fixes #641

## Test plan
- [x] Hold modifier key (Ctrl/Shift/Alt), disconnect session — verify key releases on target
- [x] Hold modifier key, let keepalive timeout — verify auto-release fires
- [x] No regression on normal keyboard input

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches HID keyboard state tracking and session teardown paths; mistakes could lead to dropped input or stuck keys, but scope is small and well-contained.
> 
> **Overview**
> Fixes modifier key auto-release by checking the `KeysDownState.Modifier` bitmask (via `KeyCodeToMaskMap`) instead of scanning `state.Keys`, which doesn’t include modifiers.
> 
> Adds a keyboard state reset on WebRTC session close (and again as a last-session safety net) by sending `rpcKeyboardReport(0, keyboardClearStateKeys)` to ensure all keys are released after disconnects/timeouts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 09507c77c93c71ff6603ad9e24c074c6587f0b3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->