### PR TITLE
test(e2e): preserve remote agent diagnostics

### DIFF
--- a/ui/e2e/global-teardown.ts
+++ b/ui/e2e/global-teardown.ts
@@ -21,6 +21,10 @@ export default async function globalTeardown() {
 
     const logs: Record<string, string> = {
       "device-last.log": "cat /userdata/jetkvm/last.log",
+      // Rotated by restartAppViaSSH — preserves the failing session's output
+      // when a later test restarts the app before teardown captures logs.
+      // sshExec(_, true) returns "" if the file is missing, so no shell guard needed.
+      "device-prev.log": "cat /userdata/jetkvm/last.log.prev",
       "device-config.json": "cat /userdata/kvm_config.json",
       "device-dmesg.txt": "dmesg | tail -200",
     };

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -750,8 +750,12 @@ export async function restoreSSHDevState(state: SSHDevState): Promise<void> {
 export async function restartAppViaSSH(): Promise<void> {
   await sshExec("killall jetkvm_app", true);
   await new Promise(r => setTimeout(r, 500));
+  // Rotate last.log into last.log.prev before respawning so a later teardown
+  // can still recover the previous session's output if a subsequent restart
+  // truncates the live log. Combined into one SSH call to save a round-trip.
   await sshExec(
-    "setsid env LD_LIBRARY_PATH=/oem/usr/lib:/oem/lib /userdata/jetkvm/bin/jetkvm_app > /userdata/jetkvm/last.log 2>&1 &",
+    "[ -s /userdata/jetkvm/last.log ] && mv /userdata/jetkvm/last.log /userdata/jetkvm/last.log.prev; " +
+      "setsid env LD_LIBRARY_PATH=/oem/usr/lib:/oem/lib /userdata/jetkvm/bin/jetkvm_app > /userdata/jetkvm/last.log 2>&1 &",
     true,
   );
   await new Promise(r => setTimeout(r, 1000));

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -2726,7 +2726,7 @@ test.describe("Remote Host Agent", () => {
       appVersion: string;
       systemVersion: string;
     };
-    if (!semverGte(localVersion.systemVersion, "0.2.9")) {
+    if (!semverGte(localVersion.systemVersion, "0.2.8")) {
       test.skip(true, `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`);
       return;
     }
@@ -2834,7 +2834,7 @@ test.describe("Remote Host Agent", () => {
       appVersion: string;
       systemVersion: string;
     };
-    if (!semverGte(localVersion.systemVersion, "0.2.9")) {
+    if (!semverGte(localVersion.systemVersion, "0.2.8")) {
       test.skip(true, `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`);
       return;
     }

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -429,6 +429,24 @@ test.afterAll(async () => {
   if (sharedPage) await sharedPage.close();
 });
 
+// Snapshot /userdata/jetkvm/last.log into the failing test's output dir before
+// any subsequent test reboots the device (RkLunch's `> last.log` at boot wipes
+// the log, and /oem is read-only so we can't change that). This makes the
+// capture race-free regardless of what later tests do.
+// Empty fixture destructure is required by Playwright; `_` would fail the
+// runtime "destructuring pattern" check.
+// oxlint-disable-next-line no-empty-pattern
+test.afterEach(async ({}, testInfo) => {
+  if (!agent) return;
+  if (testInfo.status === testInfo.expectedStatus) return;
+  const log = await sshExec("cat /userdata/jetkvm/last.log", true);
+  try {
+    await testInfo.attach("device-last.log", { body: log, contentType: "text/plain" });
+  } catch {
+    // attach can throw if the worker is already tearing down; sshExec(_, true) won't.
+  }
+});
+
 test.describe("Remote Host Agent", () => {
   // ═══════════════════════════════════════════
   // KEYBOARD: TOGGLE KEYS + LED ROUND-TRIP
@@ -2055,8 +2073,9 @@ test.describe("Remote Host Agent", () => {
     const postMountEvents = await waitForKeyboardReady(agent!, sharedPage);
     expect(postMountEvents.length, "keyboard should work after disk mount").toBeGreaterThan(0);
 
-    // Unmount
-    await callJsonRpc(sharedPage, "unmountImage");
+    // Unmount — Disk-mode unmount can hit the EBUSY rebind path plus NBD
+    // disconnect drain, which routinely runs past the default 10s RPC timeout.
+    await callJsonRpc(sharedPage, "unmountImage", {}, 30_000);
     const stateEnd = (await callJsonRpc(sharedPage, "getVirtualMediaState")) as null | object;
     expect(stateEnd).toBeNull();
 


### PR DESCRIPTION
## Summary
- Preserve device logs from failed remote-agent e2e runs before later restarts can truncate `last.log`.
- Add rotated `device-prev.log` collection during global teardown.
- Keep the S3 wake e2e system-version gate aligned with the supported requirement.

## Test plan
- Pre-commit hook ran `oxlint --fix --deny-warnings` and `oxfmt` for staged files.
- Not run: full Playwright e2e suite.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to Playwright E2E harness behavior (log capture, restart scripting, and test timeouts/skip gates) with no production runtime impact.
> 
> **Overview**
> Improves remote-agent E2E failure diagnostics by **making device log capture race-free across restarts**: `restartAppViaSSH` now rotates `/userdata/jetkvm/last.log` to `last.log.prev`, global teardown also collects `device-prev.log`, and `ra-all.spec.ts` attaches `device-last.log` immediately on test failure.
> 
> Stabilizes E2E behavior by extending the Disk-mode `unmountImage` JSON-RPC timeout to 30s and aligning the S3 wake tests’ system-version minimum to `0.2.8`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a8545fc2ae7499b8ce46399cf67c6d99bad78b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->