### PR TITLE
chore(ui): remove vite-tsconfig-paths plugin

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -68,8 +68,7 @@
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.9.3",
-        "vite": "^8.0.3",
-        "vite-tsconfig-paths": "^6.1.1"
+        "vite": "^8.0.3"
       },
       "engines": {
         "node": "^22.21.1"
@@ -3316,24 +3315,6 @@
       "integrity": "sha512-t5EcLVS6QPBNqM2z8fakk/NKel+Xzshgt8FFKAn+qwlD1pzZWxh0nVCrvFK7ZDb6XucZeF9z8C7CBWTRIVApAw==",
       "license": "MIT"
     },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -3580,13 +3561,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/globrex": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-      "integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/goober": {
       "version": "2.1.18",
@@ -4137,13 +4111,6 @@
       "version": "12.23.6",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
       "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",
-      "license": "MIT"
-    },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -4945,27 +4912,6 @@
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
     },
-    "node_modules/tsconfck": {
-      "version": "3.1.6",
-      "resolved": "https://registry.npmjs.org/tsconfck/-/tsconfck-3.1.6.tgz",
-      "integrity": "sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "tsconfck": "bin/tsconfck.js"
-      },
-      "engines": {
-        "node": "^18 || >=20"
-      },
-      "peerDependencies": {
-        "typescript": "^5.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/tslib": {
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
@@ -5210,21 +5156,6 @@
         "yaml": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vite-tsconfig-paths": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/vite-tsconfig-paths/-/vite-tsconfig-paths-6.1.1.tgz",
-      "integrity": "sha512-2cihq7zliibCCZ8P9cKJrQBkfgdvcFkOOc3Y02o3GWUDLgqjWsZudaoiuOwO/gzTzy17cS5F7ZPo4bsnS4DGkg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "globrex": "^0.1.2",
-        "tsconfck": "^3.0.3"
-      },
-      "peerDependencies": {
-        "vite": "*"
       }
     },
     "node_modules/vite/node_modules/lightningcss": {

--- a/ui/package.json
+++ b/ui/package.json
@@ -88,8 +88,7 @@
     "postcss": "^8.5.6",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.9.3",
-    "vite": "^8.0.3",
-    "vite-tsconfig-paths": "^6.1.1"
+    "vite": "^8.0.3"
   },
   "lint-staged": {
     "*.{ts,tsx}": "oxlint --fix --deny-warnings",

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,7 +1,6 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import tailwindcss from "@tailwindcss/vite";
-import tsconfigPaths from "vite-tsconfig-paths";
 import basicSsl from "@vitejs/plugin-basic-ssl";
 import { paraglideVitePlugin } from "@inlang/paraglide-js";
 
@@ -18,7 +17,7 @@ export default defineConfig(({ mode, command }) => {
   const { JETKVM_PROXY_URL, USE_SSL } = process.env;
   const useSSL = USE_SSL === "true";
 
-  const plugins = [tailwindcss(), tsconfigPaths(), react()];
+  const plugins = [tailwindcss(), react()];
 
   if (useSSL) {
     plugins.push(basicSsl());
@@ -36,6 +35,9 @@ export default defineConfig(({ mode, command }) => {
 
   return {
     plugins,
+    resolve: {
+      tsconfigPaths: true,
+    },
     oxc: {
       pure: command === "build" ? ["console.debug"] : [],
     },


### PR DESCRIPTION
## Summary
- Removes the `vite-tsconfig-paths` plugin, now redundant with Vite 8's native `resolve.tsconfigPaths` option
- Eliminates the `PLUGIN_TIMINGS` warning about `vite-tsconfig-paths` being slow during builds

## Test plan
- [x] `npm run build:device` succeeds with all path aliases resolving correctly
- [ ] Verify dev server (`npm run dev`) resolves imports as expected

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk dependency/config cleanup; main risk is TS path aliases resolving differently between dev/build if the Vite 8 native `resolve.tsconfigPaths` behavior diverges from the removed plugin.
> 
> **Overview**
> **Removes the `vite-tsconfig-paths` dependency** from `ui/package.json`/`package-lock.json` (and its transitive deps) to simplify the UI toolchain.
> 
> Updates `ui/vite.config.ts` to stop registering the plugin and instead enables Vite 8’s native `resolve.tsconfigPaths` option while keeping the rest of the Vite plugin/config setup unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 900b84cd0fc509d8bd6bb6164e31a248556f409e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->