### PR TITLE
feat: add Polish (Polski) keyboard layout for paste support (#566)

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -771,6 +771,92 @@ test.describe("Remote Host Agent", () => {
   });
 
   // ═══════════════════════════════════════════
+  // INPUT: POLISH DIACRITICS PASTE
+  // ═══════════════════════════════════════════
+
+  test("input: paste Polish diacritics via pl-PL layout", async () => {
+    test.setTimeout(30_000);
+
+    // Save current layout, switch to pl-PL
+    const prevLayout = await callJsonRpc(sharedPage, "getKeyboardLayout") as string;
+    await callJsonRpc(sharedPage, "setKeyboardLayout", { layout: "pl-PL" });
+
+    // Reload so the paste modal picks up the new layout
+    await sharedPage.reload({ waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+
+    const polishText = "ąćęłńóśźżĄĆĘŁŃÓŚŹŻ";
+
+    // Expected base key codes for each diacritic (lowercase then uppercase, same base keys)
+    // ą/Ą→A, ć/Ć→C, ę/Ę→E, ł/Ł→L, ń/Ń→N, ó/Ó→O, ś/Ś→S, ź/Ź→X, ż/Ż→Z
+    const expectedBaseKeys = [
+      KEY.A, KEY.C, KEY.E, KEY.L, KEY.N, KEY.O, KEY.S, KEY.X, KEY.Z, // lowercase
+      KEY.A, KEY.C, KEY.E, KEY.L, KEY.N, KEY.O, KEY.S, KEY.X, KEY.Z, // uppercase
+    ];
+
+    await agent!.clearKeyboardEvents();
+
+    // Open paste modal, fill text, confirm
+    await sharedPage.getByRole("button", { name: "Paste text" }).click();
+    const textarea = sharedPage.locator("textarea#asd");
+    await textarea.waitFor({ state: "visible", timeout: 3000 });
+    await textarea.fill(polishText);
+
+    const confirmBtn = sharedPage.getByRole("button", { name: "Confirm Paste" });
+    await confirmBtn.waitFor({ state: "visible", timeout: 2000 });
+    await confirmBtn.click({ force: true });
+
+    // Wait for all expected base keys to arrive in order
+    const pasteDeadline = Date.now() + 15000;
+    let matchIdx = 0;
+    while (Date.now() < pasteDeadline) {
+      const events = await agent!.getKeyboardEvents();
+      const pressedCodes = events.filter(ev => ev.type === "key_press").map(ev => ev.code);
+      matchIdx = 0;
+      for (const code of pressedCodes) {
+        if (code === expectedBaseKeys[matchIdx]) {
+          matchIdx++;
+          if (matchIdx === expectedBaseKeys.length) break;
+        }
+      }
+      if (matchIdx === expectedBaseKeys.length) break;
+      await new Promise(r => setTimeout(r, 100));
+    }
+    expect(
+      matchIdx,
+      `Polish paste: expected ${expectedBaseKeys.length} base keys but matched ${matchIdx}`,
+    ).toBe(expectedBaseKeys.length);
+
+    // Verify RIGHT_ALT was pressed at least 18 times (once per diacritic)
+    const allEvents = await agent!.getKeyboardEvents();
+    const altRightPresses = allEvents.filter(
+      ev => ev.code === KEY.RIGHT_ALT && ev.type === "key_press",
+    );
+    expect(
+      altRightPresses.length,
+      `Expected ≥18 RIGHT_ALT presses, got ${altRightPresses.length}`,
+    ).toBeGreaterThanOrEqual(18);
+
+    // Verify LEFT_SHIFT was pressed at least 9 times (once per uppercase diacritic)
+    const shiftPresses = allEvents.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press",
+    );
+    expect(
+      shiftPresses.length,
+      `Expected ≥9 LEFT_SHIFT presses, got ${shiftPresses.length}`,
+    ).toBeGreaterThanOrEqual(9);
+
+    // Dismiss any lingering paste dialog
+    const cancelBtn = sharedPage.getByRole("button", { name: "Cancel" });
+    if (await cancelBtn.isVisible({ timeout: 300 }).catch(() => false)) {
+      await cancelBtn.click();
+    }
+
+    // Restore original layout
+    await callJsonRpc(sharedPage, "setKeyboardLayout", { layout: prevLayout || "en-US" });
+  });
+
+  // ═══════════════════════════════════════════
   // VIRTUAL MEDIA
   // ═══════════════════════════════════════════
 

--- a/ui/src/keyboardLayouts.ts
+++ b/ui/src/keyboardLayouts.ts
@@ -39,6 +39,7 @@ import { hu_HU } from "@/keyboardLayouts/hu_HU";
 import { it_IT } from "@/keyboardLayouts/it_IT";
 import { ja_JP } from "@/keyboardLayouts/ja_JP";
 import { nb_NO } from "@/keyboardLayouts/nb_NO";
+import { pl_PL } from "@/keyboardLayouts/pl_PL";
 import { pt_PT } from "@/keyboardLayouts/pt_PT";
 import { sv_SE } from "@/keyboardLayouts/sv_SE";
 import { sl_SI } from "@/keyboardLayouts/sl_SI";
@@ -59,6 +60,7 @@ export const keyboards: KeyboardLayout[] = [
   it_IT,
   ja_JP,
   nb_NO,
+  pl_PL,
   pt_PT,
   sv_SE,
   sl_SI,

--- a/ui/src/keyboardLayouts/pl_PL.ts
+++ b/ui/src/keyboardLayouts/pl_PL.ts
@@ -1,0 +1,40 @@
+import { KeyboardLayout, KeyCombo } from "../keyboardLayouts";
+
+import { en_US, chars as en_US_chars } from "./en_US";
+
+const name = "Polski";
+const isoCode = "pl-PL";
+
+// Polish Programmer layout (kbdpl1): QWERTY + AltGr diacritics, no dead keys
+const chars: Record<string, KeyCombo> = {
+  ...en_US_chars,
+  // lowercase diacritics (AltGr + letter)
+  ą: { key: "KeyA", altRight: true },
+  ć: { key: "KeyC", altRight: true },
+  ę: { key: "KeyE", altRight: true },
+  ł: { key: "KeyL", altRight: true },
+  ń: { key: "KeyN", altRight: true },
+  ó: { key: "KeyO", altRight: true },
+  ś: { key: "KeyS", altRight: true },
+  ż: { key: "KeyZ", altRight: true },
+  ź: { key: "KeyX", altRight: true },
+  // uppercase diacritics (Shift + AltGr + letter)
+  Ą: { key: "KeyA", shift: true, altRight: true },
+  Ć: { key: "KeyC", shift: true, altRight: true },
+  Ę: { key: "KeyE", shift: true, altRight: true },
+  Ł: { key: "KeyL", shift: true, altRight: true },
+  Ń: { key: "KeyN", shift: true, altRight: true },
+  Ó: { key: "KeyO", shift: true, altRight: true },
+  Ś: { key: "KeyS", shift: true, altRight: true },
+  Ż: { key: "KeyZ", shift: true, altRight: true },
+  Ź: { key: "KeyX", shift: true, altRight: true },
+};
+
+export const pl_PL: KeyboardLayout = {
+  isoCode: isoCode,
+  name: name,
+  chars: chars,
+  keyDisplayMap: en_US.keyDisplayMap,
+  modifierDisplayMap: en_US.modifierDisplayMap,
+  virtualKeyboard: en_US.virtualKeyboard,
+};


### PR DESCRIPTION
## Summary
- Adds `pl_PL` Polish Programmer keyboard layout (kbdpl1) with all 18 diacritics via AltGr
- Extends en_US base layout with ą/ć/ę/ł/ń/ó/ś/ź/ż + uppercase variants
- E2E test verifies full round-trip paste of all Polish diacritics via remote agent

Closes #566

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new keyboard layout mapping and an E2E test; limited surface area aside from potentially affecting paste behavior when `pl-PL` is selected.
> 
> **Overview**
> Adds a new `pl-PL` (Polski) keyboard layout for paste input, extending the `en_US` character map with Polish diacritics using `AltGr` (and `Shift+AltGr` for uppercase).
> 
> Updates the keyboard layout registry to include `pl_PL`, and adds a remote-agent E2E test that switches to `pl-PL`, pastes all 18 Polish diacritics, and asserts the expected base key sequence plus `RIGHT_ALT`/`LEFT_SHIFT` modifier usage.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b284d9adaa8fd9435d2ded0b2aaaad2f11430094. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->