### PR TITLE
fix(video): disable H.265 on Linux to avoid undecodable streams

### DIFF
--- a/ui/src/routes/devices.$id.settings.video.tsx
+++ b/ui/src/routes/devices.$id.settings.video.tsx
@@ -10,6 +10,7 @@ import { SelectMenuBasic } from "@components/SelectMenuBasic";
 import { NestedSettingsGroup } from "@components/NestedSettingsGroup";
 import Fieldset from "@components/Fieldset";
 import notifications from "@/notifications";
+import { isLinuxDesktop } from "@/utils";
 import { m } from "@localizations/messages.js";
 
 const defaultEdid =
@@ -54,6 +55,10 @@ const allCodecOptions = [
 ];
 
 const h265Supported = (() => {
+  // Linux browsers frequently advertise H.265 they cannot actually decode,
+  // leaving users stuck on a black "Loading video stream..." screen. See
+  // jetkvm/kvm#1413.
+  if (isLinuxDesktop()) return false;
   const caps = RTCRtpReceiver.getCapabilities?.("video");
   return caps?.codecs.some(c => c.mimeType === "video/H265") ?? false;
 })();

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -58,6 +58,7 @@ import { m } from "@localizations/messages.js";
 import { doRpcHidHandshake, useHidRpc } from "@hooks/useHidRpc";
 import useKeyboard from "@hooks/useKeyboard";
 import { registerTestHandlers, cleanupTestHooks } from "@/test/testHooks";
+import { isLinuxDesktop } from "@/utils";
 
 export type AuthMode = "password" | "noPassword" | null;
 
@@ -107,6 +108,31 @@ const cloudLoader = async (params: Params<string>): Promise<CloudLoaderResp> => 
 const loader: LoaderFunction = ({ params }: LoaderFunctionArgs) => {
   return isOnDevice ? deviceLoader() : cloudLoader(params);
 };
+
+/**
+ * Removes H.265 from each video transceiver's preferred codec list so the
+ * generated SDP offer does not advertise it. Called immediately before
+ * createOffer() on Linux only — see jetkvm/kvm#1413 for context.
+ */
+function stripH265FromVideoTransceivers(pc: RTCPeerConnection) {
+  try {
+    const caps = RTCRtpReceiver.getCapabilities?.("video");
+    if (!caps) return;
+    const filtered = caps.codecs.filter(c => c.mimeType !== "video/H265");
+    if (filtered.length === caps.codecs.length) return;
+
+    for (const t of pc.getTransceivers()) {
+      // addTransceiver("video", ...) populates receiver.track with kind "video".
+      if (t.receiver.track?.kind !== "video") continue;
+      t.setCodecPreferences(filtered);
+    }
+    console.debug(
+      "[setupPeerConnection] Linux: stripped H.265 from video codec preferences",
+    );
+  } catch (e) {
+    console.warn("[setupPeerConnection] setCodecPreferences failed", e);
+  }
+}
 
 export default function KvmIdRoute() {
   const loaderResp = useLoaderData();
@@ -466,6 +492,10 @@ export default function KvmIdRoute() {
       try {
         console.debug("[setupPeerConnection] Creating offer");
         makingOffer.current = true;
+
+        if (isLinuxDesktop()) {
+          stripH265FromVideoTransceivers(pc);
+        }
 
         const offer = await pc.createOffer();
         await pc.setLocalDescription(offer);

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -247,6 +247,25 @@ export function isChromeOS() {
   return !!navigator.userAgent.match(" CrOS ");
 }
 
+/**
+ * Linux desktop browsers, excluding Android and ChromeOS.
+ *
+ * Used to gate H.265 support: many Linux browsers advertise H.265 in
+ * `RTCRtpReceiver.getCapabilities()` and in their SDP offers but cannot
+ * actually decode the stream (Chrome on NVIDIA proprietary, Brave/Chromium
+ * on Wayland, Firefox on most Linux setups), leaving users stuck on the
+ * "Loading video stream..." screen. See jetkvm/kvm#1413.
+ */
+export function isLinuxDesktop() {
+  const uaData = (navigator as Navigator & {
+    userAgentData?: { platform?: string };
+  }).userAgentData;
+
+  if (uaData?.platform) return uaData.platform === "Linux";
+
+  return /\bLinux\b/.test(navigator.userAgent) && !isAndroid() && !isChromeOS();
+}
+
 export function normalizeSortOrders(macros: KeySequence[]): KeySequence[] {
   return macros.map((macro, index) => ({
     ...macro,


### PR DESCRIPTION
Many Linux browsers (Chrome on NVIDIA proprietary, Brave/Chromium on Wayland, most Firefox builds) advertise H.265 in `RTCRtpReceiver.getCapabilities` and in their SDP offer but cannot actually decode the stream, leaving users stuck on a black "Loading video stream..." screen (#1413).

On Linux desktop we now hide H.265 from the codec dropdown and strip it from the video transceiver's `setCodecPreferences` immediately before `createOffer`, so the existing server-side `resolveCodec` naturally negotiates H.264 — no protocol, backend, or persisted-preference changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes WebRTC codec negotiation and UI codec selection behavior on Linux desktop, which can affect connection/setup and media compatibility. Impact is limited to a platform-gated codec filter and includes defensive try/catch logging.
> 
> **Overview**
> Prevents Linux desktop browsers from attempting H.265 playback by **removing H.265 from the video codec dropdown** when `isLinuxDesktop()` is detected.
> 
> On Linux desktop only, the WebRTC offer generation now **strips H.265 from video transceiver codec preferences** (via `setCodecPreferences`) immediately before `createOffer()`, reducing the chance of negotiating an undecodable stream.
> 
> Adds a shared `isLinuxDesktop()` utility (excluding Android/ChromeOS and using `navigator.userAgentData` when available) to gate this behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ad5f3c0cb1c5c5c07271e9e8ad3f2fc8dc19d7c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->