### PR TITLE
fix(keyboard): keep modifiers out of auto-release

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -475,6 +475,8 @@ func handleSessionRequest(
 	}
 	if currentSession != nil {
 		writeJSONRPCEvent("otherSessionConnected", nil, currentSession)
+		gadget.CancelAllAutoReleaseTimers()
+		_ = rpcKeyboardReport(0, keyboardClearStateKeys)
 		peerConn := currentSession.peerConnection
 		go func() {
 			time.Sleep(1 * time.Second)

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -157,10 +157,6 @@ func (u *UsbGadget) SetOnKeysDownChange(f func(state KeysDownState)) {
 	u.onKeysDownChange = &f
 }
 
-func (u *UsbGadget) SetOnKeepAliveReset(f func()) {
-	u.onKeepAliveReset = &f
-}
-
 // DefaultAutoReleaseDuration is the default duration for auto-release of a key.
 const DefaultAutoReleaseDuration = 100 * time.Millisecond
 
@@ -606,14 +602,6 @@ func (u *UsbGadget) KeypressReport(key byte, press bool) error {
 		default:
 			u.scheduleAutoRelease(key)
 		}
-	}
-
-	// When the device has zero held keys the browser stops its keepalive
-	// setInterval. Clear jitter-detection state so the next hold's first
-	// keepalive isn't compared against this hold's stale timestamps and
-	// rejected (which would prevent it from extending auto-release timers).
-	if state.Modifier == 0 && allZero(state.Keys) && u.onKeepAliveReset != nil {
-		(*u.onKeepAliveReset)()
 	}
 
 	return err

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -180,6 +180,9 @@ func (u *UsbGadget) scheduleAutoRelease(key byte) {
 	})
 }
 
+// cancelAutoRelease is a pure timer primitive: it stops and removes the
+// auto-release timer for key, if any. Callers wanting to also reset the
+// session's keepalive jitter state must do so explicitly (see KeypressReport).
 func (u *UsbGadget) cancelAutoRelease(key byte) {
 	u.kbdAutoReleaseLock.Lock()
 	defer unlockWithLog(&u.kbdAutoReleaseLock, u.log, "autoRelease cancelled")
@@ -188,11 +191,6 @@ func (u *UsbGadget) cancelAutoRelease(key byte) {
 		timer.Stop()
 		u.kbdAutoReleaseTimers[key] = nil
 		delete(u.kbdAutoReleaseTimers, key)
-
-		// Reset keep-alive timing when key is released
-		if u.onKeepAliveReset != nil {
-			(*u.onKeepAliveReset)()
-		}
 	}
 }
 
