### PR TITLE
fix(mouse): prevent double wheel scroll by sending to only one HID device

### DIFF
--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -93,6 +93,10 @@ func (u *UsbGadget) absMouseWriteHidFile(data []byte) error {
 	return nil
 }
 
+func (u *UsbGadget) HasAbsoluteMouse() bool {
+	return u.enabledDevices.AbsoluteMouse
+}
+
 func (u *UsbGadget) AbsMouseReport(x int, y int, buttons uint8) error {
 	if !u.enabledDevices.AbsoluteMouse {
 		return nil

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -1347,6 +1347,67 @@ test.describe("Remote Host Agent", () => {
     }
   });
 
+  test("mouse: wheel scroll should not produce duplicate events from both HID devices", async () => {
+    test.setTimeout(30_000);
+    const REL_WHEEL = 0x08;
+    const REL_HWHEEL = 0x06;
+
+    await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 10000);
+
+    // Retry until the agent starts receiving wheel events (host may still
+    // be re-enumerating HID devices after previous test's USB changes).
+    const vDeadline = Date.now() + 10000;
+    let vWheelEvents: RAMouseEvent[] = [];
+    while (Date.now() < vDeadline) {
+      await agent!.clearMouseEvents();
+      await callJsonRpc(sharedPage, "wheelReport", { wheelY: 1, wheelX: 0 });
+      try {
+        await agent!.waitForMouseEvent(
+          ev => ev.type === "mouse_move_rel" && ev.code === REL_WHEEL,
+          2000,
+        );
+        break;
+      } catch {
+        /* agent not ready yet, retry */
+      }
+    }
+    // Allow any duplicate from the second HID device to arrive
+    await new Promise(r => setTimeout(r, 500));
+
+    const allEvents = await agent!.getMouseEvents();
+    vWheelEvents = allEvents.filter(ev => ev.type === "mouse_move_rel" && ev.code === REL_WHEEL);
+    const devices = new Set(vWheelEvents.map(ev => ev.device));
+    console.log(
+      `Vertical wheel: ${vWheelEvents.length} event(s) from device(s): ${[...devices].join(", ")}`,
+    );
+    expect(
+      vWheelEvents.length,
+      `Expected 1 vertical wheel event, got ${vWheelEvents.length} from [${[...devices].join(", ")}]. ` +
+        `Duplicate means rpcWheelReport sends to both abs and rel mouse HID devices.`,
+    ).toBe(1);
+
+    await agent!.clearMouseEvents();
+    await callJsonRpc(sharedPage, "wheelReport", { wheelY: 0, wheelX: 1 });
+    await agent!.waitForMouseEvent(
+      ev => ev.type === "mouse_move_rel" && ev.code === REL_HWHEEL,
+      3000,
+    );
+    await new Promise(r => setTimeout(r, 500));
+
+    const allHEvents = await agent!.getMouseEvents();
+    const hWheelEvents = allHEvents.filter(
+      ev => ev.type === "mouse_move_rel" && ev.code === REL_HWHEEL,
+    );
+    const hDevices = new Set(hWheelEvents.map(ev => ev.device));
+    console.log(
+      `Horizontal wheel: ${hWheelEvents.length} event(s) from device(s): ${[...hDevices].join(", ")}`,
+    );
+    expect(
+      hWheelEvents.length,
+      `Expected 1 horizontal wheel event, got ${hWheelEvents.length} from [${[...hDevices].join(", ")}].`,
+    ).toBe(1);
+  });
+
   // ═══════════════════════════════════════════
   // INPUT: MACROS
   // ═══════════════════════════════════════════

--- a/usb.go
+++ b/usb.go
@@ -82,8 +82,8 @@ func rpcRelMouseReport(dx int8, dy int8, buttons uint8) error {
 
 func rpcWheelReport(wheelY int8, wheelX int8) error {
 	return rpcHidReport(func() error {
-		if err := gadget.AbsMouseWheelReport(wheelY, wheelX); err != nil {
-			return err
+		if gadget.HasAbsoluteMouse() {
+			return gadget.AbsMouseWheelReport(wheelY, wheelX)
 		}
 		return gadget.RelMouseWheelReport(wheelY, wheelX)
 	})


### PR DESCRIPTION
## Summary

- **Bug:** `rpcWheelReport` unconditionally sent wheel events to both the absolute and relative mouse HID devices. The host OS sees two separate USB HID devices each producing a scroll event, doubling all scroll input (e.g. 6 lines instead of 3 on Windows with default settings).
- **Fix:** Send wheel events to the absolute mouse device when enabled, falling back to the relative mouse device otherwise. This mirrors how pointer reports already work (`absMouseReport` vs `relMouseReport` are separate handlers).
- **Test:** Added an E2E test that sends a single `wheelReport` RPC and asserts exactly one `REL_WHEEL` / `REL_HWHEEL` event is received on the host, catching the duplicate if both HID devices fire.

Closes https://github.com/jetkvm/kvm/issues/1389

## Test plan

- [x] E2E test `mouse: wheel scroll should not produce duplicate events from both HID devices` passes
- [x] Existing wheel scroll tests still pass (vertical, horizontal, combined, relative-only mode)
- [x] Full `make test_e2e` suite: 53/53 passed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to wheel-report routing plus an E2E regression test; low risk aside from potential behavior differences on hosts that previously relied on dual-reporting.
> 
> **Overview**
> Fixes doubled wheel scrolling by updating `rpcWheelReport` to send wheel reports to **only one** HID mouse device: absolute mouse when enabled, otherwise the relative mouse.
> 
> Adds `UsbGadget.HasAbsoluteMouse()` to expose whether the absolute mouse function is active, and introduces an E2E regression test that asserts a single wheel RPC results in exactly one vertical/horizontal wheel event (preventing duplicates across both devices).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 552cb08a3083bc2a6197ddd719edced2b6a20189. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->