### PR TITLE
fix: align S3 wake test version gate

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -2726,7 +2726,7 @@ test.describe("Remote Host Agent", () => {
       appVersion: string;
       systemVersion: string;
     };
-    if (!semverGte(localVersion.systemVersion, "0.2.9")) {
+    if (!semverGte(localVersion.systemVersion, "0.2.8")) {
       test.skip(true, `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`);
       return;
     }
@@ -2834,7 +2834,7 @@ test.describe("Remote Host Agent", () => {
       appVersion: string;
       systemVersion: string;
     };
-    if (!semverGte(localVersion.systemVersion, "0.2.9")) {
+    if (!semverGte(localVersion.systemVersion, "0.2.8")) {
       test.skip(true, `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`);
       return;
     }


### PR DESCRIPTION
Align the S3 wake E2E version gate with the supported system version.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this only adjusts the minimum firmware version check used to skip two Playwright E2E tests, affecting test coverage/CI behavior but not production code.
> 
> **Overview**
> Lowers the firmware version gate for the S3 USB wake E2E tests in `ui/e2e/remote-agent/ra-all.spec.ts` from `0.2.9` to `0.2.8`, aligning the skip condition and message with the documented minimum supported system version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 26bd3d5ced493d982684773385aa0ac0896d79db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->