### PR TITLE
fix(test): fix e2e flakiness from RPC timeouts and stale session dialogs

### DIFF
--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -945,9 +945,10 @@ export async function callJsonRpc(
   page: Page,
   method: string,
   params: Record<string, unknown> = {},
+  timeoutMs?: number,
 ): Promise<unknown> {
   return page.evaluate(
-    ({ method, params }) => {
+    ({ method, params, timeoutMs }) => {
       return new Promise((resolve, reject) => {
         const hooks = window.__kvmTestHooks;
         if (!hooks) return reject(new Error("Test hooks not available"));
@@ -961,10 +962,11 @@ export async function callJsonRpc(
               );
             else resolve(resp.result);
           },
+          timeoutMs,
         );
       });
     },
-    { method, params },
+    { method, params, timeoutMs },
   );
 }
 

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -329,8 +329,13 @@ test.beforeAll(async ({ browser }) => {
   await setupMacrosViaRPC(sharedPage);
   await sharedPage.reload({ waitUntil: "networkidle" });
   await waitForWebRTCReady(sharedPage);
+  await waitForRpcReady(sharedPage);
 
   await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 30000);
+
+  // Wait for the video stream to be flowing — LED state reports are only
+  // reliable once the full WebRTC media pipeline is up.
+  await waitForVideoDimensions(sharedPage, 15000);
 
   // Verify the keyboard HID path works end-to-end before any tests run.
   // After reboot, Init() rebinds the USB gadget and the host needs time
@@ -454,14 +459,14 @@ test.describe("Remote Host Agent", () => {
 
     const currentEdid = (await callJsonRpc(sharedPage, "getEDID")) as string;
     const targetEdid = currentEdid === "1920x1080" ? "1280x720" : "1920x1080";
-    await callJsonRpc(sharedPage, "setEDID", { edid: targetEdid });
+    await callJsonRpc(sharedPage, "setEDID", { edid: targetEdid }, 20000);
 
     const newRes = await agent!.getResolution();
     expect(newRes).not.toBeNull();
     expect(newRes).toMatch(/^\d+x\d+$/);
 
     // Restore original EDID. This triggers USB disconnect/reconnect.
-    await callJsonRpc(sharedPage, "setEDID", { edid: currentEdid });
+    await callJsonRpc(sharedPage, "setEDID", { edid: currentEdid }, 20000);
 
     await sharedPage.goto("/", { waitUntil: "networkidle" });
     await waitForWebRTCReady(sharedPage);
@@ -1729,7 +1734,7 @@ test.describe("Remote Host Agent", () => {
 
     const originalEdid = (await callJsonRpc(sharedPage, "getEDID")) as string;
 
-    await callJsonRpc(sharedPage, "setEDID", { edid: EDID_1366x768 });
+    await callJsonRpc(sharedPage, "setEDID", { edid: EDID_1366x768 }, 20000);
 
     try {
       await agent!.waitForResolution("1366x768", 15_000);
@@ -1759,7 +1764,7 @@ test.describe("Remote Host Agent", () => {
       expect(dims.width).toBe(1366);
       expect(dims.height).toBe(768);
     } finally {
-      await callJsonRpc(sharedPage, "setEDID", { edid: originalEdid }).catch(() => {
+      await callJsonRpc(sharedPage, "setEDID", { edid: originalEdid }, 20000).catch(() => {
         /* ignore */
       });
 

--- a/ui/src/test/testHooks.ts
+++ b/ui/src/test/testHooks.ts
@@ -35,6 +35,7 @@ export interface KvmTestHooks extends TestHooksInternal {
     method: string,
     params: Record<string, unknown>,
     callback: (resp: { error?: { message: string; data?: string }; result?: unknown }) => void,
+    timeoutMs?: number,
   ) => void;
   sendTerminalCommand: (command: string) => boolean;
   isTerminalReady: () => boolean;
@@ -108,6 +109,7 @@ export function initTestHooks(): void {
       method: string,
       params: Record<string, unknown>,
       callback: (resp: { error?: { message: string; data?: string }; result?: unknown }) => void,
+      timeoutMs = 10000,
     ) => {
       const dc = hooks._getRpcDataChannel?.();
       if (!dc || dc.readyState !== "open") {
@@ -135,7 +137,7 @@ export function initTestHooks(): void {
           dc.removeEventListener("message", handler);
           callback({ error: { message: `RPC timeout for ${method}` } });
         }
-      }, 10000);
+      }, timeoutMs);
       dc.addEventListener("message", handler);
       dc.send(JSON.stringify({ jsonrpc: "2.0", method, params, id }));
     },


### PR DESCRIPTION
## Summary
- Add configurable `timeoutMs` parameter to `sendJsonRpc` (default 10s unchanged) and use 20s for all `setEDID` calls, which block ~7.5s for HDMI renegotiation
- Handle "Use Here" session dialog after page reload in `beforeAll` by calling `waitForRpcReady` post-reload
- Wait for video stream (`waitForVideoDimensions`) before LED round-trip tests to ensure WebRTC media pipeline is stable

## Test plan
- [x] All 33 remote-agent e2e tests pass (3.5m, 0 flakiness)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that adjust RPC timeout behavior and add additional readiness waits; low production risk, but could surface as longer-running/hanging e2e runs if misused.
> 
> **Overview**
> Reduces remote-agent E2E flakiness by making JSON-RPC timeouts configurable end-to-end (`callJsonRpc` → `window.__kvmTestHooks.sendJsonRpc`) while keeping the default at 10s.
> 
> Updates EDID-changing tests to use a longer 20s RPC timeout for `setEDID`, and strengthens suite setup by re-checking RPC readiness after a reload and waiting for video dimensions before relying on keyboard LED state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d470125368daa8d66eb6b7b055e81fffd46657da. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->