### PR TITLE
fix(ui): fix virtual keyboard crash after Vite 8 upgrade

### DIFF
--- a/ui/src/components/VirtualKeyboard.tsx
+++ b/ui/src/components/VirtualKeyboard.tsx
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDownIcon } from "@heroicons/react/16/solid";
 import { AnimatePresence, motion } from "framer-motion";
-import Keyboard from "react-simple-keyboard";
+import { KeyboardReact as Keyboard } from "react-simple-keyboard";
 import { LuKeyboard } from "react-icons/lu";
 
 import "react-simple-keyboard/build/css/index.css";
@@ -172,8 +172,8 @@ function KeyboardWrapper() {
       // if they press any of the latching keys, we send a keypress down event and the release it automatically (on timer)
       if (latchingKeys.includes(key)) {
         console.debug(`Latching key pressed: ${key} sending down and delayed up pair`);
-        handleKeyPress(keys[key], true);
-        setTimeout(() => handleKeyPress(keys[key], false), 100);
+        void handleKeyPress(keys[key], true);
+        setTimeout(() => void handleKeyPress(keys[key], false), 100);
         return;
       }
 
@@ -183,15 +183,15 @@ function KeyboardWrapper() {
         console.debug(
           `Dynamic key pressed: ${key} was currently down: ${currentlyDown}, toggling state`,
         );
-        handleKeyPress(keys[key], !currentlyDown);
+        void handleKeyPress(keys[key], !currentlyDown);
         return;
       }
 
       // otherwise, just treat it as a down+up pair
       const cleanKey = key.replace(/[()]/g, "");
       console.debug(`Regular key pressed: ${cleanKey} sending down and up pair`);
-      handleKeyPress(keys[cleanKey], true);
-      setTimeout(() => handleKeyPress(keys[cleanKey], false), 50);
+      void handleKeyPress(keys[cleanKey], true);
+      setTimeout(() => void handleKeyPress(keys[cleanKey], false), 50);
     },
     [executeMacro, handleKeyPress, keyNamesForDownKeys],
   );


### PR DESCRIPTION
## Summary
- Vite 8's stricter CJS/ESM interop changed how `react-simple-keyboard`'s default export resolves — it now returns the module namespace object instead of the component, crashing `KeyboardWrapper` at render time
- Switch from default import to the named `KeyboardReact` export
- Fix pre-existing floating promise lint warnings in the same file

## Test plan
- [ ] Open device view, click virtual keyboard in the action bar — keyboard should render without errors
- [ ] Verify key presses (regular, latching, modifier) still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI fix limited to `VirtualKeyboard` import semantics and explicitly ignoring async `handleKeyPress` promises; behavior should remain the same aside from avoiding a render-time crash.
> 
> **Overview**
> Fixes the virtual keyboard crashing after the Vite 8 upgrade by switching `react-simple-keyboard` from a default import to the named `KeyboardReact` export.
> 
> Also resolves floating-promise lint warnings by explicitly marking `handleKeyPress(...)` calls as intentionally un-awaited (including those inside `setTimeout`) in the key handling logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 20f1dc385d4821f19718c2a96ee0fb3548b24886. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->