### PR TITLE
feat(release): upload app binary per SKU to R2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,12 @@ REVISION  := $(shell git rev-parse HEAD)
 VERSION := 0.5.8
 VERSION_DEV := $(VERSION)-dev$(shell date -u +%Y%m%d%H%M)
 
+# SKUs the app binary must be published under in R2. The binary is currently
+# identical across SKUs but the cloud-api releases endpoint resolves
+# artifacts per SKU (app/<version>/skus/<sku>/jetkvm_app). Keep in sync with
+# KNOWN_SKUS in cloud-api/scripts/sync-releases.ts.
+APP_SKUS := jetkvm-v2 jetkvm-v2-sdmmc
+
 PROMETHEUS_TAG := github.com/prometheus/common/version
 KVM_PKG_NAME := github.com/jetkvm/kvm
 
@@ -280,11 +286,29 @@ dev_release: git_check_dev check_r2
 	@echo "───────────────────────────────────────────────────────"
 	@echo "  All tests completed. Everything is tested and ready for release."
 	@echo "  Version:   $(VERSION_DEV)"
-	@read -p "Are you sure you want to continue? [y/N] " final_confirm && [ "$$final_confirm" = "y" ] || exit 1
-	@echo "Uploading device app to R2..."
 	@shasum -a 256 bin/jetkvm_app | cut -d ' ' -f 1 > bin/jetkvm_app.sha256
-	rclone copyto bin/jetkvm_app r2://jetkvm-update/app/$(VERSION_DEV)/jetkvm_app
-	rclone copyto bin/jetkvm_app.sha256 r2://jetkvm-update/app/$(VERSION_DEV)/jetkvm_app.sha256
+	@app_hash=$$(cat bin/jetkvm_app.sha256); \
+	echo ""; \
+	echo "═══════════════════════════════════════════════════════"; \
+	echo "  R2 Upload"; \
+	echo "═══════════════════════════════════════════════════════"; \
+	echo "  Destination: r2://jetkvm-update/app/$(VERSION_DEV)/skus/<sku>/"; \
+	echo "  SHA256:      $$app_hash"; \
+	echo "  Files to upload:"; \
+	for sku in $(APP_SKUS); do \
+		echo "    - $$sku"; \
+		echo "        bin/jetkvm_app        -> r2://jetkvm-update/app/$(VERSION_DEV)/skus/$$sku/jetkvm_app"; \
+		echo "        bin/jetkvm_app.sha256 -> r2://jetkvm-update/app/$(VERSION_DEV)/skus/$$sku/jetkvm_app.sha256"; \
+	done; \
+	echo "═══════════════════════════════════════════════════════"; \
+	echo ""
+	@read -p "The R2 upload is prepared. These are the files. Do you want to continue? [y/N] " final_confirm && [ "$$final_confirm" = "y" ] || exit 1
+	@echo "Uploading device app to R2 (skus: $(APP_SKUS))..."
+	@for sku in $(APP_SKUS); do \
+		echo "  -> $$sku"; \
+		rclone copyto bin/jetkvm_app r2://jetkvm-update/app/$(VERSION_DEV)/skus/$$sku/jetkvm_app || exit 1; \
+		rclone copyto bin/jetkvm_app.sha256 r2://jetkvm-update/app/$(VERSION_DEV)/skus/$$sku/jetkvm_app.sha256 || exit 1; \
+	done
 	./scripts/deploy_cloud_app.sh -v $(VERSION_DEV) --skip-confirmation
 	@git tag release/$(VERSION_DEV)
 	@git push origin release/$(VERSION_DEV)
@@ -330,7 +354,7 @@ release: git_check_dev check_r2
 		exit 1; \
 	fi
 	$(MAKE) check_signing_key SIGNING_KEY_FPR=$(SIGNING_KEY_FPR)
-	@if rclone lsf r2://jetkvm-update/app/$(VERSION)/ 2>/dev/null | grep -q "jetkvm_app"; then \
+	@if rclone lsf r2://jetkvm-update/app/$(VERSION)/ 2>/dev/null | grep -q .; then \
 		echo "Error: Version $(VERSION) already exists in R2"; exit 1; \
 	fi
 	@latest_dev=$$(curl -s "https://api.jetkvm.com/releases?deviceId=123&prerelease=true" | jq -r '.appVersion // ""'); \
@@ -358,13 +382,33 @@ release: git_check_dev check_r2
 	@echo "───────────────────────────────────────────────────────"
 	@echo "  All tests completed. Everything is tested and ready for release."
 	@echo "  Version:   $(VERSION)"
-	@read -p "Are you sure you want to continue? [y/N] " final_confirm && [ "$$final_confirm" = "y" ] || exit 1
-
-	@echo "Uploading device app to R2..."
 	@shasum -a 256 bin/jetkvm_app | cut -d ' ' -f 1 > bin/jetkvm_app.sha256
