### PR TITLE
feat(ota): include device SKU in update requests

### DIFF
--- a/hw.go
+++ b/hw.go
@@ -80,6 +80,21 @@ func GetDeviceID() string {
 	return deviceID
 }
 
+var deviceSKU string
+var deviceSKUOnce sync.Once
+
+func GetDeviceSKU() string {
+	deviceSKUOnce.Do(func() {
+		content, err := os.ReadFile("/etc/jetkvm-sku")
+		if err != nil || strings.TrimSpace(string(content)) == "" {
+			deviceSKU = "jetkvm-v2"
+		} else {
+			deviceSKU = strings.TrimSpace(string(content))
+		}
+	})
+	return deviceSKU
+}
+
 func GetDefaultHostname() string {
 	deviceId := GetDeviceID()
 	if deviceId == "unknown_device_id" {

--- a/internal/ota/ota.go
+++ b/internal/ota/ota.go
@@ -42,6 +42,9 @@ func (s *State) getUpdateURL(params UpdateParams) (string, error, bool) {
 	query := updateURL.Query()
 	query.Set("deviceId", params.DeviceID)
 	query.Set("prerelease", fmt.Sprintf("%v", params.IncludePreRelease))
+	if params.SKU != "" {
+		query.Set("sku", params.SKU)
+	}
 
 	// set the custom versions if they are specified
 	for component, constraint := range params.Components {
@@ -305,6 +308,7 @@ func (s *State) doUpdate(ctx context.Context, params UpdateParams) error {
 // UpdateParams represents the parameters for the update
 type UpdateParams struct {
 	DeviceID          string            `json:"deviceID"`
+	SKU               string            `json:"sku"`
 	Components        map[string]string `json:"components"`
 	IncludePreRelease bool              `json:"includePreRelease"`
 	ResetConfig       bool              `json:"resetConfig"`

--- a/main.go
+++ b/main.go
@@ -155,6 +155,7 @@ func Main() {
 			includePreRelease := config.IncludePreRelease
 			err = otaState.TryUpdate(context.Background(), ota.UpdateParams{
 				DeviceID:          GetDeviceID(),
+				SKU:               GetDeviceSKU(),
 				IncludePreRelease: includePreRelease,
 			})
 			if err != nil {

--- a/ota.go
+++ b/ota.go
@@ -94,6 +94,7 @@ func GetLocalVersion() (systemVersion *semver.Version, appVersion *semver.Versio
 func getUpdateStatus(includePreRelease bool) (*ota.UpdateStatus, error) {
 	updateStatus, err := otaState.GetUpdateStatus(context.Background(), ota.UpdateParams{
 		DeviceID:          GetDeviceID(),
+		SKU:               GetDeviceSKU(),
 		IncludePreRelease: includePreRelease,
 		RequestID:         uuid.New().String(),
 	})
@@ -169,6 +170,7 @@ func rpcTryUpdate() error {
 func rpcCheckUpdateComponents(params updateParams, includePreRelease bool) (*ota.UpdateStatus, error) {
 	updateParams := ota.UpdateParams{
 		DeviceID:          GetDeviceID(),
+		SKU:               GetDeviceSKU(),
 		IncludePreRelease: includePreRelease,
 		Components:        params.Components,
 	}
@@ -182,6 +184,7 @@ func rpcCheckUpdateComponents(params updateParams, includePreRelease bool) (*ota
 func rpcTryUpdateComponents(params updateParams, includePreRelease bool, resetConfig bool) error {
 	updateParams := ota.UpdateParams{
 		DeviceID:          GetDeviceID(),
+		SKU:               GetDeviceSKU(),
 		IncludePreRelease: includePreRelease,
 		ResetConfig:       resetConfig,
 		Components:        params.Components,


### PR DESCRIPTION
Read /etc/jetkvm-sku at startup and pass the value as a sku query parameter when checking for OTA updates, enabling the cloud API to serve variant-specific firmware for jetkvm-v2 (eMMC) and jetkvm-v2-sdmmc hardware. Falls back to "jetkvm-v2" when the file is absent for backwards compatibility.

Please go to the `Preview` tab :point_up: and select the appropriate sub-template:

* [Feature](?expand=1&template=feature.md)
* [Bugfix](?expand=1&template=bugfix.md)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes OTA update-check request semantics by adding a new `sku` query parameter derived from device filesystem state, which could affect update eligibility/targeting if misread or misconfigured. Fallback behavior reduces risk, but cloud/server expectations and rollout should be validated.
> 
> **Overview**
> Adds device SKU detection via `GetDeviceSKU()` (reads `/etc/jetkvm-sku`, defaults to `jetkvm-v2`) and threads it through OTA flows.
> 
> OTA update URL generation now includes an optional `sku` query parameter, and all update checks/trigger paths (auto-update loop and RPC-driven status/update calls) populate `ota.UpdateParams.SKU` so the release API can serve variant-specific firmware.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03d0e7a587726075df120a7fc5e3fcf8a783b887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->