### PR TITLE
fix(ui): reconcile codec preference against available options

### DIFF
--- a/ui/src/routes/devices.$id.settings.video.tsx
+++ b/ui/src/routes/devices.$id.settings.video.tsx
@@ -90,7 +90,9 @@ export default function SettingsVideoRoute() {
 
     void send("getVideoCodecPreference", {}, (resp: JsonRpcResponse) => {
       if ("error" in resp) return;
-      setCodecPreference(resp.result as string);
+      const codec = resp.result as string;
+      const isAvailable = codecOptions.some(o => o.value === codec);
+      setCodecPreference(isAvailable ? codec : "auto");
     });
 
     void send("getEDID", {}, (resp: JsonRpcResponse) => {


### PR DESCRIPTION
## Summary
- Follow-up to #1380
- When a non-H.265 browser loads a stored `"h265"` preference from the backend, the value doesn't exist in the filtered `codecOptions`
- The `<select>` visually shows "Auto" but React state holds `"h265"` — a silent mismatch
- Now reconciles the backend response against available options, falling back to `"auto"` when the value isn't in the list

## Test plan
- [x] Set codec to H.265 on Chrome, then open settings on Firefox → dropdown shows "Auto", not a blank/mismatched state
- [x] On a supported browser, H.265 preference round-trips correctly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-state change limited to the video settings page; it only adjusts how the `getVideoCodecPreference` response is interpreted and does not change backend behavior.
> 
> **Overview**
> Fixes a state/UX mismatch in the video settings codec dropdown by validating the backend `getVideoCodecPreference` value against the currently available `codecOptions`.
> 
> If the stored codec (notably `h265` when the browser doesn’t support it) isn’t present in the filtered options list, the UI now normalizes the selection to `auto` instead of keeping an unreachable value in React state.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 947882475fa4c0ad7a5ea8a91c04ba2d32dc0c6b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->