### PR TITLE
Don't trust proxy headers for client IP

### DIFF
--- a/web.go
+++ b/web.go
@@ -101,6 +101,13 @@ func setupRouter() *gin.Engine {
 	gin.SetMode(gin.ReleaseMode)
 	gin.DisableConsoleColor()
 	r := gin.Default()
+	// The device is reached directly, not behind a reverse proxy, so don't
+	// trust any X-Forwarded-For/X-Real-IP headers. Without this, gin trusts
+	// all proxies by default and c.ClientIP() returns a client-controlled
+	// value, letting a caller spoof their IP to evade the login rate limiter.
+	if err := r.SetTrustedProxies(nil); err != nil {
+		logger.Fatal().Err(err).Msg("failed to disable trusted proxies")
+	}
 	r.Use(gin_logger.SetLogger(
 		gin_logger.WithLogger(func(*gin.Context, zerolog.Logger) zerolog.Logger {
 			return *ginLogger


### PR DESCRIPTION
The web server runs `gin.Default()` without calling `SetTrustedProxies`, so gin trusts every proxy by default and `c.ClientIP()` returns the client-controlled `X-Forwarded-For` / `X-Real-IP` value.

The device is reached directly, not behind a reverse proxy, so those headers should never be trusted. As-is, a caller can rotate `X-Forwarded-For` to get a fresh rate-limit key on every request and bypass the throttle on `/auth/login-local` and `/device/setup`, enabling unlimited online password guessing.

Fix: call `r.SetTrustedProxies(nil)` so `ClientIP()` uses the real socket peer. Also tightens the IP shown in logs/metrics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, security-hardening router bootstrap change with no intended behavior change when the device is not behind a proxy; fails fast if proxy config cannot be applied.
> 
> **Overview**
> **Disables trusting proxy headers** in Gin during router setup by calling `r.SetTrustedProxies(nil)`, with fatal logging if that configuration fails.
> 
> Because the KVM web UI is reached **directly** (not behind a reverse proxy), `c.ClientIP()` will now use the **real TCP peer** instead of client-controlled `X-Forwarded-For` / `X-Real-IP`. That closes a bypass where attackers could rotate forwarded IPs to evade the password **rate limiter** on `/auth/login-local` and `/device/setup`, and makes **logs/metrics** IP labels reflect the actual connection source.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97cab042df3f928204ac9cdf7a6f54783914111e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->