### PR TITLE
Add explicit USB wake control

### DIFF
--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -53,6 +53,7 @@ var defaultGadgetConfig = map[string]gadgetConfigItem{
 	},
 	// keyboard HID
 	"keyboard": keyboardConfig,
+	"wake_hid": wakeHIDConfig,
 	// mouse HID
 	"absolute_mouse": absoluteMouseConfig,
 	// relative mouse HID

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -23,9 +23,37 @@ var keyboardConfig = gadgetConfigItem{
 		"subclass":        "1",
 		"report_length":   "8",
 		"no_out_endpoint": "0",
-		"wakeup_on_write": "1",
+		"wakeup_on_write": "0",
 	},
 	reportDesc: keyboardReportDesc,
+}
+
+var wakeHIDConfig = gadgetConfigItem{
+	order:      1003,
+	device:     "hid.usb3",
+	path:       []string{"functions", "hid.usb3"},
+	configPath: []string{"hid.usb3"},
+	attrs: gadgetAttributes{
+		"protocol":        "0",
+		"subclass":        "0",
+		"report_length":   "1",
+		"no_out_endpoint": "1",
+		"wakeup_on_write": "1",
+	},
+	reportDesc: wakeReportDesc,
+}
+
+var wakeReportDesc = []byte{
+	0x06, 0x00, 0xff, // USAGE_PAGE (Vendor Defined 0xff00)
+	0x09, 0x01, // USAGE (1)
+	0xa1, 0x01, // COLLECTION (Application)
+	0x15, 0x00, //   LOGICAL_MINIMUM (0)
+	0x26, 0xff, 0x00, //   LOGICAL_MAXIMUM (255)
+	0x75, 0x08, //   REPORT_SIZE (8)
+	0x95, 0x01, //   REPORT_COUNT (1)
+	0x09, 0x01, //   USAGE (1)
+	0x81, 0x02, //   INPUT (Data,Var,Abs)
+	0xc0, // END_COLLECTION
 }
 
 // Source: https://www.kernel.org/doc/Documentation/usb/gadget_hid.txt
@@ -312,6 +340,13 @@ func (u *UsbGadget) closeKeyboardHidFileLocked() {
 	}
 }
 