@@ -239,21 +237,15 @@ func (u *UsbGadget) performAutoRelease(key byte) {
 	delete(u.kbdAutoReleaseTimers, key)
 	u.kbdAutoReleaseLock.Unlock()
 
-	// Skip if already released
+	// Skip if already released. Modifier keys never reach this function:
+	// KeypressReport structurally bypasses scheduleAutoRelease for them
+	// (see #1428 fix), so we only need to scan the non-modifier key buffer.
 	state := u.GetKeysDownState()
 	alreadyReleased := true
-
-	if mask, exists := KeyCodeToMaskMap[key]; exists {
-		// Modifier keys are tracked in state.Modifier bitmask, not in state.Keys
-		if state.Modifier&mask != 0 {
+	for i := range state.Keys {
+		if state.Keys[i] == key {
 			alreadyReleased = false
-		}
-	} else {
-		for i := range state.Keys {
-			if state.Keys[i] == key {
-				alreadyReleased = false
-				break
-			}
+			break
 		}
 	}
 
@@ -598,14 +590,30 @@ func (u *UsbGadget) KeypressReport(key byte, press bool) error {
 	if err != nil && !IsHIDTemporarilyUnavailableError(err) {
 		u.log.Warn().Uint8("key", key).Bool("press", press).Msg("failed to report key")
 	}
-	isRolledOver := state.Keys[0] == hidErrorRollOver
 
-	if isRolledOver {
-		u.cancelAutoRelease(key)
-	} else if press {
-		u.scheduleAutoRelease(key)
-	} else {
-		u.cancelAutoRelease(key)
+	isRolledOver := state.Keys[0] == hidErrorRollOver
+	_, isModifier := KeyCodeToMaskMap[key]
+
+	// Modifiers don't participate in per-key auto-release. Stuck-modifier
+	// recovery is handled by browser blur (resetKeyboardState in useKeyboard.ts),
+	// WebRTC ICE close (CancelAllAutoReleaseTimers + zero-key report in webrtc.go),
+	// and onLastSessionDisconnected. Per-key auto-release was racing with normal
+	// network jitter and dropping modifiers mid-chord (issue #1428).
+	if !isModifier {
+		switch {
+		case isRolledOver, !press:
+			u.cancelAutoRelease(key)
+		default:
+			u.scheduleAutoRelease(key)
+		}
+	}
+
+	// When the device has zero held keys the browser stops its keepalive
+	// setInterval. Clear jitter-detection state so the next hold's first
+	// keepalive isn't compared against this hold's stale timestamps and
+	// rejected (which would prevent it from extending auto-release timers).
+	if state.Modifier == 0 && allZero(state.Keys) && u.onKeepAliveReset != nil {
+		(*u.onKeepAliveReset)()
 	}
 
 	return err

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -176,9 +176,6 @@ func (u *UsbGadget) scheduleAutoRelease(key byte) {
 	})
 }
 
-// cancelAutoRelease is a pure timer primitive: it stops and removes the
-// auto-release timer for key, if any. Callers wanting to also reset the
-// session's keepalive jitter state must do so explicitly (see KeypressReport).
 func (u *UsbGadget) cancelAutoRelease(key byte) {
 	u.kbdAutoReleaseLock.Lock()
 	defer unlockWithLog(&u.kbdAutoReleaseLock, u.log, "autoRelease cancelled")
@@ -233,9 +230,7 @@ func (u *UsbGadget) performAutoRelease(key byte) {
 	delete(u.kbdAutoReleaseTimers, key)
 	u.kbdAutoReleaseLock.Unlock()
 
-	// Skip if already released. Modifier keys never reach this function:
-	// KeypressReport structurally bypasses scheduleAutoRelease for them
-	// (see #1428 fix), so we only need to scan the non-modifier key buffer.
+	// Timers are only scheduled for non-modifier keys.
 	state := u.GetKeysDownState()
 	alreadyReleased := true
 	for i := range state.Keys {
@@ -590,11 +585,8 @@ func (u *UsbGadget) KeypressReport(key byte, press bool) error {
 	isRolledOver := state.Keys[0] == hidErrorRollOver
 	_, isModifier := KeyCodeToMaskMap[key]
 
-	// Modifiers don't participate in per-key auto-release. Stuck-modifier
-	// recovery is handled by browser blur (resetKeyboardState in useKeyboard.ts),
-	// WebRTC ICE close (CancelAllAutoReleaseTimers + zero-key report in webrtc.go),
-	// and onLastSessionDisconnected. Per-key auto-release was racing with normal
-	// network jitter and dropping modifiers mid-chord (issue #1428).
+	// Modifiers are tracked separately from the key buffer and must only be
+	// released by explicit state clears or matching key-up reports.
 	if !isModifier {
 		switch {
 		case isRolledOver, !press:

--- a/internal/usbgadget/usbgadget.go
+++ b/internal/usbgadget/usbgadget.go
@@ -48,6 +48,15 @@ type KeysDownState struct {
 	Keys     ByteSlice `json:"keys"`
 }
 
+func allZero(b []byte) bool {
+	for _, v := range b {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // UsbGadget is a struct that represents a USB gadget.
 type UsbGadget struct {
 	name          string

--- a/internal/usbgadget/usbgadget.go
+++ b/internal/usbgadget/usbgadget.go
@@ -48,15 +48,6 @@ type KeysDownState struct {
 	Keys     ByteSlice `json:"keys"`
 }
 
-func allZero(b []byte) bool {
-	for _, v := range b {
-		if v != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 // UsbGadget is a struct that represents a USB gadget.
 type UsbGadget struct {
 	name          string
@@ -99,7 +90,6 @@ type UsbGadget struct {
 
 	onKeyboardStateChange *func(state KeyboardState)
 	onKeysDownChange      *func(state KeysDownState)
-	onKeepAliveReset      *func()
 
 	log *zerolog.Logger
 

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -81,20 +81,14 @@ export async function sendKeypress(page: Page, keyCode: number, press: boolean):
 }
 
 /**
- * Stop the browser keepalive interval for `ms` milliseconds, then re-arm it
- * (only if keys remain held). Used by E2E tests to deterministically reproduce
- * keepalive jitter scenarios (e.g. a Wi-Fi blip mid-hold) without depending on
- * real network conditions. See useKeyboard.ts::pauseKeepAlive.
+ * Temporarily pause browser keypress keepalives while preserving held keys.
  */
 export async function pauseKeepAlive(page: Page, ms: number): Promise<void> {
-  await page.evaluate(
-    durationMs => {
-      const hooks = window.__kvmTestHooks;
-      if (!hooks) throw new Error("Test hooks not available");
-      hooks.pauseKeepAlive(durationMs);
-    },
-    ms,
-  );
+  await page.evaluate(durationMs => {
+    const hooks = window.__kvmTestHooks;
+    if (!hooks) throw new Error("Test hooks not available");
+    hooks.pauseKeepAlive(durationMs);
+  }, ms);
 }
 
 export async function tapKey(page: Page, keyCode: number, holdMs = 20): Promise<void> {

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -80,6 +80,23 @@ export async function sendKeypress(page: Page, keyCode: number, press: boolean):
   );
 }
 
+/**
+ * Stop the browser keepalive interval for `ms` milliseconds, then re-arm it
+ * (only if keys remain held). Used by E2E tests to deterministically reproduce
+ * keepalive jitter scenarios (e.g. a Wi-Fi blip mid-hold) without depending on
+ * real network conditions. See useKeyboard.ts::pauseKeepAlive.
+ */
+export async function pauseKeepAlive(page: Page, ms: number): Promise<void> {
+  await page.evaluate(
+    durationMs => {
+      const hooks = window.__kvmTestHooks;
+      if (!hooks) throw new Error("Test hooks not available");
+      hooks.pauseKeepAlive(durationMs);
+    },
+    ms,
+  );
+}
+
 export async function tapKey(page: Page, keyCode: number, holdMs = 20): Promise<void> {
   await sendKeypress(page, keyCode, true);
   await page.waitForTimeout(holdMs);

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -636,14 +636,6 @@ test.describe("Remote Host Agent", () => {
   // ═══════════════════════════════════════════
 
   test("keyboard: modifiers do not participate in per-key auto-release (10s lone hold)", async () => {
-    // Structural invariant for #1428: modifier keys must never enter
-    // kbdAutoReleaseTimers, so a lone modifier hold survives indefinitely as long
-    // as keepalives flow. Stuck-modifier recovery is handled by other mechanisms
-    // (browser blur, ICE close, last-session disconnect — see KeypressReport).
-    //
-    // This test catches any future regression that re-introduces modifier
-    // auto-release at any timeout (1s, 5s, etc.): the 10s hold would fail.
-    // Each of 3 modifier iterations holds for 10s plus overhead, so allow 60s.
     test.setTimeout(60_000);
 
     const modifiers = [
@@ -655,13 +647,8 @@ test.describe("Remote Host Agent", () => {
     for (const { hid, linux, label, maskBit } of modifiers) {
       await agent!.clearKeyboardEvents();
 
-      // Press the modifier via the regular keypress path so the browser's
-      // keepalive interval is started (matching real-user behaviour).
       await sendKeypress(sharedPage, hid, true);
 
-      // Sample device-side state and the host's evdev log every 500ms for 10s.
-      // The modifier bit must remain set in keysDownState on every sample, and
-      // no key_release events must appear in the evdev log.
       const SAMPLES = 20;
       const SAMPLE_INTERVAL = 500;
       for (let i = 0; i < SAMPLES; i++) {
@@ -680,8 +667,6 @@ test.describe("Remote Host Agent", () => {
         );
       }
 
-      // Now release explicitly. Exactly one release event, after the explicit
-      // release moment (not earlier from auto-release).
       const releaseStart = Date.now();
       await sendKeypress(sharedPage, hid, false);
       await new Promise(r => setTimeout(r, 200));
@@ -693,9 +678,6 @@ test.describe("Remote Host Agent", () => {
       expect(presses.length, `${label} should have exactly 1 press`).toBe(1);
       expect(releases.length, `${label} should have exactly 1 release`).toBe(1);
 
-      // The release happened after the explicit release call, not at any earlier
-      // auto-release deadline. release timestamp must be within ~500ms of the
-      // explicit release call (network + scheduling slack).
       const releaseLatency = releases[0].time_ms - presses[0].time_ms;
       expect(
         releaseLatency,
@@ -1214,38 +1196,22 @@ test.describe("Remote Host Agent", () => {
   // ═══════════════════════════════════════════
 
   test("regression #1428: modifier survives induced keepalive gap mid-chord", async () => {
-    // Reproduces https://github.com/jetkvm/kvm/issues/1428 deterministically.
-    //
-    // Bug: a single dropped/late keepalive (>100ms gap) caused performAutoRelease
-    // to fire for a modifier the user was still physically holding, dropping the
-    // modifier mid-chord (e.g. Shift+H in "HELLO" → "Hello"). The fix was to
-    // structurally exclude modifiers from the per-key auto-release lifecycle.
-    //
-    // We force the failure conditions via pauseKeepAlive (no real network jitter
-    // needed): hold Shift, stop the keepalive interval for 250ms (well past the
-    // 100ms auto-release timer and 225ms maxStaleness), tap 'a' inside the gap,
-    // then verify the host saw KEY.A *without* a Shift release in between.
     await agent!.clearKeyboardEvents();
 
     await sendKeypress(sharedPage, 0xe1, true); // Shift down
-    // Let the first keepalive land cleanly so device-side jitter state is established.
     await new Promise(r => setTimeout(r, 80));
 
-    // Stop the browser-side keepalive interval for 250ms. With the old buggy
-    // code this would trigger Shift auto-release at ~100ms.
+    // Exceeds the per-key auto-release deadline but stays below the session
+    // replacement/ICE cleanup paths.
     await pauseKeepAlive(sharedPage, 250);
 
-    // Inside the gap, send the chord key. If Shift has been auto-released the
-    // host receives a lowercase 'a'; with the fix the chord is intact.
     await new Promise(r => setTimeout(r, 50));
     await sendKeypress(sharedPage, 0x04, true); // A down
     await new Promise(r => setTimeout(r, 30));
     await sendKeypress(sharedPage, 0x04, false); // A up
 
-    // Wait for the keepalive interval to resume and one more tick to land.
     await new Promise(r => setTimeout(r, 250));
 
-    // Verify Shift was held continuously across the gap (no spurious release).
     const events = await agent!.getKeyboardEvents();
     const shiftPressesPreRelease = events.filter(
       ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press",
@@ -1259,13 +1225,10 @@ test.describe("Remote Host Agent", () => {
       "Shift must NOT have been auto-released during the keepalive gap (#1428)",
     ).toBe(0);
 
-    // Verify A press happened *after* the Shift press (chord ordering)
-    // and that A's evdev event arrived at all.
     const aPresses = events.filter(ev => ev.code === KEY.A && ev.type === "key_press");
     expect(aPresses.length, "A should have been pressed inside the gap").toBeGreaterThanOrEqual(1);
     expect(aPresses[0].time_ms).toBeGreaterThan(shiftPressesPreRelease[0].time_ms);
 
-    // Now release Shift explicitly and assert the expected single release.
     await sendKeypress(sharedPage, 0xe1, false);
     await new Promise(r => setTimeout(r, 200));
 
@@ -1277,45 +1240,19 @@ test.describe("Remote Host Agent", () => {
   });
 
   test("regression #1428: lone-modifier hold does not poison next hold's auto-release", async () => {
-    // Subtle correctness check for the cross-hold keepalive jitter reset.
-    //
-    // Background: with the modifier carve-out, releasing a lone modifier no longer
-    // goes through cancelAutoRelease (no timer to cancel). Without explicitly
-    // resetting the session's keepalive jitter state on empty-state, the device's
-    // lastKeepAliveArrivalTime / lastTimerResetTime stay set to the moment of the
-    // last keepalive of the modifier hold. The NEXT hold's first keepalive then
-    // looks ancient (>maxStaleness), gets rejected by handleHidRPCKeypressKeepAlive,
-    // never extends the new hold's auto-release timer, and the new key auto-releases
-    // at 100ms regardless of how long the user is physically holding it.
-    //
-    // KeypressReport now triggers onKeepAliveReset whenever the resulting
-    // keysDownState is empty (state.Modifier == 0 && allZero(state.Keys)),
-    // which is exactly the moment the browser stops its keepalive setInterval.
-    //
-    // This test catches any future refactor of cancelAutoRelease or KeypressReport
-    // that breaks the empty-state reset trigger.
     test.setTimeout(15_000);
     await agent!.clearKeyboardEvents();
 
-    // Phase 1: lone-Shift hold (no chord keys). Browser keepalive runs.
     await sendKeypress(sharedPage, 0xe1, true);
     await new Promise(r => setTimeout(r, 1000));
     await sendKeypress(sharedPage, 0xe1, false);
 
-    // Phase 2: idle long enough that without the reset, lastTimerResetTime
-    // would now be ~3s old — well past the 225ms maxStaleness window (or 500ms
-    // if the constants have been loosened).
     await new Promise(r => setTimeout(r, 3000));
 
-    // Phase 3: hold a non-modifier for 500ms. With the fix, keepalives extend the
-    // 'a' auto-release timer normally. Without the fix, the device's filter rejects
-    // every keepalive of this hold and 'a' auto-releases at ~100ms.
     await agent!.clearKeyboardEvents();
     const aPressStart = Date.now();
     await sendKeypress(sharedPage, 0x04, true);
 
-    // Sample keysDownState at intervals well past 100ms — they would all show
-    // 'a' missing if the cross-hold reset was broken.
     for (const t of [50, 150, 300, 450]) {
       await new Promise(r => setTimeout(r, t - (Date.now() - aPressStart)));
       const state = await getKeysDownState(sharedPage);
@@ -1328,8 +1265,6 @@ test.describe("Remote Host Agent", () => {
     await sendKeypress(sharedPage, 0x04, false);
     await new Promise(r => setTimeout(r, 200));
 
-    // Final assertion via evdev: exactly one release, hold duration close to 500ms
-    // (not ~100ms which would indicate premature auto-release).
     const events = await agent!.getKeyboardEvents();
     const aPresses = events.filter(ev => ev.code === KEY.A && ev.type === "key_press");
     const aReleases = events.filter(ev => ev.code === KEY.A && ev.type === "key_release");
@@ -1349,8 +1284,6 @@ test.describe("Remote Host Agent", () => {
     test.setTimeout(15_000);
     await agent!.clearKeyboardEvents();
 
-    // Phase 1: hold A long enough for keepalive timing to initialize, then stop
-    // keepalives and let the device-side auto-release produce an empty state.
     await sendKeypress(sharedPage, 0x04, true);
     await new Promise(r => setTimeout(r, 80));
     await pauseKeepAlive(sharedPage, 5000);
@@ -1370,14 +1303,13 @@ test.describe("Remote Host Agent", () => {
       )
       .toBe(true);
 
-    // Phase 2: wait past maxStaleness. If auto-release did not reset jitter
-    // state, the next hold's keepalives are rejected and B releases at ~100ms.
     await new Promise(r => setTimeout(r, 3000));
 
     await agent!.clearKeyboardEvents();
     const bPressStart = Date.now();
     await sendKeypress(sharedPage, 0x05, true);
 
+    // Keepalive timing must reset when auto-release empties the keyboard state.
     for (const t of [50, 150, 300, 450]) {
       await new Promise(r => setTimeout(r, Math.max(0, t - (Date.now() - bPressStart))));
       const state = await getKeysDownState(sharedPage);
@@ -1411,15 +1343,12 @@ test.describe("Remote Host Agent", () => {
   test("keyboard: all keys released when WebRTC session disconnects", async ({ browser }) => {
     test.setTimeout(30_000);
 
-    // Opening a new page takes over currentSession (single-session device),
-    // kicking sharedPage. We'll reconnect sharedPage at the end.
     const freshPage = await browser.newPage();
     await freshPage.goto("/", { waitUntil: "networkidle" });
     await waitForWebRTCReady(freshPage);
 
     await agent!.clearKeyboardEvents();
 
-    // Hold down a modifier (LeftShift) and a regular key (Space) without releasing
     await sendKeypress(freshPage, 0xe1, true);
     await new Promise(r => setTimeout(r, 20));
     await sendKeypress(freshPage, HID_KEY.SPACE, true);
@@ -1438,7 +1367,6 @@ test.describe("Remote Host Agent", () => {
       )
       .toBe(true);
 
-    // Verify the host received the presses before we disconnect
     await expect
       .poll(
         async () => {
@@ -1456,8 +1384,7 @@ test.describe("Remote Host Agent", () => {
       )
       .toBe(true);
 
-    // Close the peer connection directly to trigger the WebRTC disconnect clear
-    // without relying on browser blur/page-unload keyboard cleanup.
+    // Close the peer directly so browser blur/page-unload cleanup cannot satisfy the test.
     await freshPage.evaluate(() => {
       const peerConnection = (
         globalThis as typeof globalThis & {
@@ -1468,7 +1395,6 @@ test.describe("Remote Host Agent", () => {
       peerConnection.close();
     });
 
-    // Verify the host received releases for both keys
     await expect
       .poll(
         async () => {
@@ -1488,13 +1414,10 @@ test.describe("Remote Host Agent", () => {
 
     await freshPage.close();
 
-    // Reconnect sharedPage so subsequent tests can use it
     await sharedPage.goto("/", { waitUntil: "networkidle" });
     await waitForWebRTCReady(sharedPage);
     await waitForRpcReady(sharedPage);
 
-    // Verify device-side keys-down state is clear by querying the device
-    // directly via JSON-RPC (bypasses Zustand store / hidRpc timing)
     await expect
       .poll(
         async () => {

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -12,6 +12,8 @@ import {
   HID_KEY,
   SSH_OPTS,
   callJsonRpc,
+  getKeysDownState,
+  pauseKeepAlive,
   sendKeypress,
   tapKey,
   waitForWebRTCReady,
@@ -633,31 +635,127 @@ test.describe("Remote Host Agent", () => {
   // KEYBOARD: MODIFIER AUTO-RELEASE
   // ═══════════════════════════════════════════
 
-  test("keyboard: modifier keys auto-release after timeout", async () => {
-    test.setTimeout(15_000);
+  test("keyboard: modifiers do not participate in per-key auto-release (10s lone hold)", async () => {
+    // Structural invariant for #1428: modifier keys must never enter
+    // kbdAutoReleaseTimers, so a lone modifier hold survives indefinitely as long
+    // as keepalives flow. Stuck-modifier recovery is handled by other mechanisms
+    // (browser blur, ICE close, last-session disconnect — see KeypressReport).
+    //
+    // This test catches any future regression that re-introduces modifier
+    // auto-release at any timeout (1s, 5s, etc.): the 10s hold would fail.
+    // Each of 3 modifier iterations holds for 10s plus overhead, so allow 60s.
+    test.setTimeout(60_000);
 
     const modifiers = [
-      { hid: 0xe0, linux: KEY.LEFT_CTRL, label: "LeftCtrl" },
-      { hid: 0xe1, linux: KEY.LEFT_SHIFT, label: "LeftShift" },
-      { hid: 0xe2, linux: KEY.LEFT_ALT, label: "LeftAlt" },
+      { hid: 0xe0, linux: KEY.LEFT_CTRL, label: "LeftCtrl", maskBit: 0x01 },
+      { hid: 0xe1, linux: KEY.LEFT_SHIFT, label: "LeftShift", maskBit: 0x02 },
+      { hid: 0xe2, linux: KEY.LEFT_ALT, label: "LeftAlt", maskBit: 0x04 },
     ];
 
-    for (const { hid, linux, label } of modifiers) {
+    for (const { hid, linux, label, maskBit } of modifiers) {
       await agent!.clearKeyboardEvents();
 
-      // Call keypressReport directly via JSON-RPC to bypass the browser's
-      // keepalive timer, which would otherwise extend the auto-release indefinitely.
-      await callJsonRpc(sharedPage, "keypressReport", { key: hid, press: true });
+      // Press the modifier via the regular keypress path so the browser's
+      // keepalive interval is started (matching real-user behaviour).
+      await sendKeypress(sharedPage, hid, true);
+
+      // Sample device-side state and the host's evdev log every 500ms for 10s.
+      // The modifier bit must remain set in keysDownState on every sample, and
+      // no key_release events must appear in the evdev log.
+      const SAMPLES = 20;
+      const SAMPLE_INTERVAL = 500;
+      for (let i = 0; i < SAMPLES; i++) {
+        await new Promise(r => setTimeout(r, SAMPLE_INTERVAL));
+
+        const state = await getKeysDownState(sharedPage);
+        expect(
+          state?.modifier ?? 0,
+          `${label} bit should be set on sample ${i + 1}/${SAMPLES} (t=${(i + 1) * SAMPLE_INTERVAL}ms)`,
+        ).toBe(maskBit);
+
+        const events = await agent!.getKeyboardEvents();
+        const releases = events.filter(ev => ev.code === linux && ev.type === "key_release");
+        expect(
+          releases.length,
+          `${label} must not auto-release (sample ${i + 1}/${SAMPLES})`,
+        ).toBe(0);
+      }
+
+      // Now release explicitly. Exactly one release event, after the explicit
+      // release moment (not earlier from auto-release).
+      const releaseStart = Date.now();
+      await sendKeypress(sharedPage, hid, false);
+      await new Promise(r => setTimeout(r, 200));
+
+      const finalEvents = await agent!.getKeyboardEvents();
+      const presses = finalEvents.filter(ev => ev.code === linux && ev.type === "key_press");
+      const releases = finalEvents.filter(ev => ev.code === linux && ev.type === "key_release");
+
+      expect(presses.length, `${label} should have exactly 1 press`).toBe(1);
+      expect(releases.length, `${label} should have exactly 1 release`).toBe(1);
+
+      // The release happened after the explicit release call, not at any earlier
+      // auto-release deadline. release timestamp must be within ~500ms of the
+      // explicit release call (network + scheduling slack).
+      const releaseLatency = releases[0].time_ms - presses[0].time_ms;
+      expect(
+        releaseLatency,
+        `${label} release should occur after the full 10s hold`,
+      ).toBeGreaterThan(SAMPLES * SAMPLE_INTERVAL - 1000);
+      expect(Date.now() - releaseStart).toBeLessThan(2000);
+    }
+  });
+
+  test("keyboard: modifier does not auto-release without browser keepalives", async () => {
+    await agent!.clearKeyboardEvents();
+
+    try {
+      await callJsonRpc(sharedPage, "keypressReport", { key: 0xe1, press: true });
+
+      await expect
+        .poll(
+          async () => {
+            const s = (await callJsonRpc(sharedPage, "getKeyDownState")) as {
+              modifier: number;
+              keys: number[];
+            };
+            return s.modifier === 0x02 && s.keys.every((k: number) => k === 0);
+          },
+          {
+            message: "LeftShift should be held after direct keypressReport",
+            timeout: 5000,
+            intervals: [100, 200, 500],
+          },
+        )
+        .toBe(true);
+
+      await expect
+        .poll(
+          async () => {
+            const events = await agent!.getKeyboardEvents();
+            return events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press");
+          },
+          {
+            message: "Host should see LeftShift press",
+            timeout: 5000,
+            intervals: [100, 200, 500],
+          },
+        )
+        .toBe(true);
+
       await new Promise(r => setTimeout(r, 300));
 
-      const events = await agent!.getKeyboardEvents();
-      const presses = events.filter(ev => ev.code === linux && ev.type === "key_press");
-      const releases = events.filter(ev => ev.code === linux && ev.type === "key_release");
+      const state = (await callJsonRpc(sharedPage, "getKeyDownState")) as {
+        modifier: number;
+        keys: number[];
+      };
+      expect(state.modifier, "LeftShift should still be held without keepalives").toBe(0x02);
 
-      expect(presses.length, `${label} press should be received`).toBeGreaterThanOrEqual(1);
-      expect(releases.length, `${label} should auto-release after timeout`).toBeGreaterThanOrEqual(
-        1,
-      );
+      const events = await agent!.getKeyboardEvents();
+      const releases = events.filter(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release");
+      expect(releases.length, "LeftShift must not auto-release without keepalives").toBe(0);
+    } finally {
+      await callJsonRpc(sharedPage, "keypressReport", { key: 0xe1, press: false }).catch(() => {});
     }
   });
 
@@ -739,6 +837,51 @@ test.describe("Remote Host Agent", () => {
     const focusEvents = await agent!.getKeyboardEvents();
     const stuckPresses = focusEvents.filter(ev => ev.type === "key_press");
     expect(stuckPresses.length, "No stuck keys after re-focus").toBe(0);
+  });
+
+  test("keepalive: window blur clears lone modifier", async () => {
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe1, true);
+    await expect
+      .poll(
+        async () => {
+          const state = await getKeysDownState(sharedPage);
+          return state?.modifier === 0x02;
+        },
+        {
+          message: "LeftShift should be held before blur",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
+
+    await sharedPage.evaluate(() => {
+      const target = globalThis as typeof globalThis & {
+        dispatchEvent: (event: Event) => boolean;
+      };
+      target.dispatchEvent(new Event("blur"));
+    });
+
+    await expect
+      .poll(
+        async () => {
+          const state = await getKeysDownState(sharedPage);
+          const events = await agent!.getKeyboardEvents();
+          return (
+            state?.modifier === 0 &&
+            state.keys.every((k: number) => k === 0) &&
+            events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release")
+          );
+        },
+        {
+          message: "Window blur should clear LeftShift",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
   });
 
   test("keepalive: arrow key held for 500ms is not prematurely released", async () => {
@@ -1068,6 +1211,143 @@ test.describe("Remote Host Agent", () => {
   });
 
   // ═══════════════════════════════════════════
+  // KEYBOARD: ISSUE #1428 REGRESSION TESTS
+  // ═══════════════════════════════════════════
+
+  test("regression #1428: modifier survives induced keepalive gap mid-chord", async () => {
+    // Reproduces https://github.com/jetkvm/kvm/issues/1428 deterministically.
+    //
+    // Bug: a single dropped/late keepalive (>100ms gap) caused performAutoRelease
+    // to fire for a modifier the user was still physically holding, dropping the
+    // modifier mid-chord (e.g. Shift+H in "HELLO" → "Hello"). The fix was to
+    // structurally exclude modifiers from the per-key auto-release lifecycle.
+    //
+    // We force the failure conditions via pauseKeepAlive (no real network jitter
+    // needed): hold Shift, stop the keepalive interval for 250ms (well past the
+    // 100ms auto-release timer and 225ms maxStaleness), tap 'a' inside the gap,
+    // then verify the host saw KEY.A *without* a Shift release in between.
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe1, true); // Shift down
+    // Let the first keepalive land cleanly so device-side jitter state is established.
+    await new Promise(r => setTimeout(r, 80));
+
+    // Stop the browser-side keepalive interval for 250ms. With the old buggy
+    // code this would trigger Shift auto-release at ~100ms.
+    await pauseKeepAlive(sharedPage, 250);
+
+    // Inside the gap, send the chord key. If Shift has been auto-released the
+    // host receives a lowercase 'a'; with the fix the chord is intact.
+    await new Promise(r => setTimeout(r, 50));
+    await sendKeypress(sharedPage, 0x04, true); // A down
+    await new Promise(r => setTimeout(r, 30));
+    await sendKeypress(sharedPage, 0x04, false); // A up
+
+    // Wait for the keepalive interval to resume and one more tick to land.
+    await new Promise(r => setTimeout(r, 250));
+
+    // Verify Shift was held continuously across the gap (no spurious release).
+    const events = await agent!.getKeyboardEvents();
+    const shiftPressesPreRelease = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press",
+    );
+    const shiftReleasesPreRelease = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    expect(shiftPressesPreRelease.length, "Shift pressed exactly once").toBe(1);
+    expect(
+      shiftReleasesPreRelease.length,
+      "Shift must NOT have been auto-released during the keepalive gap (#1428)",
+    ).toBe(0);
+
+    // Verify A press happened *after* the Shift press (chord ordering)
+    // and that A's evdev event arrived at all.
+    const aPresses = events.filter(ev => ev.code === KEY.A && ev.type === "key_press");
+    expect(aPresses.length, "A should have been pressed inside the gap").toBeGreaterThanOrEqual(1);
+    expect(aPresses[0].time_ms).toBeGreaterThan(shiftPressesPreRelease[0].time_ms);
+
+    // Now release Shift explicitly and assert the expected single release.
+    await sendKeypress(sharedPage, 0xe1, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const finalEvents = await agent!.getKeyboardEvents();
+    const shiftReleases = finalEvents.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+    expect(shiftReleases.length, "Shift should have exactly 1 release (the explicit one)").toBe(1);
+  });
+
+  test("regression #1428: lone-modifier hold does not poison next hold's auto-release", async () => {
+    // Subtle correctness check for the cross-hold keepalive jitter reset.
+    //
+    // Background: with the modifier carve-out, releasing a lone modifier no longer
+    // goes through cancelAutoRelease (no timer to cancel). Without explicitly
+    // resetting the session's keepalive jitter state on empty-state, the device's
+    // lastKeepAliveArrivalTime / lastTimerResetTime stay set to the moment of the
+    // last keepalive of the modifier hold. The NEXT hold's first keepalive then
+    // looks ancient (>maxStaleness), gets rejected by handleHidRPCKeypressKeepAlive,
+    // never extends the new hold's auto-release timer, and the new key auto-releases
+    // at 100ms regardless of how long the user is physically holding it.
+    //
+    // KeypressReport now triggers onKeepAliveReset whenever the resulting
+    // keysDownState is empty (state.Modifier == 0 && allZero(state.Keys)),
+    // which is exactly the moment the browser stops its keepalive setInterval.
+    //
+    // This test catches any future refactor of cancelAutoRelease or KeypressReport
+    // that breaks the empty-state reset trigger.
+    test.setTimeout(15_000);
+    await agent!.clearKeyboardEvents();
+
+    // Phase 1: lone-Shift hold (no chord keys). Browser keepalive runs.
+    await sendKeypress(sharedPage, 0xe1, true);
+    await new Promise(r => setTimeout(r, 1000));
+    await sendKeypress(sharedPage, 0xe1, false);
+
+    // Phase 2: idle long enough that without the reset, lastTimerResetTime
+    // would now be ~3s old — well past the 225ms maxStaleness window (or 500ms
+    // if the constants have been loosened).
+    await new Promise(r => setTimeout(r, 3000));
+
+    // Phase 3: hold a non-modifier for 500ms. With the fix, keepalives extend the
+    // 'a' auto-release timer normally. Without the fix, the device's filter rejects
+    // every keepalive of this hold and 'a' auto-releases at ~100ms.
+    await agent!.clearKeyboardEvents();
+    const aPressStart = Date.now();
+    await sendKeypress(sharedPage, 0x04, true);
+
+    // Sample keysDownState at intervals well past 100ms — they would all show
+    // 'a' missing if the cross-hold reset was broken.
+    for (const t of [50, 150, 300, 450]) {
+      await new Promise(r => setTimeout(r, t - (Date.now() - aPressStart)));
+      const state = await getKeysDownState(sharedPage);
+      expect(
+        state?.keys?.includes(0x04) ?? false,
+        `'a' should still be held in keysDownState at t+${t}ms (cross-hold reset working)`,
+      ).toBe(true);
+    }
+
+    await sendKeypress(sharedPage, 0x04, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    // Final assertion via evdev: exactly one release, hold duration close to 500ms
+    // (not ~100ms which would indicate premature auto-release).
+    const events = await agent!.getKeyboardEvents();
+    const aPresses = events.filter(ev => ev.code === KEY.A && ev.type === "key_press");
+    const aReleases = events.filter(ev => ev.code === KEY.A && ev.type === "key_release");
+    expect(aPresses.length, "A pressed exactly once").toBe(1);
+    expect(
+      aReleases.length,
+      "A should have exactly one release (no premature auto-release)",
+    ).toBe(1);
+
+    const holdDuration = aReleases[0].time_ms - aPresses[0].time_ms;
+    expect(
+      holdDuration,
+      "A should be held for ~500ms — premature release at ~100ms means cross-hold reset is broken",
+    ).toBeGreaterThanOrEqual(400);
+  });
+
+  // ═══════════════════════════════════════════
   // KEYBOARD: KEYS RELEASED ON DISCONNECT
   // ═══════════════════════════════════════════
 
@@ -1086,36 +1366,70 @@ test.describe("Remote Host Agent", () => {
     await sendKeypress(freshPage, 0xe1, true);
     await new Promise(r => setTimeout(r, 20));
     await sendKeypress(freshPage, HID_KEY.SPACE, true);
-    await new Promise(r => setTimeout(r, 50));
+
+    await expect
+      .poll(
+        async () => {
+          const state = await getKeysDownState(freshPage);
+          return state?.modifier === 0x02 && state.keys.includes(HID_KEY.SPACE);
+        },
+        {
+          message: "LeftShift and Space should be held before disconnect",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
 
     // Verify the host received the presses before we disconnect
-    const preEvents = await agent!.getKeyboardEvents();
-    const shiftPresses = preEvents.filter(
-      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press",
-    );
-    expect(shiftPresses.length, "Host should see LeftShift press").toBeGreaterThanOrEqual(1);
+    await expect
+      .poll(
+        async () => {
+          const events = await agent!.getKeyboardEvents();
+          return (
+            events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press") &&
+            events.some(ev => ev.code === KEY.SPACE && ev.type === "key_press")
+          );
+        },
+        {
+          message: "Host should see LeftShift and Space presses",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
 
-    // Close the page to sever the WebRTC session, triggering the all-keys-up report
-    await freshPage.close();
-    await new Promise(r => setTimeout(r, 1000));
+    // Close the peer connection directly to trigger the WebRTC disconnect clear
+    // without relying on browser blur/page-unload keyboard cleanup.
+    await freshPage.evaluate(() => {
+      const peerConnection = (
+        globalThis as typeof globalThis & {
+          __kvmTestHooks?: { _getPeerConnection?: () => { close: () => void } | null };
+        }
+      ).__kvmTestHooks?._getPeerConnection?.();
+      if (!peerConnection) throw new Error("Peer connection not available");
+      peerConnection.close();
+    });
 
     // Verify the host received releases for both keys
-    const allEvents = await agent!.getKeyboardEvents();
-    const shiftReleases = allEvents.filter(
-      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
-    );
-    const spaceReleases = allEvents.filter(
-      ev => ev.code === KEY.SPACE && ev.type === "key_release",
-    );
+    await expect
+      .poll(
+        async () => {
+          const events = await agent!.getKeyboardEvents();
+          return (
+            events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release") &&
+            events.some(ev => ev.code === KEY.SPACE && ev.type === "key_release")
+          );
+        },
+        {
+          message: "Host should see LeftShift and Space releases after disconnect",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
 
-    expect(
-      shiftReleases.length,
-      "Host should see LeftShift release after disconnect",
-    ).toBeGreaterThanOrEqual(1);
-    expect(
-      spaceReleases.length,
-      "Host should see Space release after disconnect",
-    ).toBeGreaterThanOrEqual(1);
+    await freshPage.close();
 
     // Reconnect sharedPage so subsequent tests can use it
     await sharedPage.goto("/", { waitUntil: "networkidle" });
@@ -1645,9 +1959,7 @@ test.describe("Remote Host Agent", () => {
     }
 
     // Verify keyboard works before test
-    const preEvents = await agent!.expectKeyPress(KEY.SPACE, async () => {
-      await tapKey(sharedPage, HID_KEY.SPACE);
-    });
+    const preEvents = await waitForKeyboardReady(agent!, sharedPage);
     expect(preEvents.length, "keyboard should work before EBUSY test").toBeGreaterThan(0);
 
     // Mount ISO as CDROM

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -675,10 +675,9 @@ test.describe("Remote Host Agent", () => {
 
         const events = await agent!.getKeyboardEvents();
         const releases = events.filter(ev => ev.code === linux && ev.type === "key_release");
-        expect(
-          releases.length,
-          `${label} must not auto-release (sample ${i + 1}/${SAMPLES})`,
-        ).toBe(0);
+        expect(releases.length, `${label} must not auto-release (sample ${i + 1}/${SAMPLES})`).toBe(
+          0,
+        );
       }
 
       // Now release explicitly. Exactly one release event, after the explicit
@@ -1335,15 +1334,73 @@ test.describe("Remote Host Agent", () => {
     const aPresses = events.filter(ev => ev.code === KEY.A && ev.type === "key_press");
     const aReleases = events.filter(ev => ev.code === KEY.A && ev.type === "key_release");
     expect(aPresses.length, "A pressed exactly once").toBe(1);
-    expect(
-      aReleases.length,
-      "A should have exactly one release (no premature auto-release)",
-    ).toBe(1);
+    expect(aReleases.length, "A should have exactly one release (no premature auto-release)").toBe(
+      1,
+    );
 
     const holdDuration = aReleases[0].time_ms - aPresses[0].time_ms;
     expect(
       holdDuration,
       "A should be held for ~500ms — premature release at ~100ms means cross-hold reset is broken",
+    ).toBeGreaterThanOrEqual(400);
+  });
+
+  test("regression #1428: auto-released key does not poison next hold's auto-release", async () => {
+    test.setTimeout(15_000);
+    await agent!.clearKeyboardEvents();
+
+    // Phase 1: hold A long enough for keepalive timing to initialize, then stop
+    // keepalives and let the device-side auto-release produce an empty state.
+    await sendKeypress(sharedPage, 0x04, true);
+    await new Promise(r => setTimeout(r, 80));
+    await pauseKeepAlive(sharedPage, 5000);
+    await new Promise(r => setTimeout(r, 300));
+
+    await expect
+      .poll(
+        async () => {
+          const state = await getKeysDownState(sharedPage);
+          return state?.modifier === 0 && state.keys.every((k: number) => k === 0);
+        },
+        {
+          message: "A should auto-release to an empty device state",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
+
+    // Phase 2: wait past maxStaleness. If auto-release did not reset jitter
+    // state, the next hold's keepalives are rejected and B releases at ~100ms.
+    await new Promise(r => setTimeout(r, 3000));
+
+    await agent!.clearKeyboardEvents();
+    const bPressStart = Date.now();
+    await sendKeypress(sharedPage, 0x05, true);
+
+    for (const t of [50, 150, 300, 450]) {
+      await new Promise(r => setTimeout(r, Math.max(0, t - (Date.now() - bPressStart))));
+      const state = await getKeysDownState(sharedPage);
+      expect(
+        state?.keys?.includes(0x05) ?? false,
+        `B should still be held in keysDownState at t+${t}ms after auto-release reset`,
+      ).toBe(true);
+    }
+
+    await sendKeypress(sharedPage, 0x05, false);
+    await sendKeypress(sharedPage, 0x04, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    const bPresses = events.filter(ev => ev.code === KEY.B && ev.type === "key_press");
+    const bReleases = events.filter(ev => ev.code === KEY.B && ev.type === "key_release");
+    expect(bPresses.length, "B pressed exactly once").toBe(1);
+    expect(bReleases.length, "B should have exactly one release").toBe(1);
+
+    const holdDuration = bReleases[0].time_ms - bPresses[0].time_ms;
+    expect(
+      holdDuration,
+      "B should be held for ~500ms, not auto-release at ~100ms from stale jitter state",
     ).toBeGreaterThanOrEqual(400);
   });
 
@@ -1454,6 +1511,87 @@ test.describe("Remote Host Agent", () => {
         },
       )
       .toBe(true);
+  });
+
+  test("keyboard: held modifier released when WebRTC session is replaced", async ({ browser }) => {
+    test.setTimeout(30_000);
+
+    const oldPage = await browser.newPage();
+    let replacementPage: Page | null = null;
+
+    try {
+      await oldPage.goto("/", { waitUntil: "networkidle" });
+      await waitForWebRTCReady(oldPage);
+      await waitForRpcReady(oldPage);
+
+      await agent!.clearKeyboardEvents();
+      await callJsonRpc(oldPage, "keypressReport", { key: 0xe1, press: true });
+
+      await expect
+        .poll(
+          async () => {
+            const s = (await callJsonRpc(oldPage, "getKeyDownState")) as {
+              modifier: number;
+              keys: number[];
+            };
+            return s.modifier === 0x02 && s.keys.every((k: number) => k === 0);
+          },
+          {
+            message: "Old session should hold LeftShift before replacement",
+            timeout: 5000,
+            intervals: [100, 200, 500],
+          },
+        )
+        .toBe(true);
+
+      replacementPage = await browser.newPage();
+      await replacementPage.goto("/", { waitUntil: "networkidle" });
+      await waitForWebRTCReady(replacementPage);
+      await waitForRpcReady(replacementPage);
+
+      await expect
+        .poll(
+          async () => {
+            const events = await agent!.getKeyboardEvents();
+            return events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release");
+          },
+          {
+            message: "Replacing the session should release LeftShift",
+            timeout: 5000,
+            intervals: [200, 500],
+          },
+        )
+        .toBe(true);
+
+      await expect
+        .poll(
+          async () => {
+            const s = (await callJsonRpc(replacementPage!, "getKeyDownState")) as {
+              modifier: number;
+              keys: number[];
+            };
+            return s.modifier === 0 && s.keys.every((k: number) => k === 0);
+          },
+          {
+            message: "Keyboard state should be clear after session replacement",
+            timeout: 5000,
+            intervals: [200, 500],
+          },
+        )
+        .toBe(true);
+    } finally {
+      if (replacementPage) {
+        await callJsonRpc(replacementPage, "keypressReport", { key: 0xe1, press: false }).catch(
+          () => {},
+        );
+        await replacementPage.close().catch(() => {});
+      }
+      await oldPage.close().catch(() => {});
+
+      await sharedPage.goto("/", { waitUntil: "networkidle" });
+      await waitForWebRTCReady(sharedPage);
+      await waitForRpcReady(sharedPage);
+    }
   });
 
   // ═══════════════════════════════════════════

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -1239,6 +1239,69 @@ test.describe("Remote Host Agent", () => {
     expect(shiftReleases.length, "Shift should have exactly 1 release (the explicit one)").toBe(1);
   });
 
+  test("regression #1428: auto-released key under modifier does not poison next chord", async () => {
+    test.setTimeout(15_000);
+    await agent!.clearKeyboardEvents();
+
+    await sendKeypress(sharedPage, 0xe1, true); // Shift down
+    await new Promise(r => setTimeout(r, 80));
+    await sendKeypress(sharedPage, 0x04, true); // A down
+    await new Promise(r => setTimeout(r, 80));
+    await pauseKeepAlive(sharedPage, 5000);
+    await new Promise(r => setTimeout(r, 300));
+
+    await expect
+      .poll(
+        async () => {
+          const state = await getKeysDownState(sharedPage);
+          return state?.modifier === 0x02 && state.keys.every((k: number) => k === 0);
+        },
+        {
+          message: "A should auto-release while LeftShift remains held",
+          timeout: 5000,
+          intervals: [100, 200, 500],
+        },
+      )
+      .toBe(true);
+
+    await new Promise(r => setTimeout(r, 3000));
+
+    await agent!.clearKeyboardEvents();
+    const bPressStart = Date.now();
+    await sendKeypress(sharedPage, 0x05, true); // B down
+
+    for (const t of [50, 150, 300, 450]) {
+      await new Promise(r => setTimeout(r, Math.max(0, t - (Date.now() - bPressStart))));
+      const state = await getKeysDownState(sharedPage);
+      expect(
+        state?.modifier === 0x02 && state.keys.includes(0x05),
+        `B should still be held with LeftShift at t+${t}ms`,
+      ).toBe(true);
+    }
+
+    await sendKeypress(sharedPage, 0x05, false);
+    await sendKeypress(sharedPage, 0x04, false);
+    await sendKeypress(sharedPage, 0xe1, false);
+    await new Promise(r => setTimeout(r, 200));
+
+    const events = await agent!.getKeyboardEvents();
+    const bPresses = events.filter(ev => ev.code === KEY.B && ev.type === "key_press");
+    const bReleases = events.filter(ev => ev.code === KEY.B && ev.type === "key_release");
+    const shiftReleases = events.filter(
+      ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release",
+    );
+
+    expect(bPresses.length, "B pressed exactly once").toBe(1);
+    expect(bReleases.length, "B should have exactly one release").toBe(1);
+    expect(shiftReleases.length, "LeftShift should release only explicitly").toBe(1);
+
+    const holdDuration = bReleases[0].time_ms - bPresses[0].time_ms;
+    expect(
+      holdDuration,
+      "B should not auto-release at ~100ms under LeftShift",
+    ).toBeGreaterThanOrEqual(400);
+  });
+
   test("regression #1428: lone-modifier hold does not poison next hold's auto-release", async () => {
     test.setTimeout(15_000);
     await agent!.clearKeyboardEvents();

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -138,6 +138,23 @@ export default function useKeyboard() {
     }, KEEPALIVE_INTERVAL);
   }, [cancelKeepAlive]);
 
+  // pauseKeepAlive is a test-only helper that simulates a network gap by
+  // stopping the keepalive interval for `ms` milliseconds and then
+  // re-scheduling it (only if keys are still held). Used by E2E tests to
+  // reproduce keepalive-jitter scenarios (e.g. issue #1428) without
+  // depending on real network conditions.
+  const pauseKeepAlive = useCallback(
+    (ms: number) => {
+      cancelKeepAlive();
+      window.setTimeout(() => {
+        if (heldKeysRef.current.size > 0) {
+          scheduleKeepAlive();
+        }
+      }, ms);
+    },
+    [cancelKeepAlive, scheduleKeepAlive],
+  );
+
   // resetKeyboardState is used to reset the keyboard state to no keys pressed and no modifiers.
   // This is useful for macros, in case of client-side rollover, and when the browser loses focus
   const resetKeyboardState = useCallback(async () => {
@@ -400,5 +417,6 @@ export default function useKeyboard() {
     executeMacro,
     cleanup,
     cancelExecuteMacro,
+    pauseKeepAlive,
   };
 }

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -138,11 +138,7 @@ export default function useKeyboard() {
     }, KEEPALIVE_INTERVAL);
   }, [cancelKeepAlive]);
 
-  // pauseKeepAlive is a test-only helper that simulates a network gap by
-  // stopping the keepalive interval for `ms` milliseconds and then
-  // re-scheduling it (only if keys are still held). Used by E2E tests to
-  // reproduce keepalive-jitter scenarios (e.g. issue #1428) without
-  // depending on real network conditions.
+  // Test hook: pause keepalives while preserving the held-key set.
   const pauseKeepAlive = useCallback(
     (ms: number) => {
       cancelKeepAlive();

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -683,7 +683,7 @@ export default function KvmIdRoute() {
   const { setFailsafeMode } = useFailsafeModeStore();
 
   // Keyboard handler for E2E tests
-  const { handleKeyPress } = useKeyboard();
+  const { handleKeyPress, pauseKeepAlive } = useKeyboard();
 
   // Mouse handler for E2E tests
   const { reportAbsMouseEvent, rpcHidReady } = useHidRpc();
@@ -897,6 +897,7 @@ export default function KvmIdRoute() {
   useEffect(() => {
     registerTestHandlers({
       handleKeyPress,
+      pauseKeepAlive,
       handleAbsMouseMove,
       getKeyboardLedState: () => useHidStore.getState().keyboardLedState,
       getKeysDownState: () => useHidStore.getState().keysDownState,
@@ -910,7 +911,7 @@ export default function KvmIdRoute() {
       getPeerConnection: () => useRTCStore.getState().peerConnection,
     });
     return cleanupTestHooks;
-  }, [handleKeyPress, handleAbsMouseMove]);
+  }, [handleKeyPress, pauseKeepAlive, handleAbsMouseMove]);
 
   const outlet = useOutlet();
   const onModalClose = useCallback(() => {

--- a/ui/src/test/testHooks.ts
+++ b/ui/src/test/testHooks.ts
@@ -32,9 +32,7 @@ export interface KvmTestHooks extends TestHooksInternal {
   getKeysDownState: () => KeysDownState | null;
   sendKeypress: (key: number, press: boolean) => void;
   /**
-   * Test-only: stop the browser keepalive interval for `ms` and then re-arm it
-   * (only if keys remain held). Used to reproduce keepalive jitter scenarios
-   * (e.g. issue #1428) deterministically without depending on real network jitter.
+   * Test-only: pause keypress keepalives while preserving held keys.
    */
   pauseKeepAlive: (ms: number) => void;
   sendAbsMouseMove: (x: number, y: number, buttons: number) => void;

--- a/ui/src/test/testHooks.ts
+++ b/ui/src/test/testHooks.ts
@@ -13,6 +13,7 @@ import { KeyboardLedState, KeysDownState } from "@/hooks/stores";
 /** Internal handlers set by React components (prefixed with _ to indicate internal use) */
 interface TestHooksInternal {
   _handleKeyPress?: (key: number, press: boolean) => void;
+  _pauseKeepAlive?: (ms: number) => void;
   _handleAbsMouseMove?: (x: number, y: number, buttons: number) => void;
   _getKeyboardLedState?: () => KeyboardLedState;
   _getKeysDownState?: () => KeysDownState;
@@ -30,6 +31,12 @@ export interface KvmTestHooks extends TestHooksInternal {
   getKeyboardLedState: () => KeyboardLedState | null;
   getKeysDownState: () => KeysDownState | null;
   sendKeypress: (key: number, press: boolean) => void;
+  /**
+   * Test-only: stop the browser keepalive interval for `ms` and then re-arm it
+   * (only if keys remain held). Used to reproduce keepalive jitter scenarios
+   * (e.g. issue #1428) deterministically without depending on real network jitter.
+   */
+  pauseKeepAlive: (ms: number) => void;
   sendAbsMouseMove: (x: number, y: number, buttons: number) => void;
   sendJsonRpc: (
     method: string,
@@ -94,6 +101,14 @@ export function initTestHooks(): void {
         hooks._handleKeyPress(key, press);
       } else {
         console.warn("[E2E] sendKeypress called but no handler registered");
+      }
+    },
+
+    pauseKeepAlive: (ms: number) => {
+      if (hooks._pauseKeepAlive) {
+        hooks._pauseKeepAlive(ms);
+      } else {
+        console.warn("[E2E] pauseKeepAlive called but no handler registered");
       }
     },
 
@@ -321,6 +336,7 @@ export function initTestHooks(): void {
  */
 export function registerTestHandlers(handlers: {
   handleKeyPress: (key: number, press: boolean) => void;
+  pauseKeepAlive: (ms: number) => void;
   handleAbsMouseMove: (x: number, y: number, buttons: number) => void;
   getKeyboardLedState: () => KeyboardLedState;
   getKeysDownState: () => KeysDownState;
@@ -336,6 +352,7 @@ export function registerTestHandlers(handlers: {
   if (!window.__kvmTestHooks) return;
 
   window.__kvmTestHooks._handleKeyPress = handlers.handleKeyPress;
+  window.__kvmTestHooks._pauseKeepAlive = handlers.pauseKeepAlive;
   window.__kvmTestHooks._handleAbsMouseMove = handlers.handleAbsMouseMove;
   window.__kvmTestHooks._getKeyboardLedState = handlers.getKeyboardLedState;
   window.__kvmTestHooks._getKeysDownState = handlers.getKeysDownState;
@@ -356,6 +373,7 @@ export function cleanupTestHooks(): void {
   if (!window.__kvmTestHooks) return;
 
   window.__kvmTestHooks._handleKeyPress = undefined;
+  window.__kvmTestHooks._pauseKeepAlive = undefined;
   window.__kvmTestHooks._handleAbsMouseMove = undefined;
   window.__kvmTestHooks._getKeyboardLedState = undefined;
   window.__kvmTestHooks._getKeysDownState = undefined;

--- a/usb.go
+++ b/usb.go
@@ -9,6 +9,18 @@ import (
 
 var gadget *usbgadget.UsbGadget
 
+func keysDownStateEmpty(state usbgadget.KeysDownState) bool {
+	if state.Modifier != 0 {
+		return false
+	}
+	for _, key := range state.Keys {
+		if key != 0 {
+			return false
+		}
+	}
+	return true
+}
+
 // initUsbGadget initializes the USB gadget.
 // call it only after the config is loaded.
 func initUsbGadget() {
@@ -37,12 +49,9 @@ func initUsbGadget() {
 	gadget.SetOnKeysDownChange(func(state usbgadget.KeysDownState) {
 		if currentSession != nil {
 			currentSession.enqueueKeysDownState(state)
-		}
-	})
-
-	gadget.SetOnKeepAliveReset(func() {
-		if currentSession != nil {
-			currentSession.resetKeepAliveTime()
+			if keysDownStateEmpty(state) {
+				currentSession.resetKeepAliveTime()
+			}
 		}
 	})
 

--- a/usb.go
+++ b/usb.go
@@ -9,18 +9,6 @@ import (
 
 var gadget *usbgadget.UsbGadget
 
-func keysDownStateEmpty(state usbgadget.KeysDownState) bool {
-	if state.Modifier != 0 {
-		return false
-	}
-	for _, key := range state.Keys {
-		if key != 0 {
-			return false
-		}
-	}
-	return true
-}
-
 // initUsbGadget initializes the USB gadget.
 // call it only after the config is loaded.
 func initUsbGadget() {
@@ -49,9 +37,7 @@ func initUsbGadget() {
 	gadget.SetOnKeysDownChange(func(state usbgadget.KeysDownState) {
 		if currentSession != nil {
 			currentSession.enqueueKeysDownState(state)
-			if keysDownStateEmpty(state) {
-				currentSession.resetKeepAliveTime()
-			}
+			currentSession.resetKeepAliveTime()
 		}
 	})
 

--- a/web.go
+++ b/web.go
@@ -259,6 +259,8 @@ func handleWebRTCSession(c *gin.Context) {
 	}
 	if currentSession != nil {
 		writeJSONRPCEvent("otherSessionConnected", nil, currentSession)
+		gadget.CancelAllAutoReleaseTimers()
+		_ = rpcKeyboardReport(0, keyboardClearStateKeys)
 		peerConn := currentSession.peerConnection
 		go func() {
 			time.Sleep(1 * time.Second)


### PR DESCRIPTION
Prevent modifier keys from being released by per-key auto-release during keepalive jitter.
Adds focused E2E coverage for modifier holds, blur cleanup, and WebRTC disconnect cleanup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches device-side HID keyboard state management and session-takeover cleanup; mistakes could cause stuck/phantom keys or missed releases in active sessions.
> 
> **Overview**
> Prevents modifier keys (Shift/Ctrl/Alt/etc.) from being affected by the per-key 100ms auto-release timer by skipping timer scheduling and modifier release checks for modifiers.
> 
> Hardens session takeover paths (both local `web.go` and cloud `cloud.go`) to forcibly clear keyboard state by cancelling all pending auto-release timers and sending an all-keys-up `rpcKeyboardReport` before closing the old peer connection.
> 
> Adds test-only UI support to pause browser keypress keepalives (`pauseKeepAlive`) and expands Playwright E2E coverage for long-held modifiers, induced keepalive gaps (regression #1428), blur cleanup, disconnect cleanup, and session replacement release behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 84f0257ad64746a8a85386bceaf26a5e420a8506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->