### PR TITLE
Expose USB configuration descriptor (#4) in UI

### DIFF
--- a/config.go
+++ b/config.go
@@ -163,11 +163,12 @@ var (
 		Timezone:               "UTC",
 	}
 	defaultUsbConfig = usbgadget.Config{
-		VendorId:     "0x1d6b", //The Linux Foundation
-		ProductId:    "0x0104", //Multifunction Composite Gadget
-		SerialNumber: "",
-		Manufacturer: "JetKVM",
-		Product:      "USB Emulation Device",
+		VendorId:      "0x1d6b", //The Linux Foundation
+		ProductId:     "0x0104", //Multifunction Composite Gadget
+		SerialNumber:  "",
+		Manufacturer:  "JetKVM",
+		Product:       "USB Emulation Device",
+		Configuration: "Config 1: HID",
 	}
 	defaultUsbDevices = usbgadget.Devices{
 		AbsoluteMouse: true,

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -95,6 +95,7 @@ func (u *UsbGadget) loadGadgetConfig() {
 	u.configMap["base_info"].attrs["serialnumber"] = u.customConfig.SerialNumber
 	u.configMap["base_info"].attrs["manufacturer"] = u.customConfig.Manufacturer
 	u.configMap["base_info"].attrs["product"] = u.customConfig.Product
+	u.configMap["base_info"].configAttrs["configuration"] = u.customConfig.Configuration
 }
 
 func (u *UsbGadget) SetGadgetConfig(config *Config) {

--- a/internal/usbgadget/usbgadget.go
+++ b/internal/usbgadget/usbgadget.go
@@ -26,11 +26,12 @@ type Devices struct {
 // Config is a struct that represents the customizations for a USB gadget.
 // TODO: rename to something else that won't confuse with the USB gadget configuration
 type Config struct {
-	VendorId     string `json:"vendor_id"`
-	ProductId    string `json:"product_id"`
-	SerialNumber string `json:"serial_number"`
-	Manufacturer string `json:"manufacturer"`
-	Product      string `json:"product"`
+	VendorId      string `json:"vendor_id"`
+	ProductId     string `json:"product_id"`
+	SerialNumber  string `json:"serial_number"`
+	Manufacturer  string `json:"manufacturer"`
+	Product       string `json:"product"`
+	Configuration string `json:"configuration"`
 
 	strictMode bool // when it's enabled, all warnings will be converted to errors
 	isEmpty    bool

--- a/ui/localization/messages/cy.json
+++ b/ui/localization/messages/cy.json
@@ -962,6 +962,8 @@
     "usb_config_update_identifiers": "Diweddaru Dynodwyr USB",
     "usb_config_vendor_id_label": "ID Gwerthwr",
     "usb_config_vendor_id_placeholder": "Rhowch ID Gwerthwr",
+    "usb_config_configuration_label": "Ffurfweddiad",
+    "usb_config_configuration_placeholder": "Rhowch ffurfweddiad", 
     "usb_device_classes_description": "Dosbarthiadau dyfais USB yn y ddyfais gyfansawdd",
     "usb_device_classes_title": "Dosbarthiadau",
     "usb_device_custom": "Personol",

--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Opdater USB-identifikatorer",
     "usb_config_vendor_id_label": "Leverandør-ID",
     "usb_config_vendor_id_placeholder": "Indtast leverandør-ID",
+    "usb_config_configuration_label": "Konfiguration",
+    "usb_config_configuration_placeholder": "Indtast konfiguration",
     "usb_device_classes_description": "USB-enhedsklasser i den sammensatte enhed",
     "usb_device_classes_title": "Klasser",
     "usb_device_custom": "Tilpasset",

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "USB-Kennungen aktualisieren",
     "usb_config_vendor_id_label": "Lieferanten-ID",
     "usb_config_vendor_id_placeholder": "Geben Sie die Lieferanten-ID ein",
+    "usb_config_configuration_label": "Konfiguration",
+    "usb_config_configuration_placeholder": "Konfiguration eingeben",
     "usb_device_classes_description": "USB-Geräteklassen im Verbundgerät",
     "usb_device_classes_title": "Klassen",
     "usb_device_custom": "Benutzerdefiniert",

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Update USB Identifiers",
     "usb_config_vendor_id_label": "Vendor ID",
     "usb_config_vendor_id_placeholder": "Enter Vendor ID",
+    "usb_config_configuration_label": "Configuration",
+    "usb_config_configuration_placeholder": "Enter Configuration",
     "usb_device_classes_description": "USB device classes in the composite device",
     "usb_device_classes_title": "Classes",
     "usb_device_custom": "Custom",

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Actualizar identificadores USB",
     "usb_config_vendor_id_label": "Identificación del proveedor",
     "usb_config_vendor_id_placeholder": "Ingrese el ID del proveedor",
+    "usb_config_configuration_label": "Configuración",
+    "usb_config_configuration_placeholder": "Introducir configuración",
     "usb_device_classes_description": "Clases de dispositivos USB en el dispositivo compuesto",
     "usb_device_classes_title": "Clases",
     "usb_device_custom": "Costumbre",

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Mettre à jour les identifiants USB",
     "usb_config_vendor_id_label": "ID du fournisseur",
     "usb_config_vendor_id_placeholder": "Entrez l'ID du fournisseur",
+    "usb_config_configuration_label": "Configuration",
+    "usb_config_configuration_placeholder": "Saisir la configuration",
     "usb_device_classes_description": "Classes de périphériques USB dans le périphérique composite",
     "usb_device_classes_title": "Classes",
     "usb_device_custom": "Personnalisé",

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Aggiorna identificatori USB",
     "usb_config_vendor_id_label": "ID fornitore",
     "usb_config_vendor_id_placeholder": "Inserisci l'ID del fornitore",
+    "usb_config_configuration_label": "Configurazione",
+    "usb_config_configuration_placeholder": "Inserisci configurazione",
     "usb_device_classes_description": "Classi di dispositivi USB nel dispositivo composito",
     "usb_device_classes_title": "Classi",
     "usb_device_custom": "Personalizzato",

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "USB識別子を更新",
     "usb_config_vendor_id_label": "ベンダーID",
     "usb_config_vendor_id_placeholder": "ベンダーIDを入力",
+    "usb_config_configuration_label": "構成",
+    "usb_config_configuration_placeholder": "構成を入力",
     "usb_device_classes_description": "複合デバイス内のUSBデバイスクラス",
     "usb_device_classes_title": "クラス",
     "usb_device_custom": "カスタム",

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Oppdater USB-identifikatorer",
     "usb_config_vendor_id_label": "Leverandør-ID",
     "usb_config_vendor_id_placeholder": "Skriv inn leverandør-ID",
+    "usb_config_configuration_label": "Konfigurasjon",
+    "usb_config_configuration_placeholder": "Angi konfigurasjon",
     "usb_device_classes_description": "USB-enhetsklasser i den sammensatte enheten",
     "usb_device_classes_title": "Klasser",
     "usb_device_custom": "Tilpasset",

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Atualizar Identificadores USB",
     "usb_config_vendor_id_label": "ID do Fornecedor",
     "usb_config_vendor_id_placeholder": "Digite o ID do Fornecedor",
+    "usb_config_configuration_label": "Configuração",
+    "usb_config_configuration_placeholder": "Introduzir configuração",
     "usb_device_classes_description": "Classes de dispositivo USB no dispositivo composto",
     "usb_device_classes_title": "Classes",
     "usb_device_custom": "Personalizado",

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Обновить идентификаторы USB",
     "usb_config_vendor_id_label": "ID поставщика",
     "usb_config_vendor_id_placeholder": "Введите ID поставщика",
+    "usb_config_configuration_label": "Конфигурация",
+    "usb_config_configuration_placeholder": "Введите конфигурацию",
     "usb_device_classes_description": "Классы USB-устройств в составном устройстве",
     "usb_device_classes_title": "Классы",
     "usb_device_custom": "Пользовательский",

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "Uppdatera USB-identifierare",
     "usb_config_vendor_id_label": "Leverantörs-ID",
     "usb_config_vendor_id_placeholder": "Ange leverantörs-ID",
+    "usb_config_configuration_label": "Konfiguration",
+    "usb_config_configuration_placeholder": "Ange konfiguration",
     "usb_device_classes_description": "USB-enhetsklasser i den sammansatta enheten",
     "usb_device_classes_title": "Klasser",
     "usb_device_custom": "Anpassad",

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "更新 USB 識別碼",
     "usb_config_vendor_id_label": "供應商 ID",
     "usb_config_vendor_id_placeholder": "輸入供應商 ID",
+    "usb_config_configuration_label": "設定",
+    "usb_config_configuration_placeholder": "輸入設定",
     "usb_device_classes_description": "複合裝置中的 USB 裝置類別",
     "usb_device_classes_title": "類別",
     "usb_device_custom": "自訂",

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -975,6 +975,8 @@
     "usb_config_update_identifiers": "更新 USB 标识符",
     "usb_config_vendor_id_label": "供应商ID",
     "usb_config_vendor_id_placeholder": "输入供应商ID",
+    "usb_config_configuration_label": "配置",
+    "usb_config_configuration_placeholder": "输入配置",
     "usb_device_classes_description": "复合设备中包含的 USB 设备类。",
     "usb_device_classes_title": "设备类",
     "usb_device_custom": "自定义",

--- a/ui/src/components/UsbInfoSetting.tsx
+++ b/ui/src/components/UsbInfoSetting.tsx
@@ -67,7 +67,7 @@ export function UsbInfoSetting() {
         serial_number: deviceId,
         manufacturer: "JetKVM",
         product: "USB Emulation Device",
-        configuration: "Config 1: HID1",
+        configuration: "Config 1: HID",
       },
       "Logitech USB Input Device": {
         vendor_id: "0x046d",
@@ -75,7 +75,7 @@ export function UsbInfoSetting() {
         serial_number: generatedSerialNumber,
         manufacturer: "Logitech (x64)",
         product: "Logitech USB Input Device",
-        configuration: "Config 1: HID2",
+        configuration: "RQR24.11_B0036",
       },
       "Wireless MultiMedia Keyboard": {
         vendor_id: "0x045e",
@@ -83,7 +83,7 @@ export function UsbInfoSetting() {
         serial_number: generatedSerialNumber,
         manufacturer: "Microsoft",
         product: "Wireless MultiMedia Keyboard",
-        configuration: "Config 1: HID3",
+        configuration: "Config 1: HID",
       },
       "Multimedia Pro Keyboard": {
         vendor_id: "0x413c",
@@ -91,7 +91,7 @@ export function UsbInfoSetting() {
         serial_number: generatedSerialNumber,
         manufacturer: "Dell Inc.",
         product: "Multimedia Pro Keyboard",
-        configuration: "Config 1: HID4",
+        configuration: "Config 1: HID",
       },
     }),
     [deviceId],

--- a/ui/src/components/UsbInfoSetting.tsx
+++ b/ui/src/components/UsbInfoSetting.tsx
@@ -29,6 +29,7 @@ export interface USBConfig {
   serial_number: string;
   manufacturer: string;
   product: string;
+  configuration: string;
 }
 
 const usbConfigs = [
@@ -66,6 +67,7 @@ export function UsbInfoSetting() {
         serial_number: deviceId,
         manufacturer: "JetKVM",
         product: "USB Emulation Device",
+        configuration: "Config 1: HID1",
       },
       "Logitech USB Input Device": {
         vendor_id: "0x046d",
@@ -73,6 +75,7 @@ export function UsbInfoSetting() {
         serial_number: generatedSerialNumber,
         manufacturer: "Logitech (x64)",
         product: "Logitech USB Input Device",
+        configuration: "Config 1: HID2",
       },
       "Wireless MultiMedia Keyboard": {
         vendor_id: "0x045e",
@@ -80,6 +83,7 @@ export function UsbInfoSetting() {
         serial_number: generatedSerialNumber,
         manufacturer: "Microsoft",
         product: "Wireless MultiMedia Keyboard",
+        configuration: "Config 1: HID3",
       },
       "Multimedia Pro Keyboard": {
         vendor_id: "0x413c",
@@ -87,6 +91,7 @@ export function UsbInfoSetting() {
         serial_number: generatedSerialNumber,
         manufacturer: "Dell Inc.",
         product: "Multimedia Pro Keyboard",
+        configuration: "Config 1: HID4",
       },
     }),
     [deviceId],
@@ -203,6 +208,7 @@ function USBConfigDialog({
     serial_number: "",
     manufacturer: "",
     product: "",
+    configuration: "",
   });
 
   const { send } = useJsonRpc();
@@ -242,6 +248,10 @@ function USBConfigDialog({
     setUsbConfigState({ ...usbConfigState, product: value });
   };
 
+  const handleUsbConfiguration = (value: string) => {
+    setUsbConfigState({ ...usbConfigState, configuration: value });
+  };
+
   return (
     <div className="">
       <div className="grid grid-cols-2 gap-4">
@@ -277,10 +287,17 @@ function USBConfigDialog({
         />
         <InputFieldWithLabel
           required
-          label={m.usb_config_product_name_label()}
-          placeholder={m.usb_config_product_name_placeholder()}
-          defaultValue={usbConfigState?.product}
-          onChange={e => handleUsbProduct(e.target.value)}
+          label={m.usb_config_configuration_label()}
+          placeholder={m.usb_config_configuration_placeholder()}
+          defaultValue={usbConfigState?.configuration}
+          onChange={e => handleUsbConfiguration(e.target.value)}
+        />
+        <InputFieldWithLabel
+          required
+          label="Configuration"
+          placeholder="Config 1: HID"
+          defaultValue={usbConfigState?.configuration}
+          onChange={e => handleUsbConfiguration(e.target.value)}
         />
       </div>
       <div className="mt-6 flex gap-x-2">

--- a/ui/src/components/UsbInfoSetting.tsx
+++ b/ui/src/components/UsbInfoSetting.tsx
@@ -287,15 +287,15 @@ function USBConfigDialog({
         />
         <InputFieldWithLabel
           required
-          label={m.usb_config_configuration_label()}
-          placeholder={m.usb_config_configuration_placeholder()}
-          defaultValue={usbConfigState?.configuration}
-          onChange={e => handleUsbConfiguration(e.target.value)}
+          label={m.usb_config_product_name_label()}
+          placeholder={m.usb_config_product_name_placeholder()}
+          defaultValue={usbConfigState?.product}
+          onChange={e => handleUsbProduct(e.target.value)}
         />
         <InputFieldWithLabel
           required
-          label="Configuration"
-          placeholder="Config 1: HID"
+          label={m.usb_config_configuration_label()}
+          placeholder={m.usb_config_configuration_placeholder()}
           defaultValue={usbConfigState?.configuration}
           onChange={e => handleUsbConfiguration(e.target.value)}
         />

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -688,6 +688,7 @@ export interface UsbConfigState {
   serial_number: string;
   manufacturer: string;
   product: string;
+  configuration: string;
 }
 
 export const useUsbConfigModalStore = create<UsbConfigModalState>(set => ({


### PR DESCRIPTION
Addresses #418

### Summary

Adds support for configuring USB descriptor #4 (configuration string) via the UI. The previously hardcoded value is now used as a default but can be overridden. This brings it in line with other configurable USB identifiers and improves compatibility across a wider range of host systems.

### Checklist

- [x]  Verified functionality on JetKVM device via dev_deploy.sh
- [x]  Confirmed descriptor changes on Windows host using Thesycon USB Descriptor Dumper
- [x]  Added localization entries for all supported languages
- [x]  One problem per PR (no unrelated changes)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches USB gadget descriptor values that affect how hosts enumerate the device; misconfiguration could cause compatibility issues, though the change is additive and keeps the previous value as the default.
> 
> **Overview**
> Adds support for editing the USB gadget *configuration string* (descriptor #4) end-to-end.
> 
> Backend `usbgadget.Config` and defaults now include a `Configuration` field and propagate it into the gadget’s `base_info` configfs `configuration` attribute, while the UI USB identifiers form/store and preset profiles gain a new required configuration input plus localized label/placeholder strings across languages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8b9ed0a4de75ad1604ebc6437331a52175ada77. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->