### PR TITLE
fix(test): add wakeDisplay and waitForVideoStream to video codec tests

### DIFF
--- a/ui/e2e/video-codec.spec.ts
+++ b/ui/e2e/video-codec.spec.ts
@@ -1,6 +1,12 @@
 import { test, expect, type Page } from "@playwright/test";
 
-import { ensureLocalAuthMode, waitForWebRTCReady, callJsonRpc } from "./helpers";
+import {
+  ensureLocalAuthMode,
+  waitForWebRTCReady,
+  waitForVideoStream,
+  wakeDisplay,
+  callJsonRpc,
+} from "./helpers";
 
 /**
  * Wait for inbound video stats to report a non-empty codec mimeType.
@@ -10,9 +16,7 @@ async function getActiveCodec(page: Page, timeout = 15000): Promise<string> {
   await expect
     .poll(
       async () => {
-        const stats = await page.evaluate(() =>
-          window.__kvmTestHooks?.getInboundVideoStats(),
-        );
+        const stats = await page.evaluate(() => window.__kvmTestHooks?.getInboundVideoStats());
         if (stats?.codecMimeType) codec = stats.codecMimeType;
         return codec;
       },
@@ -49,6 +53,8 @@ async function reconnect(page: Page): Promise<void> {
   await page.waitForLoadState("networkidle");
   await ensureLocalAuthMode(page, { mode: "noPassword" });
   await waitForWebRTCReady(page);
+  await wakeDisplay(page);
+  await waitForVideoStream(page);
 }
 
 test.describe("Video codec negotiation", () => {
@@ -59,6 +65,8 @@ test.describe("Video codec negotiation", () => {
     await page.waitForLoadState("networkidle");
     await ensureLocalAuthMode(page, { mode: "noPassword" });
     await waitForWebRTCReady(page);
+    await wakeDisplay(page);
+    await waitForVideoStream(page);
 
     const originalCodec = (await callJsonRpc(page, "getVideoCodecPreference")) as string;
 
@@ -88,6 +96,8 @@ test.describe("Video codec negotiation", () => {
     await page.waitForLoadState("networkidle");
     await ensureLocalAuthMode(page, { mode: "noPassword" });
     await waitForWebRTCReady(page);
+    await wakeDisplay(page);
+    await waitForVideoStream(page);
 
     const originalCodec = (await callJsonRpc(page, "getVideoCodecPreference")) as string;
 
@@ -118,6 +128,8 @@ test.describe("Video codec negotiation", () => {
     await page.waitForLoadState("networkidle");
     await ensureLocalAuthMode(page, { mode: "noPassword" });
     await waitForWebRTCReady(page);
+    await wakeDisplay(page);
+    await waitForVideoStream(page);
 
     const originalCodec = (await callJsonRpc(page, "getVideoCodecPreference")) as string;
 


### PR DESCRIPTION
## Summary
- Adds `wakeDisplay()` and `waitForVideoStream()` calls after WebRTC setup in all video codec test paths (setup, reconnect, and each test case)
- Prevents flaky codec stat assertions when the display is idle or the video stream hasn't started flowing yet

## Test plan
- [ ] Run video codec e2e suite against a real device and verify all tests pass consistently

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes that add additional waits/inputs to reduce flakiness; minimal impact outside E2E runtime and timing.
> 
> **Overview**
> Improves reliability of the Playwright video codec negotiation E2E tests by ensuring the display is awake and the video stream is actually flowing before asserting codec stats.
> 
> `ui/e2e/video-codec.spec.ts` now calls `wakeDisplay()` and `waitForVideoStream()` after `waitForWebRTCReady()` in the initial setup and in the `reconnect()` helper, reducing flakes where inbound video stats are empty due to an idle display or inactive stream.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d7cd7486026638c1e59f9929da21fff0fd4881c7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->