### PR TITLE
fix(video): align VENC virtual width/height to 16 bytes for non-standard resolutions (#699)

### DIFF
--- a/internal/native/cgo/video.c
+++ b/internal/native/cgo/video.c
@@ -129,10 +129,8 @@ static void populate_venc_attr(VENC_CHN_ATTR_S *stAttr, RK_U32 bitrate, RK_U32 m
     stAttr->stVencAttr.u32Profile = H264E_PROFILE_HIGH;
     stAttr->stVencAttr.u32PicWidth = width;
     stAttr->stVencAttr.u32PicHeight = height;
-    // stAttr->stVencAttr.u32VirWidth = (width + 15) & (~15);
-    // stAttr->stVencAttr.u32VirHeight = (height + 15) & (~15);
-    stAttr->stVencAttr.u32VirWidth = RK_ALIGN_2(width);
-    stAttr->stVencAttr.u32VirHeight = RK_ALIGN_2(height);
+    stAttr->stVencAttr.u32VirWidth = RK_ALIGN_16(width);
+    stAttr->stVencAttr.u32VirHeight = RK_ALIGN_16(height);
     stAttr->stVencAttr.u32StreamBufCnt = 3;
     stAttr->stVencAttr.u32BufSize = width * height * 3 / 2;
     stAttr->stVencAttr.enMirror = MIRROR_NONE;
@@ -592,10 +590,8 @@ void *run_video_stream(void *arg)
             stFrame.stVFrame.pMbBlk = blk;
             stFrame.stVFrame.u32Width = width;
             stFrame.stVFrame.u32Height = height;
-            // stFrame.stVFrame.u32VirWidth = (width + 15) & (~15);
-            // stFrame.stVFrame.u32VirHeight = (height + 15) & (~15);
-            stFrame.stVFrame.u32VirWidth = RK_ALIGN_2(width);
-            stFrame.stVFrame.u32VirHeight = RK_ALIGN_2(height);
+            stFrame.stVFrame.u32VirWidth = RK_ALIGN_16(width);
+            stFrame.stVFrame.u32VirHeight = RK_ALIGN_16(height);
             stFrame.stVFrame.u32TimeRef = num; // frame number
             stFrame.stVFrame.u64PTS = get_us();
             stFrame.stVFrame.enPixelFormat = RK_FMT_YUV422_YUYV;

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -14,6 +14,7 @@ import {
   sendKeypress,
   tapKey,
   waitForWebRTCReady,
+  waitForVideoDimensions,
   sendAbsMouseMove,
   sshExec,
   getDeviceHost,
@@ -1072,6 +1073,62 @@ test.describe("Remote Host Agent", () => {
 
     // Restore original duration
     await callJsonRpc(sharedPage, "setVideoSleepMode", { duration: originalDuration });
+  });
+
+  // ═══════════════════════════════════════════
+  // VIDEO: NON-ALIGNED RESOLUTION (1366x768) — #699
+  // ═══════════════════════════════════════════
+
+  // EDID for a 1366x768 monitor (pixel clock 85.5 MHz, 60 Hz)
+  const EDID_1366x768 =
+    "00ffffffffffff0028b401000100000001220103802213780aee95a3544c99260f50540000000101010101010101010101010101010166" +
+    "2156aa51002030468f350058c21000001e000000fc004a65744b564d20313336367837000000fd00384c1e530a00202020202020200000" +
+    "0010002020202020202020202020202000d0";
+
+  test("video: non-aligned resolution 1366x768 produces video frames", async () => {
+    test.setTimeout(60_000);
+
+    const originalEdid = (await callJsonRpc(sharedPage, "getEDID")) as string;
+
+    await callJsonRpc(sharedPage, "setEDID", { edid: EDID_1366x768 });
+
+    try {
+      await agent!.waitForResolution("1366x768", 15_000);
+
+      await expect
+        .poll(
+          async () => {
+            const state = (await callJsonRpc(sharedPage, "getVideoState")) as {
+              ready: boolean;
+              width: number;
+              height: number;
+            };
+            return state;
+          },
+          {
+            message: "Waiting for KVM to report 1366x768",
+            timeout: 15_000,
+            intervals: [500, 1000],
+          },
+        )
+        .toMatchObject({ ready: true, width: 1366, height: 768 });
+
+      await sharedPage.goto("/", { waitUntil: "networkidle" });
+      await waitForWebRTCReady(sharedPage);
+
+      const dims = await waitForVideoDimensions(sharedPage, 15_000);
+      expect(dims.width).toBe(1366);
+      expect(dims.height).toBe(768);
+    } finally {
+      await callJsonRpc(sharedPage, "setEDID", { edid: originalEdid }).catch(() => {
+        /* ignore */
+      });
+
+      await new Promise(r => setTimeout(r, 3000));
+
+      await sharedPage.goto("/", { waitUntil: "networkidle" });
+      await waitForWebRTCReady(sharedPage);
+    }
   });
 
   // ═══════════════════════════════════════════


### PR DESCRIPTION
## Summary
- Changes VENC encoder virtual width/height alignment from `RK_ALIGN_2` to `RK_ALIGN_16` in both `populate_venc_attr` and frame submission paths
- Fixes H.264 encoder silently failing on resolutions where width is not aligned to 8/16 pixels (e.g. 1366x768)
- Adds e2e test that sets a 1366x768 EDID and verifies video frames are produced

Closes #699

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches low-level Rockchip VENC configuration and frame submission; incorrect alignment could break encoding or performance across resolutions, though the change is small and covered by a new e2e test.
> 
> **Overview**
> Fixes H.264 encoding for non-standard (non-8/16-aligned) resolutions by aligning VENC `u32VirWidth`/`u32VirHeight` to `RK_ALIGN_16` in both encoder channel setup and per-frame submission.
> 
> Adds a Playwright remote-agent e2e that sets a 1366x768 EDID, waits for the device to report that resolution, and asserts the WebRTC video element produces frames at the expected dimensions.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec7dfedd20dc1315fa7b4ca29fb0131b502c7559. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->