+func (u *UsbGadget) closeWakeHidFileLocked() {
+	if u.wakeHidFile != nil {
+		u.wakeHidFile.Close()
+		u.wakeHidFile = nil
+	}
+}
+
 func (u *UsbGadget) openKeyboardHidFileLocked(forceReopen bool) error {
 	if forceReopen {
 		u.closeKeyboardHidFileLocked()
@@ -330,6 +365,22 @@ func (u *UsbGadget) openKeyboardHidFileLocked(forceReopen bool) error {
 	u.keyboardStateCancel = cancel
 	u.listenKeyboardEvents(ctx, file)
 
+	return nil
+}
+
+func (u *UsbGadget) openWakeHidFileLocked(forceReopen bool) error {
+	if forceReopen {
+		u.closeWakeHidFileLocked()
+	} else if u.wakeHidFile != nil {
+		return nil
+	}
+
+	file, err := openWithTimeout("/dev/hidg3", os.O_WRONLY, 0666, 3*time.Second)
+	if err != nil {
+		return fmt.Errorf("failed to open hidg3: %w", err)
+	}
+
+	u.wakeHidFile = file
 	return nil
 }
 
@@ -408,6 +459,24 @@ func (u *UsbGadget) keyboardWriteHidFileLocked(modifier byte, keys []byte) error
 	return nil
 }
 
+func (u *UsbGadget) wakeWriteHidFile(report byte) error {
+	u.wakeHidLock.Lock()
+	defer unlockWithLog(&u.wakeHidLock, u.log, "wakeHidFile wrote")
+
+	if err := u.openWakeHidFileLocked(false); err != nil {
+		return err
+	}
+
+	_, err := u.writeWithTimeout(u.wakeHidFile, []byte{report})
+	if err != nil {
+		u.logWithSuppression("wakeWriteHidFile", 100, u.log, err, "failed to write to hidg3")
+		u.closeWakeHidFileLocked()
+		return err
+	}
+	u.resetLogSuppressionCounter("wakeWriteHidFile")
+	return nil
+}
+
 func (u *UsbGadget) UpdateKeysDown(modifier byte, keys []byte) KeysDownState {
 	// if we just reported an error roll over, we should clear the keys
 	if keys[0] == hidErrorRollOver {
@@ -457,6 +526,14 @@ func (u *UsbGadget) KeyboardReport(modifier byte, keys []byte) error {
 	keyboardMutex.Unlock()
 
 	return err
+}
+
+func (u *UsbGadget) WakeReport(active bool) error {
+	var report byte
+	if active {
+		report = 1
+	}
+	return u.wakeWriteHidFile(report)
 }
 
 const (

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -15,7 +15,7 @@ var absoluteMouseConfig = gadgetConfigItem{
 		"subclass":        "0",
 		"report_length":   "6",
 		"no_out_endpoint": "1",
-		"wakeup_on_write": "1",
+		"wakeup_on_write": "0",
 	},
 	reportDesc: absoluteMouseCombinedReportDesc,
 }

--- a/internal/usbgadget/hid_mouse_relative.go
+++ b/internal/usbgadget/hid_mouse_relative.go
@@ -15,7 +15,7 @@ var relativeMouseConfig = gadgetConfigItem{
 		"subclass":        "1",
 		"report_length":   "5",
 		"no_out_endpoint": "1",
-		"wakeup_on_write": "1",
+		"wakeup_on_write": "0",
 	},
 	reportDesc: relativeMouseCombinedReportDesc,
 }

--- a/internal/usbgadget/usbgadget.go
+++ b/internal/usbgadget/usbgadget.go
@@ -62,6 +62,8 @@ type UsbGadget struct {
 
 	keyboardHidFile *os.File
 	keyboardLock    sync.Mutex
+	wakeHidFile     *os.File
+	wakeHidLock     sync.Mutex
 	absMouseHidFile *os.File
 	absMouseLock    sync.Mutex
 	relMouseHidFile *os.File
@@ -130,6 +132,7 @@ func newUsbGadget(name string, configMap map[string]gadgetConfigItem, enabledDev
 		customConfig:         *config,
 		configLock:           sync.Mutex{},
 		keyboardLock:         sync.Mutex{},
+		wakeHidLock:          sync.Mutex{},
 		absMouseLock:         sync.Mutex{},
 		relMouseLock:         sync.Mutex{},
 		txLock:               sync.Mutex{},
@@ -178,6 +181,10 @@ func (u *UsbGadget) Close() error {
 		u.keyboardHidFile.Close()
 		u.keyboardHidFile = nil
 	}
+	if u.wakeHidFile != nil {
+		u.wakeHidFile.Close()
+		u.wakeHidFile = nil
+	}
 	if u.absMouseHidFile != nil {
 		u.absMouseHidFile.Close()
 		u.absMouseHidFile = nil
@@ -197,6 +204,10 @@ func (u *UsbGadget) ResetHIDFiles() {
 	u.keyboardLock.Lock()
 	u.closeKeyboardHidFileLocked()
 	unlockWithLog(&u.keyboardLock, u.log, "keyboardHidFile reset")
+
+	u.wakeHidLock.Lock()
+	u.closeWakeHidFileLocked()
+	unlockWithLog(&u.wakeHidLock, u.log, "wakeHidFile reset")
 
 	u.absMouseLock.Lock()
 	if u.absMouseHidFile != nil {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -1257,6 +1257,7 @@ var rpcHandlers = map[string]RPCHandler{
 	"absMouseReport":             {Func: rpcAbsMouseReport, Params: []string{"x", "y", "buttons"}},
 	"relMouseReport":             {Func: rpcRelMouseReport, Params: []string{"dx", "dy", "buttons"}},
 	"wheelReport":                {Func: rpcWheelReport, Params: []string{"wheelY", "wheelX"}},
+	"wakeHost":                   {Func: rpcWakeHost},
 	"getVideoState":              {Func: rpcGetVideoState},
 	"getUSBState":                {Func: rpcGetUSBState},
 	"unmountImage":               {Func: rpcUnmountImage},

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -35,8 +35,6 @@ import {
   type KeyboardEvent as RAKeyboardEvent,
 } from "./remote-agent";
 
-const USB_WAKE_REMOTE_AGENT_TIMEOUT_MS = 120_000;
-
 /** Run a command on the remote host (the machine whose display is captured by the KVM). */
 function remoteHostExec(cmd: string, timeoutMs = 15000): string {
   const target = process.env.JETKVM_REMOTE_HOST;
@@ -75,22 +73,6 @@ function getRemoteHostTtyACM(): string {
   return remoteHostExec('sh -lc "ls -1 /dev/ttyACM* 2>/dev/null | head -1 || true"', 5000).trim();
 }
 
-function enableJetKVMUsbWakeOnRemoteHost(): void {
-  remoteHostExec(
-    "for d in /sys/bus/usb/devices/*/; do " +
-      '[ -f "$d/power/wakeup" ] || continue; ' +
-      'vendor=$(cat "$d/idVendor" 2>/dev/null || true); ' +
-      'product=$(cat "$d/idProduct" 2>/dev/null || true); ' +
-      'if grep -q JetKVM "$d/manufacturer" 2>/dev/null || ' +
-      'grep -q JetKVM "$d/product" 2>/dev/null || ' +
-      '{ [ "$vendor" = "1d6b" ] && [ "$product" = "0104" ]; }; then ' +
-      'echo enabled | sudo tee "$d/power/wakeup" > /dev/null; ' +
-      'p=$(dirname $(readlink -f "$d"))/power/wakeup; ' +
-      '[ -f "$p" ] && echo enabled | sudo tee "$p" > /dev/null; ' +
-      "fi; done",
-  );
-}
-
 async function waitForRemoteHostTtyACM(
   shouldExist: boolean,
   timeoutMs = 15000,
@@ -115,48 +97,6 @@ async function waitForRemoteHostTtyACM(
     shouldExist
       ? `ttyACM device did not appear on remote host within ${timeoutMs}ms`
       : `ttyACM device did not disappear from remote host within ${timeoutMs}ms`,
-  );
-}
-
-async function remoteAgentHealth(timeoutMs = 2000): Promise<boolean> {
-  return Promise.race([
-    agent!.health(),
-    new Promise<boolean>(resolve => setTimeout(() => resolve(false), timeoutMs)),
-  ]);
-}
-
-async function waitForRemoteAgentDown(timeoutMs = 30000): Promise<void> {
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    if (!(await remoteAgentHealth(1000))) return;
-    await new Promise(r => setTimeout(r, 500));
-  }
-  throw new Error(`Remote agent stayed reachable for ${timeoutMs}ms after S3 suspend request`);
-}
-
-function getRemoteHostDefaultNetworkInfo(): { iface: string; isWifi: boolean; driver: string } {
-  const output = remoteHostExec(
-    "iface=$(ip route show default 2>/dev/null | sed -n 's/.* dev \\([^ ]*\\).*/\\1/p' | head -1); " +
-      'driver=""; ' +
-      'if [ -n "$iface" ]; then ' +
-      'driver=$(basename "$(readlink -f "/sys/class/net/$iface/device/driver" 2>/dev/null)" 2>/dev/null || true); ' +
-      "fi; " +
-      'if [ -n "$iface" ] && [ -d "/sys/class/net/$iface/wireless" ]; then kind=wifi; else kind=nonwifi; fi; ' +
-      'printf "%s:%s:%s\\n" "$kind" "$iface" "$driver"',
-    5000,
-  ).trim();
-  const [kind = "", iface = "", driver = ""] = output.split(":");
-  return { iface, isWifi: kind === "wifi", driver };
-}
-
-function skipUsbWakeIfRemoteHostUsesWifi(): void {
-  const network = getRemoteHostDefaultNetworkInfo();
-  if (!network.isWifi) return;
-
-  test.skip(
-    true,
-    `S3 USB wake verification needs a stable remote-agent route after resume; ` +
-      `${network.iface} is Wi-Fi (${network.driver || "unknown driver"})`,
   );
 }
 
@@ -197,6 +137,201 @@ function remoteHostSetDPMS(off: boolean): void {
       `--object-path /org/gnome/ScreenSaver ` +
       `--method org.gnome.ScreenSaver.SetActive ${off ? "true" : "false"}`,
   );
+}
+
+function remoteHostSupportsS3(): { supported: boolean; reason?: string } {
+  let memSleep: string;
+  try {
+    memSleep = remoteHostExec("cat /sys/power/mem_sleep").trim();
+  } catch {
+    return { supported: false, reason: "Cannot read /sys/power/mem_sleep on remote host" };
+  }
+
+  if (!memSleep.includes("deep") && !memSleep.includes("[mem]")) {
+    return { supported: false, reason: `S3 deep sleep not available (mem_sleep: ${memSleep})` };
+  }
+
+  return { supported: true };
+}
+
+function enableRemoteHostUSBWake(options: { includeRootHub?: boolean } = {}): void {
+  // Keep parent/root hub wake disabled by default so the tests exercise the
+  // JetKVM wake-capable HID function instead of generic USB bus activity.
+  const enableParentHub = options.includeRootHub
+    ? 'p=$(dirname "$(readlink -f "$d")")/power/wakeup; [ -f "$p" ] && echo enabled | sudo tee "$p" > /dev/null; '
+    : "";
+
+  remoteHostExec(
+    "found=0; " +
+      "for d in /sys/bus/usb/devices/*/; do " +
+      '[ -f "$d/power/wakeup" ] && echo disabled | sudo tee "$d/power/wakeup" > /dev/null || true; ' +
+      "done; " +
+      "for d in /sys/bus/usb/devices/*/; do " +
+      'if [ -f "$d/power/wakeup" ] && cat "$d/product" "$d/manufacturer" 2>/dev/null | grep -q JetKVM; then ' +
+      'echo enabled | sudo tee "$d/power/wakeup" > /dev/null; ' +
+      enableParentHub +
+      "found=1; " +
+      "fi; done; " +
+      '[ "$found" -eq 1 ]',
+  );
+}
+
+function suspendRemoteHost(options: { wakeAfterSeconds?: number } = {}): void {
+  const suspendCommand = options.wakeAfterSeconds
+    ? `sleep 0.5 && rtcwake -m mem -s ${options.wakeAfterSeconds}`
+    : "sleep 0.5 && echo mem > /sys/power/state";
+
+  remoteHostExec(`sudo sh -c 'nohup sh -c "${suspendCommand}" >/dev/null 2>&1 &'`, 5000);
+}
+
+async function waitForHostAsleep(timeoutMs = 15000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (!(await agent!.health())) {
+      return;
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  throw new Error(`Host did not enter sleep within ${timeoutMs}ms`);
+}
+
+async function waitForHostAwake(timeoutMs = 60000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await agent!.health()) {
+      return;
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  throw new Error(`Host did not wake within ${timeoutMs}ms`);
+}
+
+async function expectHostStaysAsleep(durationMs: number, intervalMs = 2000): Promise<void> {
+  const deadline = Date.now() + durationMs;
+  while (Date.now() < deadline) {
+    expect(await agent!.health(), "Host woke while it should have stayed asleep").toBe(false);
+    await new Promise(r => setTimeout(r, intervalMs));
+  }
+}
+
+async function waitForNoSignalOverlay(page: Page, timeoutMs = 20000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const videoState = (await callJsonRpc(page, "getVideoState")) as { error?: string };
+      if (videoState.error === "no_signal") {
+        return;
+      }
+    } catch {
+      /* WebRTC may still be settling after host suspend */
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  throw new Error(`Video state did not become no_signal within ${timeoutMs}ms`);
+}
+
+async function putRemoteHostToSleepForUSBWakeTest(
+  page: Page,
+  options: { includeRootHubWake?: boolean; wakeAfterSeconds?: number } = {},
+): Promise<void> {
+  const s3 = remoteHostSupportsS3();
+  test.skip(!s3.supported, s3.reason ?? "S3 sleep not supported");
+
+  if (options.wakeAfterSeconds) {
+    try {
+      remoteHostExec("command -v rtcwake >/dev/null");
+    } catch {
+      test.skip(true, "rtcwake is not available on remote host");
+    }
+  }
+
+  const localVersion = (await callJsonRpc(page, "getLocalVersion")) as {
+    appVersion: string;
+    systemVersion: string;
+  };
+  test.skip(
+    !semverGte(localVersion.systemVersion, "0.2.8"),
+    `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`,
+  );
+
+  enableRemoteHostUSBWake({ includeRootHub: options.includeRootHubWake });
+  await waitForVideoDimensions(page, 10000);
+  expect(await agent!.health()).toBe(true);
+
+  let suspendScheduled = false;
+  try {
+    try {
+      suspendRemoteHost({ wakeAfterSeconds: options.wakeAfterSeconds });
+      suspendScheduled = true;
+    } catch {
+      /* SSH may drop during suspend, that's expected */
+      suspendScheduled = true;
+    }
+
+    await waitForHostAsleep();
+    await waitForNoSignalOverlay(page);
+  } catch (error) {
+    if (suspendScheduled && options.wakeAfterSeconds) {
+      await recoverRemoteHostAfterUSBWakeTest(page, options.wakeAfterSeconds * 1000 + 30000);
+    }
+    throw error;
+  }
+}
+
+async function recoverRemoteHostAfterUSBWakeTest(page: Page, timeoutMs = 120000): Promise<void> {
+  await waitForHostAwake(timeoutMs);
+  await page.goto("/", { waitUntil: "networkidle" });
+  await waitForWebRTCReady(page);
+  await waitForRpcReady(page);
+  await waitForVideoDimensions(page, 30000);
+}
+
+async function wakeRemoteHostWithWakeButton(page: Page, timeoutMs = 45000): Promise<void> {
+  await waitForNoSignalOverlay(page);
+  const wakeButton = page.getByRole("button", { name: /^try to wake$/i }).first();
+  await expect(wakeButton).toBeVisible({ timeout: 10000 });
+  await wakeButton.click();
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (await agent!.health()) {
+      return;
+    }
+    await new Promise(r => setTimeout(r, 1000));
+  }
+
+  throw new Error(`Host did not wake within ${timeoutMs}ms after clicking Try to wake`);
+}
+
+async function sendBrowserInputThatMustNotWakeHost(page: Page): Promise<void> {
+  await page.bringToFront();
+  await page.locator("body").click({ position: { x: 10, y: 10 }, force: true });
+
+  const video = page.locator("video").first();
+  const box = await video.boundingBox();
+  const videoX = box ? box.x + Math.max(12, box.width * 0.12) : 40;
+  const videoY = box ? box.y + Math.max(12, box.height * 0.12) : 40;
+
+  for (let i = 0; i < 8; i++) {
+    await page.mouse.move(videoX + i * 7, videoY + i * 5);
+    await page.mouse.down();
+    await page.mouse.up();
+    await page.mouse.wheel(i % 2 === 0 ? 120 : -120, i % 2 === 0 ? 0 : 120);
+    await page.keyboard.press("Space");
+    await page.keyboard.press("KeyA");
+    await page.keyboard.press("Escape");
+
+    await page.evaluate(() => {
+      window.dispatchEvent(new Event("blur"));
+      document.dispatchEvent(new Event("visibilitychange"));
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    await new Promise(r => setTimeout(r, 500));
+  }
 }
 
 const agent = createRemoteAgent();
@@ -2775,96 +2910,90 @@ test.describe("Remote Host Agent", () => {
   });
 
   // ═══════════════════════════════════════════
-  // USB REMOTE WAKEUP: S3 SUSPEND → HID WAKE
+  // USB REMOTE WAKEUP: S3 SUSPEND → EXPLICIT WAKE
   // ═══════════════════════════════════════════
 
-  test("usb-wake: S3 suspend and wake via HID keypress", async () => {
+  test("usb-wake: browser input on no-video overlay does not wake S3 host", async () => {
     test.setTimeout(180_000);
 
-    // Requires system firmware >= 0.2.8 (f_hid wakeup_on_write kernel patch)
-    const localVersion = (await callJsonRpc(sharedPage, "getLocalVersion")) as {
-      appVersion: string;
-      systemVersion: string;
-    };
-    if (!semverGte(localVersion.systemVersion, "0.2.8")) {
-      test.skip(true, `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`);
-      return;
-    }
-
-    // Check S3 deep sleep is available on the remote host
-    let memSleep: string;
-    try {
-      memSleep = remoteHostExec("cat /sys/power/mem_sleep").trim();
-    } catch {
-      test.skip(true, "Cannot read /sys/power/mem_sleep on remote host");
-      return;
-    }
-    if (!memSleep.includes("deep") && !memSleep.includes("[mem]")) {
-      test.skip(true, `S3 deep sleep not available (mem_sleep: ${memSleep})`);
-      return;
-    }
-    skipUsbWakeIfRemoteHostUsesWifi();
-
-    // Enable USB wakeup on JetKVM's USB device (and parent hub)
-    try {
-      enableJetKVMUsbWakeOnRemoteHost();
-    } catch {
-      /* best effort */
-    }
-
-    // Verify everything is working before we suspend
-    await waitForVideoDimensions(sharedPage, 10000);
-    expect(await agent!.health()).toBe(true);
-
-    // Fire-and-forget S3 suspend with a short delay so SSH can return
-    try {
-      remoteHostExec(
-        "sudo sh -c 'nohup sh -c \"sleep 0.5 && echo mem > /sys/power/state\" >/dev/null 2>&1 &'",
-        5000,
-      );
-    } catch {
-      /* SSH may drop during suspend, that's expected */
-    }
-
-    // Wait only until the host is unreachable, then send wake immediately.
-    // Some hosts wake from other enabled sources before a fixed 10s sleep window.
-    await waitForRemoteAgentDown();
-
-    // Send wake signal via HID (spacebar press+release)
-    await callJsonRpc(sharedPage, "keyboardReport", {
-      keys: [0x2c, 0, 0, 0, 0, 0],
-      modifier: 0,
-    });
-    await callJsonRpc(sharedPage, "keyboardReport", {
-      keys: [0, 0, 0, 0, 0, 0],
-      modifier: 0,
+    await putRemoteHostToSleepForUSBWakeTest(sharedPage, {
+      includeRootHubWake: false,
+      wakeAfterSeconds: 90,
     });
 
-    // Poll until remote-agent responds again. This verifies both wake and the
-    // post-resume input path used by the rest of the suite.
-    const wakeDeadline = Date.now() + USB_WAKE_REMOTE_AGENT_TIMEOUT_MS;
+    try {
+      await sendBrowserInputThatMustNotWakeHost(sharedPage);
+      await expectHostStaysAsleep(30_000);
+    } finally {
+      await recoverRemoteHostAfterUSBWakeTest(sharedPage);
+    }
+  });
+
+  test("usb-wake: no-video Wake button wakes S3 host", async () => {
+    test.setTimeout(210_000);
+
+    test.skip(
+      !(await agent!.health()),
+      "Remote host is already asleep; cannot schedule an RTC fallback",
+    );
+
+    await putRemoteHostToSleepForUSBWakeTest(sharedPage, {
+      includeRootHubWake: false,
+      wakeAfterSeconds: 90,
+    });
+
+    let wokeWithButton = false;
+    try {
+      await wakeRemoteHostWithWakeButton(sharedPage);
+      wokeWithButton = true;
+    } finally {
+      if (!wokeWithButton) {
+        await recoverRemoteHostAfterUSBWakeTest(sharedPage);
+      }
+    }
+
+    await new Promise(r => setTimeout(r, 5000));
+    await sharedPage.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(sharedPage);
+    await waitForVideoDimensions(sharedPage, 30000);
+
+    const postEvents = await waitForKeyboardReady(agent!, sharedPage);
+    expect(postEvents.length, "keyboard should work after S3 Wake button wake").toBeGreaterThan(0);
+  });
+
+  test("usb-wake: S3 suspend and wake via explicit wake RPC", async () => {
+    test.setTimeout(180_000);
+
+    await putRemoteHostToSleepForUSBWakeTest(sharedPage, {
+      includeRootHubWake: false,
+      wakeAfterSeconds: 90,
+    });
+
+    await callJsonRpc(sharedPage, "wakeHost");
+
+    // Poll until host wakes up (remote agent responds again)
+    const wakeDeadline = Date.now() + 30000;
     let hostUp = false;
-    while (Date.now() < wakeDeadline) {
-      if (await remoteAgentHealth()) {
-        hostUp = true;
-        break;
+    try {
+      while (Date.now() < wakeDeadline) {
+        if (await agent!.health()) {
+          hostUp = true;
+          break;
+        }
+        // Re-send wake signal periodically in case the first was lost
+        try {
+          await callJsonRpc(sharedPage, "wakeHost");
+        } catch {
+          /* RPC may fail if WebRTC is reconnecting */
+        }
+        await new Promise(r => setTimeout(r, 2000));
       }
-      // Re-send wake signal periodically in case the first was lost
-      try {
-        await callJsonRpc(sharedPage, "keyboardReport", {
-          keys: [0x2c, 0, 0, 0, 0, 0],
-          modifier: 0,
-        });
-        await callJsonRpc(sharedPage, "keyboardReport", {
-          keys: [0, 0, 0, 0, 0, 0],
-          modifier: 0,
-        });
-      } catch {
-        /* RPC may fail if WebRTC is reconnecting */
+    } finally {
+      if (!hostUp) {
+        await recoverRemoteHostAfterUSBWakeTest(sharedPage);
       }
-      await new Promise(r => setTimeout(r, 2000));
     }
-    expect(hostUp, "Remote agent should be reachable after S3 HID wake").toBe(true);
+    expect(hostUp, "Host should wake from S3 after explicit wake RPC").toBe(true);
 
     // Wait for video stream to recover after host resume
     await new Promise(r => setTimeout(r, 5000));
@@ -2880,81 +3009,54 @@ test.describe("Remote Host Agent", () => {
     expect(postEvents.length, "keyboard should work after S3 wake").toBeGreaterThan(0);
   });
 
-  test("usb-wake: S3 suspend and wake via mouse input", async () => {
+  test("usb-wake: regular HID reports do not wake from S3", async () => {
     test.setTimeout(180_000);
 
-    const localVersion = (await callJsonRpc(sharedPage, "getLocalVersion")) as {
-      appVersion: string;
-      systemVersion: string;
-    };
-    if (!semverGte(localVersion.systemVersion, "0.2.8")) {
-      test.skip(true, `S3 wake requires system >= 0.2.8 (got ${localVersion.systemVersion})`);
-      return;
-    }
+    await putRemoteHostToSleepForUSBWakeTest(sharedPage, {
+      includeRootHubWake: false,
+      wakeAfterSeconds: 90,
+    });
 
-    let memSleep: string;
-    try {
-      memSleep = remoteHostExec("cat /sys/power/mem_sleep").trim();
-    } catch {
-      test.skip(true, "Cannot read /sys/power/mem_sleep on remote host");
-      return;
-    }
-    if (!memSleep.includes("deep") && !memSleep.includes("[mem]")) {
-      test.skip(true, `S3 deep sleep not available (mem_sleep: ${memSleep})`);
-      return;
-    }
-    skipUsbWakeIfRemoteHostUsesWifi();
-
-    // Enable USB wakeup
-    try {
-      enableJetKVMUsbWakeOnRemoteHost();
-    } catch {
-      /* best effort */
-    }
-
-    await waitForVideoDimensions(sharedPage, 10000);
-    expect(await agent!.health()).toBe(true);
-
-    // Suspend host
-    try {
-      remoteHostExec(
-        "sudo sh -c 'nohup sh -c \"sleep 0.5 && echo mem > /sys/power/state\" >/dev/null 2>&1 &'",
-        5000,
-      );
-    } catch {
-      /* SSH may drop */
-    }
-
-    await waitForRemoteAgentDown();
-
-    // Wake via relative mouse activity. This exercises the boot-style mouse HID
-    // interface, which is typically a more reliable suspend wake source than
-    // the absolute mouse reports used during normal pointer sync.
+    // Keyboard/mouse HID endpoints have wakeup_on_write=0; only the dedicated
+    // wake HID (sent via the wakeHost RPC) can wake the host from S3.
     await callJsonRpc(sharedPage, "relMouseReport", { dx: 8, dy: 0, buttons: 0 });
     await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 1 });
     await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 0 });
+    await callJsonRpc(sharedPage, "keyboardReport", {
+      keys: [0x2c, 0, 0, 0, 0, 0],
+      modifier: 0,
+    });
+    await callJsonRpc(sharedPage, "keyboardReport", {
+      keys: [0, 0, 0, 0, 0, 0],
+      modifier: 0,
+    });
 
-    const wakeDeadline = Date.now() + USB_WAKE_REMOTE_AGENT_TIMEOUT_MS;
+    await new Promise(r => setTimeout(r, 5000));
+    expect(await agent!.health(), "Host should stay asleep after regular HID reports").toBe(false);
+
+    await callJsonRpc(sharedPage, "wakeHost");
+
+    const wakeDeadline = Date.now() + 30000;
     let hostUp = false;
-    while (Date.now() < wakeDeadline) {
-      if (await remoteAgentHealth()) {
-        hostUp = true;
-        break;
+    try {
+      while (Date.now() < wakeDeadline) {
+        if (await agent!.health()) {
+          hostUp = true;
+          break;
+        }
+        try {
+          await callJsonRpc(sharedPage, "wakeHost");
+        } catch {
+          /* best effort */
+        }
+        await new Promise(r => setTimeout(r, 2000));
       }
-      try {
-        await callJsonRpc(sharedPage, "relMouseReport", {
-          dx: Math.random() > 0.5 ? 12 : -12,
-          dy: Math.random() > 0.5 ? 6 : -6,
-          buttons: 0,
-        });
-        await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 1 });
-        await callJsonRpc(sharedPage, "relMouseReport", { dx: 0, dy: 0, buttons: 0 });
-      } catch {
-        /* best effort */
+    } finally {
+      if (!hostUp) {
+        await recoverRemoteHostAfterUSBWakeTest(sharedPage);
       }
-      await new Promise(r => setTimeout(r, 2000));
     }
-    expect(hostUp, "Remote agent should be reachable after S3 mouse wake").toBe(true);
+    expect(hostUp, "Host should wake from S3 after explicit wake RPC").toBe(true);
 
     await new Promise(r => setTimeout(r, 5000));
     await sharedPage.goto("/", { waitUntil: "networkidle" });
@@ -2962,7 +3064,7 @@ test.describe("Remote Host Agent", () => {
     await waitForVideoDimensions(sharedPage, 30000);
 
     const postEvents = await waitForKeyboardReady(agent!, sharedPage);
-    expect(postEvents.length, "keyboard should work after S3 mouse wake").toBeGreaterThan(0);
+    expect(postEvents.length, "keyboard should work after S3 wake").toBeGreaterThan(0);
   });
 
   // ═══════════════════════════════════════════

--- a/ui/e2e/remote-agent/remote-agent.ts
+++ b/ui/e2e/remote-agent/remote-agent.ts
@@ -241,12 +241,18 @@ export class RemoteAgent {
   }
 
   /** Check if the agent is running. */
-  async health(): Promise<boolean> {
+  async health(timeoutMs = 2000): Promise<boolean> {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), timeoutMs);
     try {
-      const res = await this.get<{ status: string }>("/health");
-      return res.status === "ok";
+      const res = await fetch(`${this.baseUrl}/health`, { signal: controller.signal });
+      if (!res.ok) return false;
+      const body = (await res.json()) as { status: string };
+      return body.status === "ok";
     } catch {
       return false;
+    } finally {
+      clearTimeout(timeout);
     }
   }
 

--- a/ui/localization/messages/cy.json
+++ b/ui/localization/messages/cy.json
@@ -1050,6 +1050,8 @@
     "video_overlay_retrying_connection": "Yn ailgeisio cysylltiad…",
     "video_overlay_troubleshooting_guide": "Canllaw Datrys Problemau",
     "video_overlay_try_again": "Rhowch gynnig arall",
+    "video_overlay_try_wake": "Ceisio deffro",
+    "video_overlay_trying_wake": "Yn ceisio deffro…",
     "video_pointer_lock_disabled": "Clo pwyntydd wedi'i analluogi",
     "video_pointer_lock_enabled": "Clo pwyntydd wedi'i alluogi — pwyswch Escape i ddatgloi",
     "video_quality_high": "Uchel",

--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Prøver at oprette forbindelse igen…",
     "video_overlay_troubleshooting_guide": "Fejlfindingsvejledning",
     "video_overlay_try_again": "Prøv igen",
+    "video_overlay_try_wake": "Prøv at vække",
+    "video_overlay_trying_wake": "Prøver at vække…",
     "video_pointer_lock_disabled": "Markørlås deaktiveret",
     "video_pointer_lock_enabled": "Markørlås aktiveret — tryk på Escape for at låse op",
     "video_quality_high": "Høj",

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Verbindung wird erneut versucht …",
     "video_overlay_troubleshooting_guide": "Handbuch zur Fehlerbehebung",
     "video_overlay_try_again": "Versuchen Sie es erneut",
+    "video_overlay_try_wake": "Aufwecken versuchen",
+    "video_overlay_trying_wake": "Aufwecken…",
     "video_pointer_lock_disabled": "Zeigersperre deaktiviert",
     "video_pointer_lock_enabled": "Zeigersperre aktiviert – drücken Sie Escape, um die Sperre aufzuheben",
     "video_quality_high": "Hoch",

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Retrying connection…",
     "video_overlay_troubleshooting_guide": "Troubleshooting Guide",
     "video_overlay_try_again": "Try again",
+    "video_overlay_try_wake": "Try to wake",
+    "video_overlay_trying_wake": "Trying to wake…",
     "video_pointer_lock_disabled": "Pointer lock disabled",
     "video_pointer_lock_enabled": "Pointer lock enabled — press Escape to unlock",
     "video_quality_high": "High",

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Reintentando conexión…",
     "video_overlay_troubleshooting_guide": "Guía de solución de problemas",
     "video_overlay_try_again": "Intentar otra vez",
+    "video_overlay_try_wake": "Intentar despertar",
+    "video_overlay_trying_wake": "Intentando despertar…",
     "video_pointer_lock_disabled": "Bloqueo del puntero deshabilitado",
     "video_pointer_lock_enabled": "Bloqueo del puntero habilitado: presione Escape para desbloquear",
     "video_quality_high": "Alto",

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Nouvelle tentative de connexion…",
     "video_overlay_troubleshooting_guide": "Guide de dépannage",
     "video_overlay_try_again": "Essayer à nouveau",
+    "video_overlay_try_wake": "Essayer de réveiller",
+    "video_overlay_trying_wake": "Tentative de réveil…",
     "video_pointer_lock_disabled": "Verrouillage du pointeur désactivé",
     "video_pointer_lock_enabled": "Verrouillage du pointeur activé — appuyez sur Échap pour déverrouiller",
     "video_quality_high": "Haut",

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Nuovo tentativo di connessione…",
     "video_overlay_troubleshooting_guide": "Guida alla risoluzione dei problemi",
     "video_overlay_try_again": "Riprova",
+    "video_overlay_try_wake": "Prova a riattivare",
+    "video_overlay_trying_wake": "Riattivazione…",
     "video_pointer_lock_disabled": "Blocco puntatore disabilitato",
     "video_pointer_lock_enabled": "Blocco puntatore abilitato: premi Esc per sbloccarlo",
     "video_quality_high": "Alto",

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "接続を再試行中…",
     "video_overlay_troubleshooting_guide": "トラブルシューティングガイド",
     "video_overlay_try_again": "再試行",
+    "video_overlay_try_wake": "スリープ解除を試行",
+    "video_overlay_trying_wake": "スリープ解除を試行中…",
     "video_pointer_lock_disabled": "ポインターロック無効",
     "video_pointer_lock_enabled": "ポインターロック有効 — Escapeで解除",
     "video_quality_high": "高",

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Prøver tilkobling på nytt …",
     "video_overlay_troubleshooting_guide": "Feilsøkingsveiledning",
     "video_overlay_try_again": "Prøv igjen",
+    "video_overlay_try_wake": "Prøv å vekke",
+    "video_overlay_trying_wake": "Prøver å vekke…",
     "video_pointer_lock_disabled": "Pekerlås deaktivert",
     "video_pointer_lock_enabled": "Pekerlås aktivert – trykk Escape for å låse opp",
     "video_quality_high": "Høy",

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Tentando conexão novamente…",
     "video_overlay_troubleshooting_guide": "Guia de Solução de Problemas",
     "video_overlay_try_again": "Tentar novamente",
+    "video_overlay_try_wake": "Tentar despertar",
+    "video_overlay_trying_wake": "A tentar despertar…",
     "video_pointer_lock_disabled": "Bloqueio de ponteiro desativado",
     "video_pointer_lock_enabled": "Bloqueio de ponteiro ativado — pressione Escape para desbloquear",
     "video_quality_high": "Alta",

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Повторная попытка подключения…",
     "video_overlay_troubleshooting_guide": "Руководство по устранению неполадок",
     "video_overlay_try_again": "Попробовать снова",
+    "video_overlay_try_wake": "Попробовать разбудить",
+    "video_overlay_trying_wake": "Пробуем разбудить…",
     "video_pointer_lock_disabled": "Блокировка указателя отключена",
     "video_pointer_lock_enabled": "Блокировка указателя включена — нажмите Escape, чтобы разблокировать",
     "video_quality_high": "Высокое",

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "Försöker ansluta igen…",
     "video_overlay_troubleshooting_guide": "Felsökningsguide",
     "video_overlay_try_again": "Försök igen",
+    "video_overlay_try_wake": "Försök väcka",
+    "video_overlay_trying_wake": "Försöker väcka…",
     "video_pointer_lock_disabled": "Pekarlås inaktiverat",
     "video_pointer_lock_enabled": "Pekarlås aktiverat — tryck på Escape för att låsa upp",
     "video_quality_high": "Hög",

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "正在重試連線…",
     "video_overlay_troubleshooting_guide": "故障排除指南",
     "video_overlay_try_again": "再試一次",
+    "video_overlay_try_wake": "嘗試喚醒",
+    "video_overlay_trying_wake": "正在嘗試喚醒…",
     "video_pointer_lock_disabled": "指標鎖定已停用",
     "video_pointer_lock_enabled": "指標鎖定已啟用 — 按 Escape 解鎖",
     "video_quality_high": "高",

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -1063,6 +1063,8 @@
     "video_overlay_retrying_connection": "正在尝试重新连接...",
     "video_overlay_troubleshooting_guide": "故障排查指南",
     "video_overlay_try_again": "重试",
+    "video_overlay_try_wake": "尝试唤醒",
+    "video_overlay_trying_wake": "正在尝试唤醒…",
     "video_pointer_lock_disabled": "指针锁定已禁用",
     "video_pointer_lock_enabled": "指针锁定已启用 - 按 Esc 键解除锁定",
     "video_quality_high": "高",

--- a/ui/src/components/VideoOverlay.tsx
+++ b/ui/src/components/VideoOverlay.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useRef, useCallback } from "react";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/solid";
 import { ArrowPathIcon, ArrowRightIcon } from "@heroicons/react/16/solid";
 import { motion, AnimatePresence } from "framer-motion";
-import { LuPlay } from "react-icons/lu";
+import { LuPlay, LuPower } from "react-icons/lu";
 import { BsMouseFill } from "react-icons/bs";
 
 import { m } from "@localizations/messages.js";
@@ -10,6 +10,7 @@ import { Button, LinkButton } from "@components/Button";
 import LoadingSpinner from "@components/LoadingSpinner";
 import Card, { GridCard } from "@components/Card";
 import { useRTCStore, PostRebootAction } from "@/hooks/stores";
+import { useJsonRpc } from "@/hooks/useJsonRpc";
 import LogoBlue from "@/assets/logo-blue.svg";
 import LogoWhite from "@/assets/logo-white.svg";
 import { isOnDevice } from "@/main";
@@ -219,8 +220,39 @@ interface HDMIErrorOverlayProps {
 }
 
 export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
+  const { send } = useJsonRpc();
+  const [wakeAttemptPending, setWakeAttemptPending] = useState(false);
+  const wakeAttemptTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const isNoSignal = hdmiState === "no_signal";
   const isOtherError = hdmiState === "no_lock" || hdmiState === "out_of_range";
+  const canWakeHost = isNoSignal;
+
+  useEffect(() => {
+    return () => {
+      if (wakeAttemptTimeoutRef.current) {
+        clearTimeout(wakeAttemptTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const handleWakeHost = useCallback(() => {
+    if (wakeAttemptPending) return;
+
+    setWakeAttemptPending(true);
+    if (wakeAttemptTimeoutRef.current) {
+      clearTimeout(wakeAttemptTimeoutRef.current);
+    }
+    wakeAttemptTimeoutRef.current = setTimeout(() => {
+      setWakeAttemptPending(false);
+      wakeAttemptTimeoutRef.current = null;
+    }, 2500);
+
+    void send("wakeHost", {}, resp => {
+      if ("error" in resp) {
+        console.error("Failed to wake host", resp.error);
+      }
+    });
+  }, [send, wakeAttemptPending]);
 
   return (
     <>
@@ -249,7 +281,21 @@ export function HDMIErrorOverlay({ show, hdmiState }: HDMIErrorOverlayProps) {
                         <li>{m.video_overlay_no_hdmi_adapter_compat()}</li>
                       </ul>
                     </div>
-                    <div>
+                    <div className="flex items-center gap-x-2">
+                      {canWakeHost && (
+                        <Button
+                          onClick={handleWakeHost}
+                          loading={wakeAttemptPending}
+                          LeadingIcon={LuPower}
+                          text={
+                            wakeAttemptPending
+                              ? m.video_overlay_trying_wake()
+                              : m.video_overlay_try_wake()
+                          }
+                          size="SM"
+                          theme="primary"
+                        />
+                      )}
                       <LinkButton
                         to={"https://jetkvm.com/docs/getting-started/troubleshooting"}
                         theme="light"

--- a/usb.go
+++ b/usb.go
@@ -1,6 +1,7 @@
 package kvm
 
 import (
+	"fmt"
 	"sync"
 	"time"
 
@@ -82,6 +83,33 @@ func rpcWheelReport(wheelY int8, wheelX int8) error {
 		}
 		return gadget.RelMouseWheelReport(wheelY, wheelX)
 	})
+}
+
+func rpcWakeHost() error {
+	if gadget == nil {
+		return fmt.Errorf("USB gadget is not initialized")
+	}
+
+	state := gadget.GetUsbState()
+	if state == usbgadget.USBStateNotAttached || state == usbgadget.USBStateUnknown {
+		return nil
+	}
+
+	for i := 0; i < 3; i++ {
+		if err := gadget.WakeReport(true); err != nil && !usbgadget.IsHIDTemporarilyUnavailableError(err) {
+			return err
+		}
+
+		time.Sleep(50 * time.Millisecond)
+
+		if err := gadget.WakeReport(false); err != nil && !usbgadget.IsHIDTemporarilyUnavailableError(err) {
+			return err
+		}
+
+		time.Sleep(150 * time.Millisecond)
+	}
+
+	return nil
 }
 
 func rpcGetKeyboardLedState() (state usbgadget.KeyboardState) {


### PR DESCRIPTION
Adds a no-signal `Try to wake` control that sends a dedicated wake-only HID signal, while regular keyboard and mouse reports stay blocked during suspend or no-signal states.

Covers the behavior with S3 E2E tests for both ignored browser input and successful button-triggered wake, with the full E2E suite passing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `wakeHost` RPC that drives a dedicated wake-capable HID function and changes HID wake settings, which can impact suspend/resume behavior and USB gadget enumeration.
> 
> **Overview**
> Adds an **explicit USB wake path** by introducing a dedicated vendor HID function (`wake_hid` on `/dev/hidg3`) with `wakeup_on_write=1`, while disabling `wakeup_on_write` for the normal keyboard and mouse HID functions.
> 
> Exposes this via a new JSON-RPC method `wakeHost` (toggling the wake report a few times) and wires it to a new **“Try to wake”** button on the no-signal video overlay (with new localized strings).
> 
> Updates E2E coverage to validate S3 behavior: browser/regular HID input does *not* wake the host, and waking works via the overlay button and the explicit `wakeHost` RPC; remote-agent `health()` now supports a timeout to make these checks more reliable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 913ece1886749d6d2218b28fc5e19608f80bbed6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->