### PR TITLE
fix(ui): Add Save & Disconnect button for MQTT on disable

### DIFF
--- a/ui/localization/messages/cy.json
+++ b/ui/localization/messages/cy.json
@@ -683,6 +683,8 @@
     "mqtt_remote_control_description": "Caniatáu i gleientiaid MQTT sbarduno rheolaeth pŵer, ailgychwyn, a gweithredoedd eraill",
     "mqtt_remote_control_title": "Rheolaeth o Bell",
     "mqtt_save_button": "Cadw ac Ailgysylltu",
+    "mqtt_save_disconnect_button": "Cadw a Datgysylltu",
+    "mqtt_saved_disconnect": "Gosodiadau MQTT wedi'u cadw. Yn datgysylltu o'r brocer…",
     "mqtt_saved_error": "Methwyd â chadw gosodiadau MQTT: {error}",
     "mqtt_saved_success": "Gosodiadau MQTT wedi'u cadw. Yn ailgysylltu â'r brocer…",
     "mqtt_section_advanced": "Uwch",

--- a/ui/localization/messages/da.json
+++ b/ui/localization/messages/da.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Tillad MQTT-klienter at udløse strømstyring, genstart og andre handlinger",
     "mqtt_remote_control_title": "Fjernstyring",
     "mqtt_save_button": "Gem og genforbind",
+    "mqtt_save_disconnect_button": "Gem og afbryd forbindelsen",
+    "mqtt_saved_disconnect": "MQTT-indstillinger gemt. Afbryder forbindelse til broker…",
     "mqtt_saved_error": "Kunne ikke gemme MQTT-indstillinger: {error}",
     "mqtt_saved_success": "MQTT-indstillinger gemt. Genopretter forbindelse til broker…",
     "mqtt_section_advanced": "Avanceret",

--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "MQTT-Clients erlauben, Stromsteuerung, Neustart und andere Aktionen auszulösen",
     "mqtt_remote_control_title": "Fernsteuerung",
     "mqtt_save_button": "Speichern & Verbinden",
+    "mqtt_save_disconnect_button": "Speichern &amp; Trennen",
+    "mqtt_saved_disconnect": "MQTT-Einstellungen gespeichert. Verbindung zum Broker wird getrennt…",
     "mqtt_saved_error": "MQTT-Einstellungen konnten nicht gespeichert werden: {error}",
     "mqtt_saved_success": "MQTT-Einstellungen gespeichert. Verbindung zum Broker wird hergestellt…",
     "mqtt_section_advanced": "Erweitert",

--- a/ui/localization/messages/en.json
+++ b/ui/localization/messages/en.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Allow MQTT clients to trigger power control, reboot, and other actions",
     "mqtt_remote_control_title": "Remote Control",
     "mqtt_save_button": "Save & Reconnect",
+    "mqtt_save_disconnect_button": "Save & Disconnect",
+    "mqtt_saved_disconnect": "MQTT settings saved. Disconnecting from broker…",
     "mqtt_saved_error": "Failed to save MQTT settings: {error}",
     "mqtt_saved_success": "MQTT settings saved. Reconnecting to broker…",
     "mqtt_section_advanced": "Advanced",

--- a/ui/localization/messages/es.json
+++ b/ui/localization/messages/es.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Permitir que clientes MQTT activen control de energía, reinicio y otras acciones",
     "mqtt_remote_control_title": "Control remoto",
     "mqtt_save_button": "Guardar y reconectar",
+    "mqtt_save_disconnect_button": "Guardar y desconectar",
+    "mqtt_saved_disconnect": "Configuración MQTT guardada. Desconectando del broker…",
     "mqtt_saved_error": "Error al guardar la configuración de MQTT: {error}",
     "mqtt_saved_success": "Configuración de MQTT guardada. Reconectando al broker…",
     "mqtt_section_advanced": "Avanzado",

