### PR TITLE
fix: reset HID file handles after disk-mode virtual media mount (#560)

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -663,6 +663,7 @@ func resetConfig() error {
 // factoryResetPaths lists all user data paths that should be removed during a factory reset.
 var factoryResetPaths = []string{
 	configPath,
+	configPath + ".bak",
 	imagesFolder,
 	tlsStorePath,
 	sshKeyDir,

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -269,6 +269,7 @@ async function waitForRpcReady(page: Page, timeoutMs = 30000) {
     }
   }
   throw new Error(`RPC channel not ready after ${timeoutMs}ms`);
+
 }
 
 test.beforeAll(async ({ browser }) => {
@@ -808,6 +809,65 @@ test.describe("Remote Host Agent", () => {
 
     const finalDevices = await agent!.getUSBDevices();
     expect(finalDevices.length).toBeGreaterThan(0);
+  });
+
+  test("virtual-media: mount ISO as Disk mode preserves keyboard (#560)", async () => {
+    test.setTimeout(90_000);
+
+    // Ensure clean state
+    try {
+      await callJsonRpc(sharedPage, "unmountImage");
+    } catch {
+      /* ok */
+    }
+
+    // Verify keyboard works before mount
+    const preEvents = await agent!.expectKeyPress(KEY.SPACE, async () => {
+      await tapKey(sharedPage, HID_KEY.SPACE);
+    });
+    expect(preEvents.length, "keyboard should work before disk mount").toBeGreaterThan(0);
+
+    // Mount as Disk mode — this triggers USB rebind (unlike CDROM which skips it)
+    const NETBOOT_XYZ_URL = "https://boot.netboot.xyz/ipxe/netboot.xyz.iso";
+    await callJsonRpc(sharedPage, "mountWithHTTP", { url: NETBOOT_XYZ_URL, mode: "Disk" });
+
+    const stateAfter = (await callJsonRpc(sharedPage, "getVirtualMediaState")) as {
+      source: string;
+      mode: string;
+    } | null;
+    expect(stateAfter).not.toBeNull();
+    expect(stateAfter!.mode).toBe("Disk");
+
+    // Wait for HID devices to re-enumerate after USB rebind
+    await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 15000);
+
+    // Verify keyboard works after disk mount (this would fail without the ResetHIDFiles fix)
+    const postMountEvents = await agent!.expectKeyPress(
+      KEY.SPACE,
+      async () => {
+        await tapKey(sharedPage, HID_KEY.SPACE);
+      },
+      5000,
+    );
+    expect(postMountEvents.length, "keyboard should work after disk mount").toBeGreaterThan(0);
+
+    // Unmount
+    await callJsonRpc(sharedPage, "unmountImage");
+    const stateEnd = (await callJsonRpc(sharedPage, "getVirtualMediaState")) as null | object;
+    expect(stateEnd).toBeNull();
+
+    // Wait for HID devices after unmount (unmount also triggers rebind back to CDROM default)
+    await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 15000);
+
+    // Verify keyboard works after unmount too
+    const postUnmountEvents = await agent!.expectKeyPress(
+      KEY.SPACE,
+      async () => {
+        await tapKey(sharedPage, HID_KEY.SPACE);
+      },
+      5000,
+    );
+    expect(postUnmountEvents.length, "keyboard should work after unmount").toBeGreaterThan(0);
   });
 
   // ═══════════════════════════════════════════

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -66,7 +66,22 @@ func setMassStorageMode(cdrom bool) error {
 		return nil
 	}
 
-	return gadget.UpdateGadgetConfig()
+	if err := gadget.UpdateGadgetConfig(); err != nil {
+		return err
+	}
+
+	// USB gadget was rebound — HID device nodes were recreated.
+	// Reset stale file handles so subsequent HID writes use fresh descriptors.
+	gadget.ResetHIDFiles()
+
+	// Give the kernel time to attach the HID function driver to new device nodes.
+	time.Sleep(1 * time.Second)
+
+	if err := gadget.OpenKeyboardHidFile(); err != nil {
+		usbLogger.Warn().Err(err).Msg("failed to reopen keyboard HID file after mass storage mode change")
+	}
+
+	return nil
 }
 
 func mountImage(imagePath string) error {


### PR DESCRIPTION
## Summary
- After USB rebind triggered by mass storage mode change (Disk mode), resets stale HID file handles and reopens the keyboard device
- Fixes keyboard/mouse loss when mounting virtual media in Disk mode (CDROM mode was unaffected as it skips the rebind)
- Adds E2E regression test that mounts an ISO in Disk mode and verifies keyboard still works

Closes #560
Also fixes #493

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches USB gadget rebind/HID file lifecycle during virtual media mode switches; regressions could break keyboard input until reboot, though changes are scoped and covered by a new E2E test.
> 
> **Overview**
> Fixes keyboard loss when mounting virtual media in **Disk** mode by resetting stale HID file handles after the USB gadget is rebound, then reopening the keyboard HID node (with a short delay) in `setMassStorageMode`.
> 
> Adds an E2E regression test that mounts an ISO via `mountWithHTTP` in Disk mode and verifies keyboard input works before mount, after mount, and after unmount. Also expands factory reset cleanup to remove the `kvm_config.json.bak` file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e771c1c5d24c18b3971270675bdfa7dc488104f6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->