### PR TITLE
fix(keyboard): serialise keyboard state mutations to eliminate race

### DIFF
--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -34,7 +34,7 @@ var defaultGadgetConfig = map[string]gadgetConfigItem{
 			"bcdDevice": "0x0100", // USB2
 		},
 		configAttrs: gadgetAttributes{
-			"MaxPower":      "250", // in unit of 2mA
+			"MaxPower":     "250",  // in unit of 2mA
 			"bmAttributes": "0xa0", // bus-powered + remote wakeup
 		},
 	},

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -196,6 +196,22 @@ func (u *UsbGadget) cancelAutoRelease(key byte) {
 	}
 }
 
+// CancelAllAutoReleaseTimers stops and removes all pending auto-release timers.
+// This must be called when forcibly clearing the keyboard state (e.g. on session
+// disconnect) to prevent racing auto-release goroutines from re-introducing
+// stale key state after the clear.
+func (u *UsbGadget) CancelAllAutoReleaseTimers() {
+	u.kbdAutoReleaseLock.Lock()
+	defer unlockWithLog(&u.kbdAutoReleaseLock, u.log, "all autoRelease timers cancelled")
+
+	for key, timer := range u.kbdAutoReleaseTimers {
+		if timer != nil {
+			timer.Stop()
+		}
+		delete(u.kbdAutoReleaseTimers, key)
+	}
+}
+
 func (u *UsbGadget) DelayAutoReleaseWithDuration(resetDuration time.Duration) {
 	u.kbdAutoReleaseLock.Lock()
 	defer unlockWithLog(&u.kbdAutoReleaseLock, u.log, "autoRelease delayed")
@@ -382,11 +398,17 @@ func (u *UsbGadget) ReopenKeyboardHidFile() error {
 	return u.reopenKeyboardHidFile()
 }
 
-var keyboardWriteHidFileLock sync.Mutex
+// keyboardMutex serialises all keyboard state mutations. Every path that
+// reads keysDownState, computes a new state, writes the HID report, and
+// updates keysDownState must hold this lock for the entire sequence.
+// This eliminates read-modify-write races between concurrent callers
+// (e.g. two auto-release timers firing simultaneously, or an auto-release
+// racing with a session-disconnect clear).
+var keyboardMutex sync.Mutex
 
-func (u *UsbGadget) keyboardWriteHidFile(modifier byte, keys []byte) error {
-	keyboardWriteHidFileLock.Lock()
-	defer keyboardWriteHidFileLock.Unlock()
+// keyboardWriteHidFileLocked writes a keyboard HID report to the device.
+// Caller MUST hold keyboardMutex.
+func (u *UsbGadget) keyboardWriteHidFileLocked(modifier byte, keys []byte) error {
 	if err := u.openKeyboardHidFile(); err != nil {
 		return err
 	}
@@ -443,12 +465,14 @@ func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
 		keys = append(keys, make([]byte, hidKeyBufferSize-len(keys))...)
 	}
 
-	err := u.keyboardWriteHidFile(modifier, keys)
+	keyboardMutex.Lock()
+	err := u.keyboardWriteHidFileLocked(modifier, keys)
 	if err != nil && !IsHIDTemporarilyUnavailableError(err) {
 		u.log.Warn().Uint8("modifier", modifier).Uints8("keys", keys).Msg("Could not write keyboard report to hidg0")
 	}
-
 	u.UpdateKeysDown(modifier, keys)
+	keyboardMutex.Unlock()
+
 	return err
 }
 
@@ -497,6 +521,11 @@ func (u *UsbGadget) keypressReport(key byte, press bool) (KeysDownState, error) 
 		requestID := xid.New()
 		l = l.With().Str("requestID", requestID.String()).Logger()
 	}
+
+	// Hold keyboardMutex for the entire read-compute-write-update sequence.
+	// This prevents concurrent callers (auto-release timers, session disconnect
+	// clears, other key events) from interleaving and causing lost updates.
+	keyboardMutex.Lock()
 
 	// IMPORTANT: This code parallels the logic in the kernel's hid-gadget driver
 	// for handling key presses and releases. It ensures that the USB gadget
@@ -557,8 +586,11 @@ func (u *UsbGadget) keypressReport(key byte, press bool) (KeysDownState, error) 
 		}
 	}
 
