### PR TITLE
feat(ui): add toggles to hide header and status bars (#1333)

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -269,7 +269,6 @@ async function waitForRpcReady(page: Page, timeoutMs = 30000) {
     }
   }
   throw new Error(`RPC channel not ready after ${timeoutMs}ms`);
-
 }
 
 test.beforeAll(async ({ browser }) => {
@@ -1073,6 +1072,57 @@ test.describe("Remote Host Agent", () => {
 
     // Restore original duration
     await callJsonRpc(sharedPage, "setVideoSleepMode", { duration: originalDuration });
+  });
+
+  // ═══════════════════════════════════════════
+  // PANEL VISIBILITY: HIDE HEADER BAR / STATUS BAR
+  // ═══════════════════════════════════════════
+
+  test("panel-visibility: hide and show header and status bars via appearance settings", async () => {
+    const checkboxFor = (label: string) => sharedPage.getByRole("checkbox", { name: label });
+
+    const headerBar = sharedPage.locator('img[alt=""]').first();
+
+    await sharedPage.evaluate(() => {
+      const stored = localStorage.getItem("settings");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (parsed.state) {
+          delete parsed.state.hideHeaderBar;
+          delete parsed.state.hideStatusBar;
+          delete parsed.state.showHeaderBar;
+          delete parsed.state.showStatusBar;
+          localStorage.setItem("settings", JSON.stringify(parsed));
+        }
+      }
+    });
+
+    await sharedPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+    await expect(headerBar).toBeVisible({ timeout: 5000 });
+
+    await sharedPage.goto("/settings/appearance", { waitUntil: "networkidle" });
+    await checkboxFor("Hide header bar").check();
+
+    await sharedPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+    await expect(headerBar).not.toBeVisible({ timeout: 5000 });
+
+    await sharedPage.goto("/settings/appearance", { waitUntil: "networkidle" });
+    await checkboxFor("Hide status bar").check();
+
+    await sharedPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+    await expect(headerBar).not.toBeVisible({ timeout: 5000 });
+    await expect(sharedPage.getByText("Caps Lock").first()).not.toBeVisible({ timeout: 5000 });
+
+    await sharedPage.goto("/settings/appearance", { waitUntil: "networkidle" });
+    await checkboxFor("Hide header bar").uncheck();
+    await checkboxFor("Hide status bar").uncheck();
+
+    await sharedPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+    await expect(headerBar).toBeVisible({ timeout: 5000 });
   });
 
   // ═══════════════════════════════════════════

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -1055,5 +1055,9 @@
     "wake_on_lan_invalid_mac": "Invalid MAC address",
     "wake_on_lan_magic_sent_success": "Magic Packet sent successfully",
     "welcome_to_jetkvm": "Welcome to JetKVM",
-    "welcome_to_jetkvm_description": "Control any computer remotely"
+    "welcome_to_jetkvm_description": "Control any computer remotely",
+    "appearance_show_header_bar": "Show header bar",
+    "appearance_show_header_bar_description": "Show the top navigation bar with connection status and device info",
+    "appearance_show_status_bar": "Show status bar",
+    "appearance_show_status_bar_description": "Show the bottom status bar with stream information"
 }

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -1056,8 +1056,8 @@
     "wake_on_lan_magic_sent_success": "Magic Packet sent successfully",
     "welcome_to_jetkvm": "Welcome to JetKVM",
     "welcome_to_jetkvm_description": "Control any computer remotely",
