### PR TITLE
fix(settings): add space before 'root' in SSH default user message

### DIFF
--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -329,7 +329,7 @@ export default function SettingsAdvancedRoute() {
                 />
                 <p className="text-xs text-slate-600 dark:text-slate-400">
                   {m.advanced_ssh_default_user()}
-                  <strong>root</strong>.
+                  <strong> root</strong>.
                 </p>
                 {!sshKey?.trim() && (
                   <p className="text-xs text-amber-600 dark:text-amber-500">

--- a/ui/src/routes/devices.$id.settings.advanced.tsx
+++ b/ui/src/routes/devices.$id.settings.advanced.tsx
@@ -328,8 +328,7 @@ export default function SettingsAdvancedRoute() {
                   placeholder={m.advanced_ssh_public_key_placeholder()}
                 />
                 <p className="text-xs text-slate-600 dark:text-slate-400">
-                  {m.advanced_ssh_default_user()}
-                  <strong> root</strong>.
+                  {m.advanced_ssh_default_user()}{" "}<strong>root</strong>.
                 </p>
                 {!sshKey?.trim() && (
                   <p className="text-xs text-amber-600 dark:text-amber-500">


### PR DESCRIPTION
Fixes #1397

### Summary
-  This PR fixes the default SSH user message "The default SSH user isroot." by adding a space under `advanced_ssh_default_user` in `ui/src/routes/devices.$id.settings.advanced.tsx`

### Images
#### Before
<img width="624" height="455" alt="image" src="https://github.com/user-attachments/assets/ea50b000-ef59-4dec-a1b8-caa430d5f3d9" />

#### After
<img width="638" height="507" alt="image" src="https://github.com/user-attachments/assets/b4673d6d-ea36-4e7e-b89e-ba6ffe7e2f2d" />

### Checklist
- [X] Ran `make test_e2e` locally and passed
- [X] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [X] One problem per PR (no unrelated changes)
- [X] Lints pass; CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts rendered text spacing with no impact to settings logic or RPC calls.
> 
> **Overview**
> Fixes a minor formatting bug in `devices.$id.settings.advanced.tsx` where the SSH default user label rendered as "isroot" by explicitly inserting a space before the bolded `root` username.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1be4303c39e298525dd10feda0a238793a9e2f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->