-	err := u.keyboardWriteHidFile(modifier, keys)
-	return u.UpdateKeysDown(modifier, keys), err
+	err := u.keyboardWriteHidFileLocked(modifier, keys)
+	newState := u.UpdateKeysDown(modifier, keys)
+	keyboardMutex.Unlock()
+
+	return newState, err
 }
 
 func (u *UsbGadget) KeypressReport(key byte, press bool) error {

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -20,7 +20,6 @@ import {
   sshExec,
   getDeviceHost,
   getLedState,
-  getKeysDownState,
   waitForLedState,
   restartAppViaSSH,
 } from "../helpers";
@@ -828,13 +827,15 @@ test.describe("Remote Host Agent", () => {
     await waitForWebRTCReady(sharedPage);
     await waitForRpcReady(sharedPage);
 
-    // Verify device-side keys-down state is clear (poll briefly for the
-    // all-keys-up report to propagate through the HID stack)
+    // Verify device-side keys-down state is clear by querying the device
+    // directly via JSON-RPC (bypasses Zustand store / hidRpc timing)
     await expect
       .poll(
         async () => {
-          const s = await getKeysDownState(sharedPage);
-          if (!s) return false;
+          const s = (await callJsonRpc(sharedPage, "getKeyDownState")) as {
+            modifier: number;
+            keys: number[];
+          };
           return s.modifier === 0 && s.keys.every((k: number) => k === 0);
         },
         {
@@ -1436,7 +1437,9 @@ test.describe("Remote Host Agent", () => {
     await new Promise(r => setTimeout(r, 3000));
 
     // Verify the host does NOT see a ttyACM device
-    const beforeACM = remoteHostExec("find /dev -maxdepth 1 -name 'ttyACM*' | head -1 || true").trim();
+    const beforeACM = remoteHostExec(
+      "find /dev -maxdepth 1 -name 'ttyACM*' | head -1 || true",
+    ).trim();
     expect(beforeACM).toBe("");
 
     // Enable serial console
@@ -1460,7 +1463,9 @@ test.describe("Remote Host Agent", () => {
     await new Promise(r => setTimeout(r, 3000));
 
     // Verify the host no longer sees a ttyACM device
-    const removedACM = remoteHostExec("find /dev -maxdepth 1 -name 'ttyACM*' | head -1 || true").trim();
+    const removedACM = remoteHostExec(
+      "find /dev -maxdepth 1 -name 'ttyACM*' | head -1 || true",
+    ).trim();
     expect(removedACM).toBe("");
 
     // Verify other USB functions still work (keyboard, mouse)

--- a/webrtc.go
+++ b/webrtc.go
@@ -425,7 +425,11 @@ func newSession(config SessionConfig) (*Session, error) {
 			if session == currentSession {
 				// Cancel any ongoing keyboard report multi when session closes
 				cancelKeyboardMacro()
-				// Release all keys to prevent stuck keys after disconnect
+				// Stop pending auto-release timers (avoids unnecessary work),
+				// then clear all keys. keyboardMutex inside KeyboardReport
+				// serialises with any auto-release goroutine already in flight,
+				// so the clear is guaranteed to be the final state.
+				gadget.CancelAllAutoReleaseTimers()
 				_ = rpcKeyboardReport(0, keyboardClearStateKeys)
 				currentSession = nil
 			}


### PR DESCRIPTION
## Summary

- **Root cause**: `keypressReport` performed a read-modify-write on `keysDownState` across three separate lock acquisitions. Concurrent callers (two auto-release timers firing simultaneously, or an auto-release racing with a session-disconnect `KeyboardReport(0, zeros)`) could interleave — each reading the same stale state, computing a partial mutation, and the last writer winning with one key still "held".

- **Fix**: Replace the per-write `keyboardWriteHidFileLock` with a `keyboardMutex` that covers the entire read→compute→write→update sequence in both `keypressReport` and `KeyboardReport`. All keyboard state mutations are now serialisable, eliminating the race by construction.

- Also cancel pending auto-release timers on session close (avoids unnecessary HID writes after the clear) and query device key state directly via JSON-RPC in the E2E test (removes Zustand store timing dependency).

## Test plan

- [x] `keyboard: all keys released when WebRTC session disconnects` — 10/10 passes (was ~1-in-10 failure before fix)
- [x] Full E2E suite (43 tests) passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrency and teardown paths in USB HID keyboard reporting; mistakes could cause dropped or stuck key events, but changes are localized and covered by E2E validation updates.
> 
> **Overview**
> Prevents stuck keys by **serializing the full keyboard read→compute→HID write→state update sequence** with a new `keyboardMutex`, replacing the prior per-write lock and eliminating races between concurrent key events (including auto-release timers).
> 
> On WebRTC session close, the device now **cancels all pending keyboard auto-release timers** before sending the all-keys-up report, ensuring no late timer can reintroduce stale key state. The E2E disconnect test is updated to **query keys-down state via JSON-RPC** (instead of UI hook/Zustand timing) to make the assertion deterministic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70a6792b81fb42f30bea7fbacee9e1aeb275917e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->