### PR TITLE
feat(ui/mouse): forward mouse X1/X2 buttons to remote

### DIFF
--- a/ui/src/components/WebRTCVideo.tsx
+++ b/ui/src/components/WebRTCVideo.tsx
@@ -548,6 +548,15 @@ export default function WebRTCVideo({
       const preventContextMenu = (e: MouseEvent) => e.preventDefault();
       videoElmRefValue.addEventListener("contextmenu", preventContextMenu, { signal });
 
+      // Suppress browser Back/Forward navigation on X1/X2 mouse buttons so
+      // those presses are forwarded to the remote target instead.
+      const preventXButtonNav = (e: MouseEvent) => {
+        if (e.button === 3 || e.button === 4) e.preventDefault();
+      };
+      videoElmRefValue.addEventListener("mousedown", preventXButtonNav, { signal });
+      videoElmRefValue.addEventListener("mouseup", preventXButtonNav, { signal });
+      videoElmRefValue.addEventListener("auxclick", preventXButtonNav, { signal });
+
       return () => {
         abortController.abort();
       };
@@ -606,13 +615,8 @@ export default function WebRTCVideo({
     <div className="grid h-full w-full grid-rows-(--grid-layout)">
       <div className="flex min-h-[39.5px] flex-col">
         <div className="flex flex-col">
-          <fieldset
-            disabled={peerConnection?.connectionState !== "connected"}
-            className="contents"
-          >
-            <Actionbar
-              requestFullscreen={requestFullscreen}
-            />
+          <fieldset disabled={peerConnection?.connectionState !== "connected"} className="contents">
+            <Actionbar requestFullscreen={requestFullscreen} />
             <MacroBar />
           </fieldset>
         </div>
@@ -634,9 +638,7 @@ export default function WebRTCVideo({
                 <div className="grid grow grid-rows-(--grid-bodyFooter) overflow-hidden">
                   {/* In relative mouse mode and under https, we enable the pointer lock, and to do so we need a bar to show the user to click on the video to enable mouse control */}
                   <PointerLockBar show={showPointerLockBar} />
-                  <div
-                    className="relative mx-4 my-2 flex items-center justify-center overflow-hidden"
-                  >
+                  <div className="relative mx-4 my-2 flex items-center justify-center overflow-hidden">
                     <div
                       ref={fullscreenContainerRef}
                       className="relative flex h-full w-full items-center justify-center"
@@ -652,20 +654,17 @@ export default function WebRTCVideo({
                         disablePictureInPicture
                         controlsList="nofullscreen"
                         style={videoStyle}
-                        className={cx(
-                          "h-full w-full object-contain transition-all duration-1000",
-                          {
-                            "cursor-none": settings.isCursorHidden,
-                            "pointer-events-none": isOcrMode,
-                            "opacity-0!":
-                              isVideoLoading ||
-                              hdmiError ||
-                              hasConnectionIssues ||
-                              peerConnectionState !== "connected",
-                            "opacity-60!": showPointerLockBar,
-                            "animate-slideUpFade": isPlaying,
-                          },
-                        )}
+                        className={cx("h-full w-full object-contain transition-all duration-1000", {
+                          "cursor-none": settings.isCursorHidden,
+                          "pointer-events-none": isOcrMode,
+                          "opacity-0!":
+                            isVideoLoading ||
+                            hdmiError ||
+                            hasConnectionIssues ||
+                            peerConnectionState !== "connected",
+                          "opacity-60!": showPointerLockBar,
+                          "animate-slideUpFade": isPlaying,
+                        })}
                       />
                       <OcrOverlay />
                       {peerConnection?.connectionState == "connected" && !hasConnectionIssues && (

--- a/ui/src/hooks/useMouse.ts
+++ b/ui/src/hooks/useMouse.ts
@@ -35,13 +35,15 @@ export default function useMouse() {
       // if (x === 0 && y === 0 && buttons === 0) return;
       const dx = calcDelta(x);
       const dy = calcDelta(y);
+      // Keep L/R/M/X1/X2; drop pen-eraser and any future high bits.
+      const b = buttons & 0x1f;
       if (rpcHidReady) {
-        reportRelMouseEvent(dx, dy, buttons);
+        reportRelMouseEvent(dx, dy, b);
       } else {
         // kept for backward compatibility
-        send("relMouseReport", { dx, dy, buttons });
+        send("relMouseReport", { dx, dy, buttons: b });
       }
-      setMouseMove({ x, y, buttons });
+      setMouseMove({ x, y, buttons: b });
     },
     [send, reportRelMouseEvent, setMouseMove, mouseMode, rpcHidReady],
   );
@@ -60,11 +62,13 @@ export default function useMouse() {
   const sendAbsMouseMovement = useCallback(
     (x: number, y: number, buttons: number) => {
       if (mouseMode !== "absolute") return;
+      // Keep L/R/M/X1/X2; drop pen-eraser and any future high bits.
+      const b = buttons & 0x1f;
       if (rpcHidReady) {
-        reportAbsMouseEvent(x, y, buttons);
+        reportAbsMouseEvent(x, y, b);
       } else {
         // kept for backward compatibility
-        send("absMouseReport", { x, y, buttons });
+        send("absMouseReport", { x, y, buttons: b });
       }
       // We set that for the debug info bar
       setMousePosition(x, y);


### PR DESCRIPTION
Closes #172

### Summary
Browser default Back/Forward nav was eating buttons 4/5 before the HID path ever saw them.
Suppress nav with mousedown/mouseup/auxclick preventDefault, and mask buttons to bits 0..4 so pen-eraser and any future high bits don't leak onto the wire.
HID descriptors and RPC already carry the full byte; no backend change needed.

### Checklist

- [X] Ran `make test_e2e` locally and passed
- [X] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [X] One problem per PR (no unrelated changes)
- [X] Lints pass; CI green
- [X] Tricky parts are commented in code
