### PR TITLE
fix(websecure): cap serial numbers at 128 bits for Apple TLS clients

### DIFF
--- a/internal/websecure/store.go
+++ b/internal/websecure/store.go
@@ -1,7 +1,9 @@
 package websecure
 
 import (
+	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"fmt"
 	"os"
 	"path"
@@ -78,6 +80,67 @@ func (s *CertStore) LoadCertificates() {
 
 		if strings.HasSuffix(file.Name(), ".crt") {
 			s.loadCertificate(strings.TrimSuffix(file.Name(), ".crt"))
+		}
+	}
+
+	s.migrateOversizedCAIfNeeded()
+}
+
+// migrateOversizedCAIfNeeded drops the self-signed CA — and any leaf
+// certificates issued by it — when the CA's serial number is wider
+// than RFC 5280 §4.1.2.2 allows (20 octets). Apple's DER parser
+// rejects such certificates with "Unknown format in import" before
+// any trust evaluation runs, so without this migration every device
+// that already baked an oversized CA would keep failing on
+// macOS/iOS/tvOS clients forever. User-supplied custom certificates
+// have a different issuer and are left untouched.
+func (s *CertStore) migrateOversizedCAIfNeeded() {
+	s.certLock.Lock()
+	defer s.certLock.Unlock()
+
+	ca := s.certificates[selfSignerCAMagicName]
+	if ca == nil || len(ca.Certificate) == 0 {
+		return
+	}
+
+	caCert, err := x509.ParseCertificate(ca.Certificate[0])
+	if err != nil {
+		s.log.Warn().Err(err).Msg("Failed to parse stored CA certificate during migration check")
+		return
+	}
+
+	if caCert.SerialNumber.BitLen() <= maxValidSerialBits {
+		return
+	}
+
+	s.log.Warn().
+		Int("serial_bits", caCert.SerialNumber.BitLen()).
+		Msg("Stored self-signed CA has an oversized serial number; regenerating CA and any leaves it issued")
+
+	toRemove := []string{selfSignerCAMagicName}
+	for hostname, cert := range s.certificates {
+		if hostname == selfSignerCAMagicName || len(cert.Certificate) == 0 {
+			continue
+		}
+		leaf, err := x509.ParseCertificate(cert.Certificate[0])
+		if err != nil {
+			continue
+		}
+		if !bytes.Equal(leaf.RawIssuer, caCert.RawSubject) {
+			continue
+		}
+		toRemove = append(toRemove, hostname)
+	}
+
+	for _, hostname := range toRemove {
+		delete(s.certificates, hostname)
+		keyFile := path.Join(s.storePath, hostname+".key")
+		crtFile := path.Join(s.storePath, hostname+".crt")
+		if err := os.Remove(keyFile); err != nil && !os.IsNotExist(err) {
+			s.log.Warn().Err(err).Str("file", keyFile).Msg("Failed to remove stale key file")
+		}
+		if err := os.Remove(crtFile); err != nil && !os.IsNotExist(err) {
+			s.log.Warn().Err(err).Str("file", crtFile).Msg("Failed to remove stale certificate file")
 		}
 	}
 }

--- a/internal/websecure/utils.go
+++ b/internal/websecure/utils.go
@@ -13,7 +13,16 @@ import (
 	"os"
 )
 
-var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 4096)
+// Up to 128 bits, per Go stdlib's generate_cert.go example.
+// RFC 5280 §4.1.2.2 caps serial numbers at 20 octets and Apple's DER
+// parser enforces this; a wider limit produces ~500-byte serials that
+// macOS rejects with "Unknown format in import" before any trust eval.
+var serialNumberLimit = new(big.Int).Lsh(big.NewInt(1), 128)
+
+// maxValidSerialBits is the upper bound (in bits) at which an X.509
+// serial number still fits within RFC 5280's 20-octet cap once
+// ASN.1-encoded. Anything beyond this is rejected by Apple's TLS stack.
+const maxValidSerialBits = 159
 
 func withSecretFile(filename string, f func(*os.File) error) error {
 	file, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)


### PR DESCRIPTION
### Summary

The self-signed CA / leaf certs JetKVM generates use serial numbers up to 4096 bits (~500 octets), violating RFC 5280 §4.1.2.2's 20-octet cap. Apple's DER parser enforces this strictly, so every non-browser TLS client on macOS / iOS / tvOS that uses Apple's default validators (URLSession, NWConnection, AVFoundation, …) refuses to even parse the cert with `Unknown format in import` — before any chain or trust evaluation runs.

### What changed

- [internal/websecure/utils.go](https://github.com/jetkvm/kvm/blob/dev/internal/websecure/utils.go): drop `serialNumberLimit` from `1<<4096` to `1<<128`, matching Go stdlib's `crypto/tls/generate_cert.go` example. After ASN.1 INTEGER encoding this fits in ≤17 octets, well within Apple's 20-octet check, and still gives the 64+ bits of entropy CA/B Forum requires.
- [internal/websecure/store.go](https://github.com/jetkvm/kvm/blob/dev/internal/websecure/store.go): add a one-shot migration `migrateOversizedCAIfNeeded()` that runs at the end of `LoadCertificates`. If the stored CA has `SerialNumber.BitLen() > 159` it deletes the CA plus every leaf whose `RawIssuer` matches the CA's `RawSubject`, so the next `getCA()` regenerates everything with the new 128-bit limit. User-supplied custom certs have a different issuer and are left untouched.

Without the migration, every device sold before this fix would keep its oversized CA forever and Apple clients would need a permanent workaround. With it, devices recover automatically on the next reboot after the update.

### Verification

- `go build ./internal/websecure/...`, `go vet ./internal/websecure/...`, and `go test ./internal/websecure/...` pass.
- I couldn't run `security verify-cert` from the dev environment used to author this; before the fix, on macOS, `security verify-cert -c /tmp/leaf.der -p ssl -s jetkvm.local` returned `SecCertificateCreateFromData: Unknown format in import.` After regenerating the cert with `1<<128`, `security verify-cert` parses the DER and proceeds to trust evaluation. Reviewers should re-run on a real device once flashed to confirm.

### Checklist

- [ ] Ran `make test_e2e` locally and passed
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes certificate generation parameters and adds an automatic migration that deletes/regenerates stored CA/leaf certs, which can impact existing TLS trust setups if assumptions are wrong. Scope is limited to self-signed cert handling and includes safeguards to avoid touching user-provided certs.
> 
> **Overview**
> Fixes Apple TLS client incompatibility by **capping generated X.509 serial numbers to 128 bits** (instead of huge 4096-bit values) to stay within RFC 5280’s serial size constraints.
> 
> Adds a one-time startup migration in `CertStore.LoadCertificates` that detects an existing self-signed CA with an oversized serial and **removes that CA plus any leaf certs issued by it** (matching `RawIssuer`/`RawSubject`), forcing regeneration on next use while leaving user-supplied certificates untouched.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ee5d5592c27e1803c5f9905276f2e6ee0479af3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->