-    "appearance_show_header_bar": "Show header bar",
-    "appearance_show_header_bar_description": "Show the top navigation bar with connection status and device info",
-    "appearance_show_status_bar": "Show status bar",
-    "appearance_show_status_bar_description": "Show the bottom status bar with stream information"
+    "appearance_hide_header_bar": "Hide header bar",
+    "appearance_hide_header_bar_description": "Hide the top navigation bar with connection status and device info",
+    "appearance_hide_status_bar": "Hide status bar",
+    "appearance_hide_status_bar_description": "Hide the bottom status bar with stream information"
 }

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -705,7 +705,7 @@ export default function WebRTCVideo({
           </div>
         </div>
       </div>
-      {!hideActionBar && settings.showStatusBar && (
+      {!hideActionBar && !settings.hideStatusBar && (
         <div>
           <InfoBar />
         </div>

--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -705,7 +705,7 @@ export default function WebRTCVideo({
           </div>
         </div>
       </div>
-      {!hideActionBar && (
+      {!hideActionBar && settings.showStatusBar && (
         <div>
           <InfoBar />
         </div>

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -380,11 +380,11 @@ export interface SettingsState {
   videoContrast: number;
   setVideoContrast: (value: number) => void;
 
-  showHeaderBar: boolean;
-  setShowHeaderBar: (show: boolean) => void;
+  hideHeaderBar: boolean;
+  setHideHeaderBar: (hide: boolean) => void;
 
-  showStatusBar: boolean;
-  setShowStatusBar: (show: boolean) => void;
+  hideStatusBar: boolean;
+  setHideStatusBar: (hide: boolean) => void;
 }
 
 export const useSettingsStore = create(
@@ -432,11 +432,11 @@ export const useSettingsStore = create(
       videoContrast: 1.0,
       setVideoContrast: (value: number) => set({ videoContrast: value }),
 
-      showHeaderBar: true,
-      setShowHeaderBar: (show: boolean) => set({ showHeaderBar: show }),
+      hideHeaderBar: false,
+      setHideHeaderBar: (hide: boolean) => set({ hideHeaderBar: hide }),
 
-      showStatusBar: true,
-      setShowStatusBar: (show: boolean) => set({ showStatusBar: show }),
+      hideStatusBar: false,
+      setHideStatusBar: (hide: boolean) => set({ hideStatusBar: hide }),
     }),
     {
       name: "settings",

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -379,6 +379,12 @@ export interface SettingsState {
 
   videoContrast: number;
   setVideoContrast: (value: number) => void;
+
+  showHeaderBar: boolean;
+  setShowHeaderBar: (show: boolean) => void;
+
+  showStatusBar: boolean;
+  setShowStatusBar: (show: boolean) => void;
 }
 
 export const useSettingsStore = create(
@@ -425,6 +431,12 @@ export const useSettingsStore = create(
 
       videoContrast: 1.0,
       setVideoContrast: (value: number) => set({ videoContrast: value }),
+
+      showHeaderBar: true,
+      setShowHeaderBar: (show: boolean) => set({ showHeaderBar: show }),
+
+      showStatusBar: true,
+      setShowStatusBar: (show: boolean) => set({ showStatusBar: show }),
     }),
     {
       name: "settings",

--- a/ui/src/routes/devices.$id.settings.appearance.tsx
+++ b/ui/src/routes/devices.$id.settings.appearance.tsx
@@ -1,14 +1,18 @@
 import { useCallback, useState } from "react";
 
+import { Checkbox } from "@components/Checkbox";
 import { SelectMenuBasic } from "@components/SelectMenuBasic";
 import { SettingsItem } from "@components/SettingsItem";
 import { SettingsPageHeader } from "@components/SettingsPageheader";
+import { useSettingsStore } from "@hooks/stores";
 import { m } from "@localizations/messages.js";
 
 export default function SettingsAppearanceRoute() {
   const [currentTheme, setCurrentTheme] = useState(() => {
     return localStorage.theme || "system";
   });
+
+  const settings = useSettingsStore();
 
   const handleThemeChange = useCallback((value: string) => {
     const root = document.documentElement;
@@ -50,6 +54,24 @@ export default function SettingsAppearanceRoute() {
             setCurrentTheme(e.target.value);
             handleThemeChange(e.target.value);
           }}
+        />
+      </SettingsItem>
+      <SettingsItem
+        title={m.appearance_show_header_bar()}
+        description={m.appearance_show_header_bar_description()}
+      >
+        <Checkbox
+          checked={settings.showHeaderBar}
+          onChange={e => settings.setShowHeaderBar(e.target.checked)}
+        />
+      </SettingsItem>
+      <SettingsItem
+        title={m.appearance_show_status_bar()}
+        description={m.appearance_show_status_bar_description()}
+      >
+        <Checkbox
+          checked={settings.showStatusBar}
+          onChange={e => settings.setShowStatusBar(e.target.checked)}
         />
       </SettingsItem>
     </div>

--- a/ui/src/routes/devices.$id.settings.appearance.tsx
+++ b/ui/src/routes/devices.$id.settings.appearance.tsx
@@ -57,21 +57,21 @@ export default function SettingsAppearanceRoute() {
         />
       </SettingsItem>
       <SettingsItem
-        title={m.appearance_show_header_bar()}
-        description={m.appearance_show_header_bar_description()}
+        title={m.appearance_hide_header_bar()}
+        description={m.appearance_hide_header_bar_description()}
       >
         <Checkbox
-          checked={settings.showHeaderBar}
-          onChange={e => settings.setShowHeaderBar(e.target.checked)}
+          checked={settings.hideHeaderBar}
+          onChange={e => settings.setHideHeaderBar(e.target.checked)}
         />
       </SettingsItem>
       <SettingsItem
-        title={m.appearance_show_status_bar()}
-        description={m.appearance_show_status_bar_description()}
+        title={m.appearance_hide_status_bar()}
+        description={m.appearance_hide_status_bar_description()}
       >
         <Checkbox
-          checked={settings.showStatusBar}
-          onChange={e => settings.setShowStatusBar(e.target.checked)}
+          checked={settings.hideStatusBar}
+          onChange={e => settings.setHideStatusBar(e.target.checked)}
         />
       </SettingsItem>
     </div>

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -34,6 +34,7 @@ import {
   useVideoStore,
   VideoState,
   useFailsafeModeStore,
+  useSettingsStore,
 } from "@hooks/stores";
 import { JsonRpcRequest, JsonRpcResponse, RpcMethodNotFound, useJsonRpc } from "@hooks/useJsonRpc";
 import { useDeviceUiNavigation } from "@hooks/useAppNavigation";
@@ -125,6 +126,7 @@ export default function KvmIdRoute() {
   } = useUiStore();
   const [queryParams, setQueryParams] = useSearchParams();
   const isDetachedWindow = queryParams.get("detached") === "true";
+  const showHeaderBar = useSettingsStore(state => state.showHeaderBar);
 
   const {
     peerConnection,
@@ -994,10 +996,10 @@ export default function KvmIdRoute() {
 
         <div
           className={cx("grid h-full select-none", {
-            "grid-rows-(--grid-headerBody)": !isDetachedWindow,
+            "grid-rows-(--grid-headerBody)": !isDetachedWindow && showHeaderBar,
           })}
         >
-          {!isDetachedWindow && (
+          {!isDetachedWindow && showHeaderBar && (
             <DashboardNavbar
               primaryLinks={isOnDevice ? [] : [{ title: "Cloud Devices", to: "/devices" }]}
               showConnectionStatus={true}

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -126,7 +126,7 @@ export default function KvmIdRoute() {
   } = useUiStore();
   const [queryParams, setQueryParams] = useSearchParams();
   const isDetachedWindow = queryParams.get("detached") === "true";
-  const showHeaderBar = useSettingsStore(state => state.showHeaderBar);
+  const hideHeaderBar = useSettingsStore(state => state.hideHeaderBar);
 
   const {
     peerConnection,
@@ -996,10 +996,10 @@ export default function KvmIdRoute() {
 
         <div
           className={cx("grid h-full select-none", {
-            "grid-rows-(--grid-headerBody)": !isDetachedWindow && showHeaderBar,
+            "grid-rows-(--grid-headerBody)": !isDetachedWindow && !hideHeaderBar,
           })}
         >
-          {!isDetachedWindow && showHeaderBar && (
+          {!isDetachedWindow && !hideHeaderBar && (
             <DashboardNavbar
               primaryLinks={isOnDevice ? [] : [{ title: "Cloud Devices", to: "/devices" }]}
               showConnectionStatus={true}


### PR DESCRIPTION
## Summary
- Adds two checkboxes in Settings > Appearance to hide the header bar and status bar
- Settings persisted in localStorage via the settings store
- Default state shows both bars (unchecked = visible)

Closes #1333

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that conditionally hides existing UI chrome based on persisted local settings; main risk is unintended layout/visibility regressions in the main device view.
> 
> **Overview**
> Adds **Appearance** settings to toggle visibility of the top header bar and bottom status/info bar, persisting both flags in the `useSettingsStore` (localStorage).
> 
> Updates the main device route and `WebRTCVideo` to conditionally render `DashboardNavbar` and `InfoBar` (and adjust the grid layout) when these settings are enabled, and adds an E2E test covering hide/show behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cc5436784777bf5dfa50c915dca95fbf6c7a70a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->