--- a/ui/localization/messages/fr.json
+++ b/ui/localization/messages/fr.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Autoriser les clients MQTT à déclencher le contrôle d'alimentation, le redémarrage et d'autres actions",
     "mqtt_remote_control_title": "Contrôle à distance",
     "mqtt_save_button": "Enregistrer et reconnecter",
+    "mqtt_save_disconnect_button": "Sauvegarder et déconnecter",
+    "mqtt_saved_disconnect": "Paramètres MQTT enregistrés. Déconnexion du broker…",
     "mqtt_saved_error": "Échec de l'enregistrement des paramètres MQTT : {error}",
     "mqtt_saved_success": "Paramètres MQTT enregistrés. Reconnexion au broker…",
     "mqtt_section_advanced": "Avancé",

--- a/ui/localization/messages/it.json
+++ b/ui/localization/messages/it.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Consenti ai client MQTT di attivare il controllo alimentazione, il riavvio e altre azioni",
     "mqtt_remote_control_title": "Controllo remoto",
     "mqtt_save_button": "Salva e riconnetti",
+    "mqtt_save_disconnect_button": "Salva e disconnetti",
+    "mqtt_saved_disconnect": "Impostazioni MQTT salvate. Disconnessione dal broker in corso…",
     "mqtt_saved_error": "Impossibile salvare le impostazioni MQTT: {error}",
     "mqtt_saved_success": "Impostazioni MQTT salvate. Riconnessione al broker…",
     "mqtt_section_advanced": "Avanzate",

--- a/ui/localization/messages/ja.json
+++ b/ui/localization/messages/ja.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "MQTTクライアントから電源制御、再起動、その他のアクションをトリガーできるようにします",
     "mqtt_remote_control_title": "リモートコントロール",
     "mqtt_save_button": "保存して再接続",
+    "mqtt_save_disconnect_button": "保存して切断",
+    "mqtt_saved_disconnect": "MQTT設定が保存されました。ブローカーから切断します…",
     "mqtt_saved_error": "MQTT設定の保存に失敗しました: {error}",
     "mqtt_saved_success": "MQTT設定を保存しました。ブローカーに再接続中…",
     "mqtt_section_advanced": "詳細設定",

--- a/ui/localization/messages/nb.json
+++ b/ui/localization/messages/nb.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Tillat MQTT-klienter å utløse strømstyring, omstart og andre handlinger",
     "mqtt_remote_control_title": "Fjernstyring",
     "mqtt_save_button": "Lagre og koble til på nytt",
+    "mqtt_save_disconnect_button": "Lagre og koble fra",
+    "mqtt_saved_disconnect": "MQTT-innstillinger lagret. Kobler fra megleren …",
     "mqtt_saved_error": "Kunne ikke lagre MQTT-innstillinger: {error}",
     "mqtt_saved_success": "MQTT-innstillinger lagret. Kobler til broker…",
     "mqtt_section_advanced": "Avansert",

--- a/ui/localization/messages/pt.json
+++ b/ui/localization/messages/pt.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Permitir que clientes MQTT acionem controlo de energia, reinício e outras ações",
     "mqtt_remote_control_title": "Controlo Remoto",
     "mqtt_save_button": "Guardar e Reconectar",
+    "mqtt_save_disconnect_button": "Salvar e desconectar",
+    "mqtt_saved_disconnect": "Configurações MQTT salvas. Desconectando do broker…",
     "mqtt_saved_error": "Falha ao guardar definições MQTT: {error}",
     "mqtt_saved_success": "Definições MQTT guardadas. A reconectar ao broker…",
     "mqtt_section_advanced": "Avançado",

--- a/ui/localization/messages/ru.json
+++ b/ui/localization/messages/ru.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Разрешить MQTT-клиентам запускать управление питанием, перезагрузку и другие действия",
     "mqtt_remote_control_title": "Удалённое управление",
     "mqtt_save_button": "Сохранить и переподключить",
