### PR TITLE
fix(test): use relative mouse wake for S3 suspend

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -2389,8 +2389,12 @@ test.describe("Remote Host Agent", () => {
     await new Promise(r => setTimeout(r, 10000));
     expect(await agent!.health(), "Host should be asleep after 10s").toBe(false);
 
-    // Wake via mouse movement
-    await sendAbsMouseMove(sharedPage, 16384, 16384);
+    // Wake via relative mouse activity. This exercises the boot-style mouse HID
+    // interface, which is typically a more reliable suspend wake source than
+    // the absolute mouse reports used during normal pointer sync.
+    await callJsonRpc(sharedPage, "relMouseReport", { dx: 8, dy: 0, buttons: 0 });
+    await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 1 });
+    await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 0 });
 
     const wakeDeadline = Date.now() + 30000;
     let hostUp = false;
@@ -2400,11 +2404,13 @@ test.describe("Remote Host Agent", () => {
         break;
       }
       try {
-        await sendAbsMouseMove(
-          sharedPage,
-          100 + Math.random() * 32000,
-          100 + Math.random() * 32000,
-        );
+        await callJsonRpc(sharedPage, "relMouseReport", {
+          dx: Math.random() > 0.5 ? 12 : -12,
+          dy: Math.random() > 0.5 ? 6 : -6,
+          buttons: 0,
+        });
+        await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 1 });
+        await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 0 });
       } catch {
         /* best effort */
       }


### PR DESCRIPTION
## Summary
- switch the S3 mouse wake e2e test from absolute mouse movement to relative mouse reports
- add a small button press/release pulse so the wake path matches a more standard mouse HID activity pattern
- keep the test aligned with the host behavior validated on the current JetKVM and remote host setup

## Test plan
- [x] `JETKVM_URL=http://192.168.1.77 JETKVM_REMOTE_HOST=192.168.1.180 npx playwright test e2e/remote-agent/ra-all.spec.ts --grep \"usb-wake: S3 suspend and wake via mouse input\"`
- [x] optional: run the paired keyboard S3 wake test on the same setup

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to an E2E test and only adjust the wake-input method, with no production logic impact. Main risk is potential flakiness if `relMouseReport` behavior differs across hosts/firmware.
> 
> **Overview**
> Updates the `usb-wake: S3 suspend and wake via mouse input` E2E test to wake the host using `relMouseReport` (relative mouse HID activity) instead of absolute mouse moves.
> 
> The wake loop now sends a small relative movement plus a button press/release pulse and repeats this pattern while polling for the host to come back up, aiming to make S3 wake more reliable across environments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6a8f9681158c9013187bd198f527bc3502c58c3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->