### PR TITLE
fix(serial) keep serial console mux closed when not needed

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -770,6 +770,8 @@ func rpcSetActiveExtension(extensionId string) error {
 		_ = unmountATXControl()
 	case "dc-power":
 		_ = unmountDCControl()
+	case "serial-console":
+		_ = unmountSerialConsole()
 	}
 	config.ActiveExtension = extensionId
 	if err := SaveConfig(); err != nil {
@@ -780,6 +782,8 @@ func rpcSetActiveExtension(extensionId string) error {
 		_ = mountATXControl()
 	case "dc-power":
 		_ = mountDCControl()
+	case "serial-console":
+		_ = mountSerialConsole()
 	}
 
 	// Re-publish MQTT HA Discovery for the new extension

--- a/serial.go
+++ b/serial.go
@@ -580,10 +580,20 @@ func initSerialPort() {
 		_ = mountATXControl()
 	case "dc-power":
 		_ = mountDCControl()
+	case "serial-console":
+		_ = mountSerialConsole()
 	}
 }
 
 func reopenSerialPort() error {
+	if serialMux != nil {
+		serialMux.Close()
+		serialMux = nil
+	}
+	if consoleBroker != nil {
+		consoleBroker.Close()
+		consoleBroker = nil
+	}
 	if port != nil {
 		port.Close()
 	}
@@ -598,6 +608,10 @@ func reopenSerialPort() error {
 		return err
 	}
 
+	return nil
+}
+
+func mountSerialConsole() error {
 	// new broker (no sink yet—set it in handleSerialChannel.OnOpen)
 	norm := NormalizationOptions{
 		Mode: ModeNames, LineEnding: LineEnding_LF, TabRender: "", PreserveANSI: true,
@@ -616,6 +630,11 @@ func reopenSerialPort() error {
 	serialMux.SetEchoEnabled(serialConfig.EnableEcho) // honor your setting
 	serialMux.Start()
 
+	return nil
+}
+
+func unmountSerialConsole() error {
+	_ = reopenSerialPort()
 	return nil
 }
 

--- a/serial_console_helpers.go
+++ b/serial_console_helpers.go
@@ -273,9 +273,16 @@ func NewConsoleBroker(s Sink, norm NormalizationOptions) *ConsoleBroker {
 }
 
 func (b *ConsoleBroker) Start()                                   { go b.loop() }
-func (b *ConsoleBroker) Close()                                   { close(b.done) }
 func (b *ConsoleBroker) SetSink(s Sink)                           { b.sink = s }
 func (b *ConsoleBroker) SetNormOptions(norm NormalizationOptions) { b.norm = norm }
+func (b *ConsoleBroker) Close() {
+	select {
+	case <-b.done:
+		return
+	default:
+		close(b.done)
+	}
+}
 func (b *ConsoleBroker) SetTerminalPaused(v bool) {
 	if b == nil {
 		return
@@ -626,7 +633,14 @@ func (m *SerialMux) Start() {
 	go m.writer()
 }
 
-func (m *SerialMux) Close() { close(m.done) }
+func (m *SerialMux) Close() {
+	select {
+	case <-m.done:
+		return
+	default:
+		close(m.done)
+	}
+}
 
 func (m *SerialMux) SetEchoEnabled(v bool) { m.echoEnabled.Store(v) }
 


### PR DESCRIPTION
Only open the serial console mux and broker when the extension is actually in use, otherwise the mux gets in a fight with the ATX or DC control extension in reading from the serial port.

Closes: #1420


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes serial port lifecycle and goroutine shutdown behavior across extensions, which could affect serial availability or introduce regressions if close/reopen ordering is wrong.
> 
> **Overview**
> Ensures the serial console’s `ConsoleBroker`/`SerialMux` only run when the `serial-console` extension is active, and are torn down when switching to other extensions to avoid competing reads on the UART.
> 
> Extension switching (`rpcSetActiveExtension`) and serial initialization now explicitly mount/unmount the serial console, with `reopenSerialPort` closing and clearing the mux/broker before reopening the port.
> 
> Makes `ConsoleBroker.Close()` and `SerialMux.Close()` idempotent (safe to call multiple times) to reduce panics during repeated mount/unmount cycles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c0bcc783f2066547c8ae8d6630271ff572fcd58d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->