### PR TITLE
test(ota): add e2e test for upgrading to a signed release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ test_e2e:
 	cd ui && npx playwright install chromium
 	cd ui && $(call OTA_ENV,$(TEST_VERSION)) \
 		$(if $(JETKVM_REMOTE_HOST),JETKVM_REMOTE_HOST=$(JETKVM_REMOTE_HOST)) \
-		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-upgrade-from-stable
+		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-upgrade-from-stable --project=ota-upgrade-to-signed
 
 # Production release validation lane
 test_production_release:

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -1160,6 +1160,7 @@ export interface StableReleaseInfo {
   appVersion: string;
   appUrl: string;
   appHash: string;
+  appSigUrl?: string;
 }
 
 export async function fetchLatestStableRelease(): Promise<StableReleaseInfo> {
@@ -1184,7 +1185,12 @@ export async function fetchLatestStableRelease(): Promise<StableReleaseInfo> {
   if (!json.appVersion || !json.appUrl || !json.appHash) {
     throw new Error(`Unexpected release API response: ${body}`);
   }
-  return { appVersion: json.appVersion, appUrl: json.appUrl, appHash: json.appHash };
+  return {
+    appVersion: json.appVersion,
+    appUrl: json.appUrl,
+    appHash: json.appHash,
+    appSigUrl: json.appSigUrl,
+  };
 }
 
 export async function downloadFile(url: string, destPath: string): Promise<void> {

--- a/ui/e2e/ota-upgrade-to-signed.spec.ts
+++ b/ui/e2e/ota-upgrade-to-signed.spec.ts
@@ -1,0 +1,130 @@
+import { test, expect } from "@playwright/test";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+import {
+  getCurrentVersion,
+  reconnectAfterReboot,
+  rebootDeviceViaSSH,
+  ensureLocalAuthMode,
+  verifyHidAndVideo,
+  createMockUpdateServer,
+  deployBinaryToDevice,
+  configureDeviceUpdateUrl,
+  restoreDeviceUpdateUrl,
+  getOTAEnvVars,
+  fetchLatestStableRelease,
+  downloadFile,
+  type MockUpdateServer,
+  type StableReleaseInfo,
+  type OTAEnvVars,
+} from "./helpers";
+
+/**
+ * Validates that the locally-built binary can accept a signed OTA update.
+ *
+ * Deploys the dev build to the device, then serves the latest production
+ * binary (with its real GPG signature) via a mock update server advertising
+ * a higher version. The device must fetch, verify, and install the update —
+ * proving the OTA client in the current build works end-to-end with
+ * signature enforcement.
+ */
+test.describe("OTA Upgrade to Signed Release", () => {
+  test.setTimeout(420000);
+
+  let mockServer: MockUpdateServer;
+  let stableRelease: StableReleaseInfo;
+  let downloadedBinaryPath: string;
+  let downloadedSigPath: string;
+  let env: OTAEnvVars;
+
+  test.beforeAll(async ({ browser }) => {
+    env = getOTAEnvVars();
+
+    stableRelease = await fetchLatestStableRelease();
+    if (!stableRelease.appSigUrl) {
+      throw new Error("Latest stable release has no signature URL — cannot run this test");
+    }
+
+    downloadedBinaryPath = path.join(os.tmpdir(), `jetkvm_stable_${stableRelease.appVersion}`);
+    downloadedSigPath = path.join(os.tmpdir(), `jetkvm_stable_${stableRelease.appVersion}.sig`);
+
+    await Promise.all([
+      downloadFile(stableRelease.appUrl, downloadedBinaryPath),
+      downloadFile(stableRelease.appSigUrl, downloadedSigPath),
+    ]);
+
+    const context = await browser.newContext({ baseURL: process.env.JETKVM_URL });
+    const page = await context.newPage();
+    try {
+      await ensureLocalAuthMode(page, { mode: "noPassword" });
+    } finally {
+      await page.close();
+      await context.close();
+    }
+
+    // Deploy the locally-built binary as the device's current version
+    await deployBinaryToDevice(env.releasePath);
+    await rebootDeviceViaSSH();
+
+    // Serve the production binary+signature as a "future" version
+    mockServer = await createMockUpdateServer({
+      binaryPath: downloadedBinaryPath,
+      version: "99.99.99",
+      signaturePath: downloadedSigPath,
+    });
+
+    await configureDeviceUpdateUrl(mockServer.url);
+    await rebootDeviceViaSSH();
+  });
+
+  test("current build accepts signed update", async ({ page }) => {
+    await test.step("Verify device is running the dev build", async () => {
+      await page.goto("/settings/general/update");
+      await page.waitForLoadState("networkidle");
+
+      const initialVersion = await getCurrentVersion(page);
+      expect(initialVersion).not.toBeNull();
+      expect(initialVersion, "Device should be running the dev build").toBe(env.releaseVersion);
+    });
+
+    await test.step("Trigger signed update", async () => {
+      const updateButton = page.getByRole("button", { name: "Update Now" });
+      await expect(updateButton).toBeVisible({ timeout: 30000 });
+      await updateButton.click();
+
+      await expect(page.getByText(/downloading|verifying|installing|awaiting reboot/i)).toBeVisible(
+        { timeout: 30000 },
+      );
+    });
+
+    await test.step("Reconnect after reboot", async () => {
+      await reconnectAfterReboot(page, 35000);
+    });
+
+    await test.step("Verify update installed", async () => {
+      const finalVersion = await getCurrentVersion(page);
+      expect(finalVersion).not.toBeNull();
+      // The installed binary reports its compiled-in version, not the
+      // advertised mock version. Verify we're now running the production
+      // release, not the dev build we started with.
+      expect(finalVersion).toBe(stableRelease.appVersion);
+    });
+
+    await test.step("Verify HID and video", async () => {
+      await verifyHidAndVideo(page);
+    });
+  });
+
+  test.afterAll(async () => {
+    await restoreDeviceUpdateUrl();
+    await mockServer?.close();
+
+    for (const p of [downloadedBinaryPath, downloadedSigPath]) {
+      if (p && fs.existsSync(p)) {
+        fs.unlinkSync(p);
+      }
+    }
+  });
+});

--- a/ui/playwright.config.ts
+++ b/ui/playwright.config.ts
@@ -28,9 +28,30 @@ export default defineConfig({
       testMatch: "ra-all.spec.ts",
     },
     { name: "ota-signed", testMatch: /ota-signature\.spec\.ts/, dependencies: ["remote-agent"] },
-    { name: "ota-prerelease-unsigned", testMatch: /ota-prerelease-unsigned\.spec\.ts/, dependencies: ["remote-agent"] },
-    { name: "ota-prerelease-rejected", testMatch: /ota-prerelease-rejected\.spec\.ts/, dependencies: ["remote-agent"] },
-    { name: "ota-specific-version", testMatch: /ota-specific-version-unsigned\.spec\.ts/, dependencies: ["remote-agent"] },
-    { name: "ota-upgrade-from-stable", testMatch: /ota-upgrade-from-stable\.spec\.ts/, dependencies: ["remote-agent"] },
+    {
+      name: "ota-prerelease-unsigned",
+      testMatch: /ota-prerelease-unsigned\.spec\.ts/,
+      dependencies: ["remote-agent"],
+    },
+    {
+      name: "ota-prerelease-rejected",
+      testMatch: /ota-prerelease-rejected\.spec\.ts/,
+      dependencies: ["remote-agent"],
+    },
+    {
+      name: "ota-specific-version",
+      testMatch: /ota-specific-version-unsigned\.spec\.ts/,
+      dependencies: ["remote-agent"],
+    },
+    {
+      name: "ota-upgrade-from-stable",
+      testMatch: /ota-upgrade-from-stable\.spec\.ts/,
+      dependencies: ["remote-agent"],
+    },
+    {
+      name: "ota-upgrade-to-signed",
+      testMatch: /ota-upgrade-to-signed\.spec\.ts/,
+      dependencies: ["remote-agent"],
+    },
   ],
 });


### PR DESCRIPTION
## Summary
- Adds a new e2e test (`ota-upgrade-to-signed`) that validates the locally-built binary can accept a GPG-signed OTA update
- Deploys the dev build to the device, then serves the latest production binary + its real signature via a mock update server advertising a higher version
- Proves the OTA client in the current build can fetch, verify, and install a properly signed update end-to-end
- Runs in the regular `test_e2e` lane — no signing key or YubiKey required (reuses already-signed production artifacts)

## Test plan
- [x] `npx playwright test --project=ota-upgrade-to-signed` passes against device

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Playwright E2E test coverage and test wiring, with no production runtime behavior changes.
> 
> **Overview**
> Adds a new Playwright E2E scenario, `ota-upgrade-to-signed`, that deploys the locally-built dev binary, then performs an OTA upgrade to the latest *production signed* release served via the mock update server (validating signature verification end-to-end).
> 
> Extends the release fetch helper to surface `appSigUrl`, registers the new project in `ui/playwright.config.ts`, and includes it in the `Makefile` `test_e2e` lane.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34abe08810a9cbd695ccf150b9d092dbc4f34d95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->