### PR TITLE
fix(ui): hide H.265 codec option when browser doesn't support it

### DIFF
--- a/ui/src/routes/devices.$id.settings.video.tsx
+++ b/ui/src/routes/devices.$id.settings.video.tsx
@@ -47,11 +47,20 @@ const streamQualityOptions = [
   { value: "0.1", label: m.video_quality_low() },
 ];
 
-const codecOptions = [
+const allCodecOptions = [
   { value: "auto", label: m.video_codec_auto() },
   { value: "h265", label: m.video_codec_h265() },
   { value: "h264", label: m.video_codec_h264() },
 ];
+
+const h265Supported = (() => {
+  const caps = RTCRtpReceiver.getCapabilities?.("video");
+  return caps?.codecs.some(c => c.mimeType === "video/H265") ?? false;
+})();
+
+const codecOptions = h265Supported
+  ? allCodecOptions
+  : allCodecOptions.filter(o => o.value !== "h265");
 
 export default function SettingsVideoRoute() {
   const { send } = useJsonRpc();


### PR DESCRIPTION
## Summary
- Use `RTCRtpReceiver.getCapabilities("video")` to detect browser H.265 support at module load
- Filter H.265 from the video codec dropdown when the browser can't decode it
- Backend `resolveCodec()` already handles the fallback safely — this is purely a UX fix

## Test plan
- [ ] Open video settings in Chrome (H.265 supported) → Auto, H.265, H.264 all visible
- [ ] Open video settings in Firefox (no H.265) → only Auto and H.264 visible
- [ ] Verify `RTCRtpReceiver.getCapabilities("video")` in browser console matches behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that conditionally hides a select option based on `RTCRtpReceiver.getCapabilities` without altering backend codec negotiation.
> 
> **Overview**
> **Improves video settings UX** by detecting browser H.265 support via `RTCRtpReceiver.getCapabilities("video")` and removing the `h265` option from the codec dropdown when unsupported.
> 
> Refactors the codec options list into `allCodecOptions` plus a derived `codecOptions` filtered at module load.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4473d243c3c5a153c188cc556a7c96c42901c016. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->