-	rclone copyto bin/jetkvm_app r2://jetkvm-update/app/$(VERSION)/jetkvm_app
-	rclone copyto bin/jetkvm_app.sha256 r2://jetkvm-update/app/$(VERSION)/jetkvm_app.sha256
-	rclone copyto bin/jetkvm_app.sig r2://jetkvm-update/app/$(VERSION)/jetkvm_app.sig
+	@app_hash=$$(cat bin/jetkvm_app.sha256); \
+	echo ""; \
+	echo "═══════════════════════════════════════════════════════"; \
+	echo "  R2 Upload (PRODUCTION, signed)"; \
+	echo "═══════════════════════════════════════════════════════"; \
+	echo "  Destination: r2://jetkvm-update/app/$(VERSION)/skus/<sku>/"; \
+	echo "  SHA256:      $$app_hash"; \
+	echo "  Signing key: $(SIGNING_KEY_FPR)"; \
+	echo "  Files to upload:"; \
+	for sku in $(APP_SKUS); do \
+		echo "    - $$sku"; \
+		echo "        bin/jetkvm_app        -> r2://jetkvm-update/app/$(VERSION)/skus/$$sku/jetkvm_app"; \
+		echo "        bin/jetkvm_app.sha256 -> r2://jetkvm-update/app/$(VERSION)/skus/$$sku/jetkvm_app.sha256"; \
+		echo "        bin/jetkvm_app.sig    -> r2://jetkvm-update/app/$(VERSION)/skus/$$sku/jetkvm_app.sig"; \
+	done; \
+	echo "═══════════════════════════════════════════════════════"; \
+	echo ""
+	@read -p "The R2 upload is prepared. These are the files. Do you want to continue? [y/N] " final_confirm && [ "$$final_confirm" = "y" ] || exit 1
+
+	@echo "Uploading device app to R2 (skus: $(APP_SKUS))..."
+	@for sku in $(APP_SKUS); do \
+		echo "  -> $$sku"; \
+		rclone copyto bin/jetkvm_app r2://jetkvm-update/app/$(VERSION)/skus/$$sku/jetkvm_app || exit 1; \
+		rclone copyto bin/jetkvm_app.sha256 r2://jetkvm-update/app/$(VERSION)/skus/$$sku/jetkvm_app.sha256 || exit 1; \
+		rclone copyto bin/jetkvm_app.sig r2://jetkvm-update/app/$(VERSION)/skus/$$sku/jetkvm_app.sig || exit 1; \
+	done
 	./scripts/deploy_cloud_app.sh -v $(VERSION) --set-as-default --skip-confirmation
 	@git tag release/$(VERSION)
 	@git push origin release/$(VERSION)


### PR DESCRIPTION
## Summary

The cloud-api releases endpoint and its DB sync script were updated to resolve OTA artifacts per SKU under `app/<version>/skus/<sku>/`, and `rv1106-system` already uploads its system images that way for `jetkvm-v2` and `jetkvm-v2-sdmmc`. The app binary in this repo is currently identical across both SKUs but it still needs to live under each SKU folder so the cloud-api can serve it.

- Add `APP_SKUS := jetkvm-v2 jetkvm-v2-sdmmc` near the top of the Makefile (kept in sync with `KNOWN_SKUS` in `cloud-api/scripts/sync-releases.ts`).
- `dev_release`: upload `jetkvm_app` and `jetkvm_app.sha256` to `app/<version>/skus/<sku>/` for each entry in `APP_SKUS`.
- `release`: same per-SKU loop, plus `jetkvm_app.sig`.
- Show the planned R2 destination paths (per SKU) and SHA256 in the final pre-upload confirmation prompt, mirroring `rv1106-system`'s `release_r2.sh`.
- Relax the version-already-exists pre-flight check (`rclone lsf … | grep -q .`) so it catches the new `skus/` subfolder layout.

No changes to `internal/ota/ota.go`, `hw.go`, or the e2e mock update server were needed — the device already sends `sku` (from `/etc/jetkvm-sku`) when querying the cloud-api, and the e2e tests are hermetic.

## Test plan

- [x] `make -n dev_release` shows per-SKU `rclone copyto` commands targeting `…/skus/jetkvm-v2/…` and `…/skus/jetkvm-v2-sdmmc/…`, plus the formatted destination prompt
- [x] `make -n release` shows per-SKU uploads of `jetkvm_app`, `jetkvm_app.sha256`, and `jetkvm_app.sig`, with the PRODUCTION-flavoured prompt and signing key fingerprint
- [ ] Run an actual `make dev_release` against a throwaway version and verify `rclone lsf -R r2://jetkvm-update/app/<version>/` shows both `skus/jetkvm-v2/` and `skus/jetkvm-v2-sdmmc/` with matching SHA256
- [ ] `curl 'https://api.jetkvm.com/releases?deviceId=test&prerelease=true&sku=jetkvm-v2-sdmmc'` returns the new dev version, with `appUrl` pointing at the `skus/jetkvm-v2-sdmmc/` path
- [ ] Run cloud-api's `npm run sync-releases` against staging — both SKUs should appear as artifacts on the new release row

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation to publish artifacts under per-SKU R2 paths and alters the “version already exists” guard; a mistake here could break OTA artifact resolution or accidentally overwrite/duplicate release uploads.
> 
> **Overview**
> Release automation now publishes `jetkvm_app` artifacts **per SKU** in R2 under `app/<version>/skus/<sku>/...`, driven by a new `APP_SKUS` list.
> 
> Both `dev_release` and `release` switch from single uploads to a per-SKU loop (including `.sig` for production), print the planned destination paths and SHA256 in the final confirmation prompt, and the production preflight check now treats *any* existing objects under `app/<version>/` as an existing release (to account for the new `skus/` layout).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bd0bac31e7be2f01c8e6c6f8a2b48529fe0e198a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->