### PR TITLE
fix(keyboard): prevent modifier key auto-release during typing (#1386)

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -738,6 +738,203 @@ test.describe("Remote Host Agent", () => {
     expect(shiftReleases[0].time_ms).toBeGreaterThan(aReleases[0].time_ms);
   });
 
+  test("keepalive: modifier held while tapping multiple keys (Shift+10 chars over 10s)", async () => {
+    // Reproduces https://github.com/jetkvm/kvm/issues/1386
+    // Hold Shift and tap 10 letter keys with ~1s inter-key delays (~10s total).
+    // The modifier must remain held throughout all letter presses.
+    test.setTimeout(30_000);
+    await agent!.clearKeyboardEvents();
+
+    // HID codes for A-J (0x04-0x0D)
+    const letters = [0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d];
+
+    await sendKeypress(sharedPage, 0xe1, true); // Shift down
+    await new Promise(r => setTimeout(r, 500));
+
+    for (const hid of letters) {
+      await sendKeypress(sharedPage, hid, true);
+      await new Promise(r => setTimeout(r, 50));
+      await sendKeypress(sharedPage, hid, false);
+      await new Promise(r => setTimeout(r, 950)); // ~1s between keys
+    }
+
+    await sendKeypress(sharedPage, 0xe1, false); // Shift up
+    await new Promise(r => setTimeout(r, 300));
+
+    const events = await agent!.getKeyboardEvents();
+
+    const shiftPresses = events.filter(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press");
+    const shiftReleases = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    expect(shiftPresses.length, "Shift should have exactly 1 press").toBe(1);
+    expect(
+      shiftReleases.length,
+      "Shift should have exactly 1 release (no premature auto-release)",
+    ).toBe(1);
+
+    // All 10 letter keys should have been pressed
+    const expectedLinux: number[] = [
+      KEY.A,
+      KEY.B,
+      KEY.C,
+      KEY.D,
+      KEY.E,
+      KEY.F,
+      KEY.G,
+      KEY.H,
+      KEY.I,
+      KEY.J,
+    ];
+    for (const code of expectedLinux) {
+      const presses = events.filter(ev => ev.code === code && ev.type === "key_press");
+      expect(presses.length, `Key ${code} should have been pressed`).toBeGreaterThanOrEqual(1);
+    }
+
+    // Shift release must come after the last letter press
+    const lastLetterPress = Math.max(
+      ...events
+        .filter(ev => expectedLinux.includes(ev.code) && ev.type === "key_press")
+        .map(ev => ev.time_ms),
+    );
+    expect(
+      shiftReleases[0].time_ms,
+      "Shift release must come after all letter key presses",
+    ).toBeGreaterThan(lastLetterPress);
+  });
+
+  test("keepalive: modifier held with key-repeat simulation", async () => {
+    // Simulates browser key-repeat: Shift held, then rapid repeated A presses
+    // without releases (mimicking how browsers fire keydown with repeat=true).
+    // Key-repeat must not starve the keepalive and cause modifier auto-release.
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe1, true); // Shift down
+    await new Promise(r => setTimeout(r, 50));
+
+    // Simulate key-repeat: 20 rapid A presses at ~30ms (no releases between)
+    await sharedPage.evaluate(async () => {
+      const hooks = window.__kvmTestHooks;
+      if (!hooks) throw new Error("Test hooks not available");
+      for (let i = 0; i < 20; i++) {
+        hooks.sendKeypress(0x04, true); // repeated A press
+        await new Promise(r => setTimeout(r, 30));
+      }
+    });
+
+    await sendKeypress(sharedPage, 0x04, false);
+    await new Promise(r => setTimeout(r, 200));
+    await sendKeypress(sharedPage, 0xe1, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    const shiftReleases = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    expect(shiftReleases.length, "Shift should have exactly 1 release").toBe(1);
+  });
+
+  test("keepalive: modifier held across rapid tap burst", async () => {
+    // Hold Shift, tap 20 keys at ~50ms spacing. Shift must survive throughout.
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe1, true);
+    await new Promise(r => setTimeout(r, 50));
+
+    await sharedPage.evaluate(async () => {
+      const hooks = window.__kvmTestHooks;
+      if (!hooks) throw new Error("Test hooks not available");
+      for (let i = 0; i < 20; i++) {
+        const hid = 0x04 + (i % 10); // cycle A-J
+        hooks.sendKeypress(hid, true);
+        await new Promise(r => setTimeout(r, 20));
+        hooks.sendKeypress(hid, false);
+        await new Promise(r => setTimeout(r, 30));
+      }
+    });
+
+    await sendKeypress(sharedPage, 0xe1, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    const shiftReleases = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    expect(shiftReleases.length, "Shift should have exactly 1 release").toBe(1);
+  });
+
+  test("keepalive: multiple simultaneous modifiers + key", async () => {
+    // Hold Ctrl+Shift, tap A, release both. Neither modifier should auto-release.
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe0, true); // Ctrl
+    await sendKeypress(sharedPage, 0xe1, true); // Shift
+    await new Promise(r => setTimeout(r, 50));
+    await sendKeypress(sharedPage, 0x04, true); // A
+    await new Promise(r => setTimeout(r, 50));
+    await sendKeypress(sharedPage, 0x04, false);
+    await new Promise(r => setTimeout(r, 200));
+    await sendKeypress(sharedPage, 0xe1, false);
+    await sendKeypress(sharedPage, 0xe0, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    for (const [code, label] of [
+      [KEY.LEFT_CTRL, "Ctrl"],
+      [KEY.LEFT_SHIFT, "Shift"],
+    ] as const) {
+      const releases = events.filter(ev => ev.code === code && ev.type === "key_release");
+      expect(releases.length, `${label} should have exactly 1 release`).toBe(1);
+    }
+    const aPresses = events.filter(ev => ev.code === KEY.A && ev.type === "key_press");
+    expect(aPresses.length, "A should have been pressed").toBeGreaterThanOrEqual(1);
+  });
+
+  test("keepalive: modifier released before non-modifier (reversed release order)", async () => {
+    // Shift down, A down, Shift up (while A still held), A up.
+    // Tests that releasing the modifier first doesn't corrupt the key buffer.
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe1, true); // Shift
+    await new Promise(r => setTimeout(r, 50));
+    await sendKeypress(sharedPage, 0x04, true); // A
+    await new Promise(r => setTimeout(r, 100));
+    await sendKeypress(sharedPage, 0xe1, false); // Shift up first
+    await new Promise(r => setTimeout(r, 100));
+    await sendKeypress(sharedPage, 0x04, false); // A up
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    const shiftRelease = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    const aRelease = events.filter(ev => ev.code === KEY.A && ev.type === "key_release");
+
+    expect(shiftRelease.length, "Shift should have exactly 1 release").toBe(1);
+    expect(aRelease.length, "A should have exactly 1 release").toBe(1);
+    // Shift released before A
+    expect(shiftRelease[0].time_ms).toBeLessThan(aRelease[0].time_ms);
+  });
+
+  test("keepalive: AltGr (AltRight) held while tapping key", async () => {
+    // Hold AltRight (AltGr on international layouts), tap A.
+    // AltRight must not auto-release prematurely.
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe6, true); // AltRight
+    await new Promise(r => setTimeout(r, 50));
+    await sendKeypress(sharedPage, 0x04, true); // A
+    await new Promise(r => setTimeout(r, 50));
+    await sendKeypress(sharedPage, 0x04, false);
+    await new Promise(r => setTimeout(r, 200));
+    await sendKeypress(sharedPage, 0xe6, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    const altReleases = events.filter(ev => ev.code === KEY.RIGHT_ALT && ev.type === "key_release");
+    expect(altReleases.length, "AltRight should have exactly 1 release").toBe(1);
+  });
+
   test("keepalive: multiple simultaneous keys held for 300ms", async () => {
     // Hold A + B + C simultaneously, wait 300ms, release all.
     // Each key should get exactly 1 release — tests per-key timer independence.

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -45,6 +45,7 @@ export default function useKeyboard() {
 
   // Keepalive timer management
   const keepAliveTimerRef = useRef<number | null>(null);
+  const heldKeysRef = useRef<Set<number>>(new Set());
 
   // INTRODUCTION: The earlier version of the JetKVM device shipped with all keyboard state
   // being tracked on the browser/client-side. When adding the keyPressReport API to the
@@ -82,11 +83,16 @@ export default function useKeyboard() {
     }
   });
 
+  // Ref ensures the setInterval closure always calls the latest send function,
+  // even after WebRTC reconnection produces a new rpcHidChannel.
+  const sendKeepAliveRef = useRef(sendKeypressKeepAliveHidRpc);
+  sendKeepAliveRef.current = sendKeypressKeepAliveHidRpc;
+
   const handleLegacyKeyboardReport = useCallback(
     async (keys: number[], modifier: number) => {
-      send("keyboardReport", { keys, modifier }, (resp: JsonRpcResponse) => {
+      void send("keyboardReport", { keys, modifier }, (resp: JsonRpcResponse) => {
         if ("error" in resp) {
-          console.error(`Failed to send keyboard report ${keys} ${modifier}`, resp.error);
+          console.error("Failed to send keyboard report", keys, modifier, resp.error);
         }
 
         // On older backends, we need to set the keysDownState manually since without the hidRpc API, the state doesn't trickle down from the backend
@@ -105,7 +111,7 @@ export default function useKeyboard() {
 
         ac?.signal?.addEventListener("abort", abortListener);
 
-        send("keyboardReport", { keys, modifier }, params => {
+        void send("keyboardReport", { keys, modifier }, params => {
           if ("error" in params) return reject(params.error);
           resolve();
         });
@@ -128,22 +134,23 @@ export default function useKeyboard() {
     cancelKeepAlive();
 
     keepAliveTimerRef.current = setInterval(() => {
-      sendKeypressKeepAliveHidRpc();
+      sendKeepAliveRef.current();
     }, KEEPALIVE_INTERVAL);
-  }, [cancelKeepAlive, sendKeypressKeepAliveHidRpc]);
+  }, [cancelKeepAlive]);
 
   // resetKeyboardState is used to reset the keyboard state to no keys pressed and no modifiers.
   // This is useful for macros, in case of client-side rollover, and when the browser loses focus
   const resetKeyboardState = useCallback(async () => {
     // Cancel keepalive since we're resetting the keyboard state
     cancelKeepAlive();
+    heldKeysRef.current.clear();
     // Reset the keys buffer to zeros and the modifier state to zero
     const { keys, modifier } = MACRO_RESET_KEYBOARD_STATE;
     if (rpcHidReady) {
       sendKeyboardEventHidRpc(keys, modifier);
     } else {
       // Older backends don't support the hidRpc API, so we send the full reset state
-      handleLegacyKeyboardReport(keys, modifier);
+      void handleLegacyKeyboardReport(keys, modifier);
     }
   }, [rpcHidReady, sendKeyboardEventHidRpc, handleLegacyKeyboardReport, cancelKeepAlive]);
 
@@ -197,7 +204,7 @@ export default function useKeyboard() {
       // If we reach here it means we didn't find an empty slot or the key in the buffer
       if (overrun) {
         if (press) {
-          console.warn(`keyboard buffer overflow current keys ${keys}, key: ${key} not added`);
+          console.warn("keyboard buffer overflow current keys", keys, "key:", key, "not added");
           // Fill all key slots with ErrorRollOver (0x01) to indicate overflow
           keys.length = hidKeyBufferSize;
           keys.fill(hidErrorRollOver);
@@ -212,12 +219,24 @@ export default function useKeyboard() {
 
   const sendKeypress = useCallback(
     (key: number, press: boolean) => {
-      cancelKeepAlive();
+      if (press) {
+        heldKeysRef.current.add(key);
+      } else {
+        heldKeysRef.current.delete(key);
+      }
 
       sendKeypressEventHidRpc(key, press);
 
-      if (press) {
-        scheduleKeepAlive();
+      if (heldKeysRef.current.size > 0) {
+        // Start keepalive if not already running. Don't restart an existing
+        // interval — key-repeat events fire faster (~33ms) than the keepalive
+        // period (50ms), so cancel+restart would prevent the tick from ever
+        // firing, starving the device-side auto-release extension (issue #1386).
+        if (!keepAliveTimerRef.current) {
+          scheduleKeepAlive();
+        }
+      } else {
+        cancelKeepAlive();
       }
     },
     [sendKeypressEventHidRpc, scheduleKeepAlive, cancelKeepAlive],
@@ -248,11 +267,11 @@ export default function useKeyboard() {
         // 2. Send the newly calculated state to the device
         const downState = simulateDeviceSideKeyHandlingForLegacyDevices(keysDownState, key, press);
 
-        handleLegacyKeyboardReport(downState.keys, downState.modifier);
+        void handleLegacyKeyboardReport(downState.keys, downState.modifier);
 
         // if we just sent ErrorRollOver, reset to empty state
         if (downState.keys[0] === hidErrorRollOver) {
-          resetKeyboardState();
+          void resetKeyboardState();
         }
       }
     },


### PR DESCRIPTION
## Summary

- Fix modifier keys (Shift, Ctrl, Alt) being dropped after the first key combination when held during typing
- Root cause: browser key-repeat events (~30Hz) cancelled and restarted the keepalive interval on every `keydown`, but the repeat rate (~33ms) was shorter than the keepalive period (50ms), so the keepalive tick could never fire. When a second key was pressed and the modifier's repeat stopped, the modifier's 100ms auto-release timer expired with no keepalive to extend it
- Fix: start the keepalive interval on first key press and leave it running undisturbed until all keys are released; track held keys client-side via a `Set<number>` to know when to start/stop
- Also fixes pre-existing oxlint warnings in `useKeyboard.ts` (no-floating-promises, restrict-template-expressions)

## Test plan

- [x] New e2e test: modifier held with key-repeat simulation (20 rapid presses)
- [x] New e2e test: modifier held across rapid tap burst (20 keys at 50ms)
- [x] New e2e test: multiple simultaneous modifiers (Ctrl+Shift+key)
- [x] New e2e test: reversed release order (modifier up before non-modifier)
- [x] New e2e test: AltGr (AltRight) held while tapping
- [x] New e2e test: modifier held while tapping 10 keys over 10 seconds
- [x] All 39 remote-agent e2e tests pass
- [x] Full `make test_e2e` suite (47 tests) passes
- [x] Manual verification: Shift+JSON types "JSON" correctly on deployed device

Closes #1386

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the client-side HID keepalive scheduling used to prevent device auto-release, which can affect all keyboard input timing and stuck-key behavior; adds broad e2e coverage to reduce regression risk.
> 
> **Overview**
> Fixes a regression where held modifiers (e.g. Shift/Ctrl/Alt) could auto-release during typing by changing the keepalive logic in `useKeyboard` to **keep a single interval running while any keys are held**, instead of cancelling/restarting it on each press.
> 
> Adds client-side tracking of currently held keys and ensures the keepalive tick always uses the latest HID RPC sender across reconnects; also cleans up a few legacy RPC sends/logging to avoid floating promises. Expands `ra-all.spec.ts` with several new e2e scenarios covering long holds, key-repeat, burst typing, multiple modifiers, reversed release order, and AltGr to validate modifiers are not dropped.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6189cbad0a7be448b1a1bff7e46527a543d11a74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->