+    "mqtt_save_disconnect_button": "Сохранить и отключиться",
+    "mqtt_saved_disconnect": "Настройки MQTT сохранены. Отключение от брокера…",
     "mqtt_saved_error": "Не удалось сохранить настройки MQTT: {error}",
     "mqtt_saved_success": "Настройки MQTT сохранены. Переподключение к брокеру…",
     "mqtt_section_advanced": "Дополнительно",

--- a/ui/localization/messages/sv.json
+++ b/ui/localization/messages/sv.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "Tillåt MQTT-klienter att utföra strömstyrning, omstart och andra åtgärder",
     "mqtt_remote_control_title": "Fjärrstyrning",
     "mqtt_save_button": "Spara och återanslut",
+    "mqtt_save_disconnect_button": "Spara och koppla från",
+    "mqtt_saved_disconnect": "MQTT-inställningar sparade. Kopplar från brokern…",
     "mqtt_saved_error": "Kunde inte spara MQTT-inställningar: {error}",
     "mqtt_saved_success": "MQTT-inställningar sparade. Återansluter till broker…",
     "mqtt_section_advanced": "Avancerat",

--- a/ui/localization/messages/zh-tw.json
+++ b/ui/localization/messages/zh-tw.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "允許 MQTT 用戶端觸發電源控制、重新啟動及其他操作",
     "mqtt_remote_control_title": "遠端控制",
     "mqtt_save_button": "儲存並重新連線",
+    "mqtt_save_disconnect_button": "儲存並斷開連接",
+    "mqtt_saved_disconnect": "MQTT 設定已儲存。正在斷開與代理的連線…",
     "mqtt_saved_error": "儲存 MQTT 設定失敗：{error}",
     "mqtt_saved_success": "MQTT 設定已儲存。正在重新連線至 Broker…",
     "mqtt_section_advanced": "進階",

--- a/ui/localization/messages/zh.json
+++ b/ui/localization/messages/zh.json
@@ -688,6 +688,8 @@
     "mqtt_remote_control_description": "允许 MQTT 客户端触发电源控制、重启等操作",
     "mqtt_remote_control_title": "远程控制",
     "mqtt_save_button": "保存并重新连接",
+    "mqtt_save_disconnect_button": "保存并断开连接",
+    "mqtt_saved_disconnect": "MQTT 设置已保存。正在断开与代理的连接……",
     "mqtt_saved_error": "保存 MQTT 设置失败：{error}",
     "mqtt_saved_success": "MQTT 设置已保存，正在重新连接 Broker…",
     "mqtt_section_advanced": "高级",

--- a/ui/src/routes/devices.$id.settings.mqtt.tsx
+++ b/ui/src/routes/devices.$id.settings.mqtt.tsx
@@ -163,7 +163,7 @@ export default function SettingsMqttRoute() {
           );
           return;
         }
-        notifications.success(m.mqtt_saved_success());
+        notifications.success(m.mqtt_saved_disconnect());
         setConnectionState("disconnected");
       });
       return;
@@ -253,6 +253,7 @@ export default function SettingsMqttRoute() {
   const saveButtonText = () => {
     if (savePhase === "testing") return m.mqtt_testing();
     if (savePhase === "saving") return m.saving();
+    if (settings.enabled === false) return m.mqtt_save_disconnect_button();
     return m.mqtt_save_button();
   };
 
@@ -483,6 +484,18 @@ export default function SettingsMqttRoute() {
                 text={testing ? m.mqtt_testing() : m.mqtt_test_button()}
                 loading={testing}
                 onClick={handleTestConnection}
+              />
+            </div>
+          </>
+        ) || (
+          <>
+            <div className="flex items-center gap-x-2 pt-2">
+              <Button
+                size="SM"
+                theme="primary"
+                text={saveButtonText()}
+                loading={savePhase !== "idle"}
+                onClick={handleSave}
               />
             </div>
           </>


### PR DESCRIPTION
Adds a button that's visible (only) when MQTT is disabled, such that the new setting may be saved and effected, and a corresponding notification message.

Closes: #1485

