### PR TITLE
fix(test): add ota-upgrade-to-signed project to dev_release target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -275,7 +275,7 @@ dev_release: git_check_dev check_r2
 	cd ui && npx playwright install --with-deps chromium
 	cd ui && $(call OTA_ENV,$(VERSION_DEV)) \
 		JETKVM_REMOTE_HOST=$(JETKVM_REMOTE_HOST) \
-		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-prerelease-rejected --project=ota-specific-version --project=ota-upgrade-from-stable
+		npx playwright test --project=ui --project=remote-agent --project=ota-prerelease-unsigned --project=ota-prerelease-rejected --project=ota-specific-version --project=ota-upgrade-from-stable --project=ota-upgrade-to-signed
 
 	@echo "───────────────────────────────────────────────────────"
 	@echo "  All tests completed. Everything is tested and ready for release."


### PR DESCRIPTION
## Summary
- Adds the `ota-upgrade-to-signed` test project to the `dev_release` Makefile target so it runs as part of the pre-release test suite.

## Test plan
- [x] Run `make dev_release` and verify the `ota-upgrade-to-signed` project is included in the Playwright test run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: Makefile-only change that just expands the pre-release Playwright test matrix without affecting runtime code.
> 
> **Overview**
> Dev release validation now also runs the Playwright `ota-upgrade-to-signed` project as part of `make dev_release`, ensuring signed-upgrade OTA coverage is included before publishing a dev release.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 046baa5fe2550b2609c02ad8fc6bdfcb006a1cc4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->