### PR TITLE
fix(test): fix e2e flakiness from HDMI signal not detected during beforeAll

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -333,9 +333,28 @@ test.beforeAll(async ({ browser }) => {
 
   await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 30000);
 
+  // Wake the remote host display — it may have entered DPMS sleep during
+  // the build/deploy phase, preventing the KVM from detecting an HDMI signal.
+  try {
+    remoteHostSetDPMS(false);
+  } catch {
+    /* best-effort: not all hosts have GNOME ScreenSaver */
+  }
+
   // Wait for the video stream to be flowing — LED state reports are only
   // reliable once the full WebRTC media pipeline is up.
-  await waitForVideoDimensions(sharedPage, 15000);
+  // Use a generous timeout: after app restart, the HDMI capture chip may need
+  // time to re-detect the signal, especially if the display was in DPMS sleep.
+  try {
+    await waitForVideoDimensions(sharedPage, 30000);
+  } catch {
+    // If video dimensions still aren't available, reload the page and retry.
+    // This handles the case where the WebRTC session connected before the
+    // HDMI signal was detected and the video track never started.
+    await sharedPage.reload({ waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+    await waitForVideoDimensions(sharedPage, 30000);
+  }
 
   // Verify the keyboard HID path works end-to-end before any tests run.
   // After reboot, Init() rebinds the USB gadget and the host needs time


### PR DESCRIPTION
## Summary
- Wake remote host display via DPMS before waiting for video dimensions in the remote-agent `beforeAll` — the display may enter sleep during the build/deploy phase, causing "No HDMI signal detected"
- Increase `waitForVideoDimensions` timeout from 15s to 30s to accommodate HDMI re-detection after DPMS wake
- Add page-reload retry if the WebRTC session connected before the HDMI signal was detected

## Test plan
- [x] Ran `make test_e2e` 3 times consecutively with 0 failures (was failing 100% before the fix)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are confined to Playwright E2E setup logic, mainly adding best-effort DPMS wake and retry behavior to reduce timing-related flakes.
> 
> **Overview**
> Improves remote-agent E2E `beforeAll` reliability when the captured host display is asleep and the KVM reports **no HDMI signal**.
> 
> The setup now best-effort wakes the remote host display via `remoteHostSetDPMS(false)`, increases `waitForVideoDimensions` timeout from 15s to 30s, and adds a reload+retry path if WebRTC connected before the HDMI signal was detected (video track never starts).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 30ae37e0e93c33fdf79b15b91dbd2f4788d76e3c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->