### PR TITLE
fix: make mouse jiggler use tiny random movement near current position

### DIFF
--- a/jiggler.go
+++ b/jiggler.go
@@ -135,14 +135,17 @@ func runJiggler() {
 		logger.Debug().Msgf("Time since last user input %v", timeSinceLastInput)
 		if timeSinceLastInput > time.Duration(inactivitySeconds)*time.Second {
 			logger.Debug().Msg("Jiggling mouse...")
-			//TODO: change to rel mouse
-			err := rpcAbsMouseReport(1, 1, 0)
+			dx := int8(rand.Intn(3) + 1)
+			dy := int8(rand.Intn(3) + 1)
+			if rand.Intn(2) == 0 {
+				dx = -dx
+			}
+			if rand.Intn(2) == 0 {
+				dy = -dy
+			}
+			err := rpcRelMouseReport(dx, dy, 0)
 			if err != nil {
 				logger.Warn().Msgf("Failed to jiggle mouse: %v", err)
-			}
-			err = rpcAbsMouseReport(0, 0, 0)
-			if err != nil {
-				logger.Warn().Msgf("Failed to reset mouse position: %v", err)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #290

### Summary
- change mouse jiggler behavior to move only 1-3 pixels from the current cursor position
- use a random distance and random direction instead of a fixed jump


### Problem
When mouse jiggler is enabled, it can still interfere while the user is actively dragging a window or file. In Windows this may move the dragged window to the top-left corner or change its state unexpectedly.

Testing
- reproduced while dragging a window in Windows Explorer
- verified the cursor no longer jumps to a fixed position
- verified jiggler still produces enough movement to prevent idle

### Checklist
- [x] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the jiggler from absolute cursor jumps to randomized relative movement, which affects HID/mouse-report behavior and could vary across OS/drivers. Scope is small and isolated to the jiggler path.
> 
> **Overview**
> Updates the mouse jiggler to send **tiny randomized relative movements** (±1–3 px in each axis) instead of fixed absolute positioning and a subsequent reset.
> 
> This reduces interference with active user interactions (e.g., dragging) while still generating enough motion to prevent idle.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ae571b913d37c4af1ef7fda37a3a0d69a733a3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->