### PR TITLE
fix(e2e): kill remote-agent before scp to avoid ETXTBSY

### DIFF
--- a/ui/e2e/remote-agent/remote-agent.ts
+++ b/ui/e2e/remote-agent/remote-agent.ts
@@ -536,11 +536,15 @@ export class RemoteAgent {
       "-o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o ServerAliveInterval=5 -o ServerAliveCountMax=3";
 
     console.log(`[remote-agent] Deploying to ${target}...`);
+    // Kill the running agent first — Linux prevents overwriting a running binary
+    execSync(`ssh ${sshOpts} ${target} 'pkill -x remote-agent 2>/dev/null; sleep 0.5'`, {
+      stdio: "inherit",
+    });
     execSync(`scp ${sshOpts} "${binary}" ${target}:/tmp/remote-agent`, { stdio: "inherit" });
 
     console.log(`[remote-agent] Starting on port ${port}...`);
     execSync(
-      `ssh ${sshOpts} ${target} 'pkill -x remote-agent 2>/dev/null; sleep 0.5; PORT=${port} nohup /tmp/remote-agent </dev/null >/tmp/remote-agent.log 2>&1 & sleep 0.5'`,
+      `ssh ${sshOpts} ${target} 'PORT=${port} nohup /tmp/remote-agent </dev/null >/tmp/remote-agent.log 2>&1 & sleep 0.5'`,
       { stdio: "inherit" },
     );
 


### PR DESCRIPTION
## Summary
- Linux prevents overwriting a running binary (`ETXTBSY`). Moves the `pkill` step before `scp` so the agent is stopped before copying the new binary, then starts it without the redundant kill+sleep.

## Test plan
- [x] Verified deploy works when remote-agent is already running on target
- [x] Verified deploy works when remote-agent is not running (pkill exits cleanly)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts the e2e remote-agent deploy sequence to stop a running process before copying the binary, which should mainly affect test infrastructure behavior on Linux.
> 
> **Overview**
> Fixes remote-agent deployment in e2e runs by **killing any running `remote-agent` before `scp`** to avoid Linux `ETXTBSY` failures when overwriting an in-use binary.
> 
> Also removes the redundant `pkill` from the subsequent start command, leaving startup as a simple `nohup` launch after the copy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 308c86f5e671d7e533091df7042905d6398bc16f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->