### PR TITLE
Keep USB audio attached when streaming is disabled

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -376,7 +376,7 @@ func rpcGetBacklightSettings() (*BacklightSettings, error) {
 }
 
 func rpcGetAudioConfig() (*AudioConfig, error) {
-	return &AudioConfig{Enabled: config.AudioEnabled}, nil
+	return &AudioConfig{Enabled: effectiveAudioEnabled()}, nil
 }
 
 func rpcSetAudioConfig(params AudioConfig) error {
@@ -390,10 +390,6 @@ func rpcSetAudioConfig(params AudioConfig) error {
 	config.AudioEnabled = enabled
 	if !effectiveAudioEnabled() {
 		stopAudio()
-	}
-	if gadget != nil {
-		gadget.SetGadgetDevices(effectiveUsbDevices())
-		return updateUsbRelatedConfig()
 	}
 	if err := SaveConfig(); err != nil {
 		return fmt.Errorf("failed to save config: %w", err)

--- a/ui/e2e/global-setup.ts
+++ b/ui/e2e/global-setup.ts
@@ -25,7 +25,7 @@ export default async function globalSetup() {
   }
 
   console.log("[global-setup] Deploying binary to device...");
-  await sshExec("killall jetkvm_app", true);
+  await sshExec("killall jetkvm_app jetkvm_app_debug", true);
   await new Promise(r => setTimeout(r, 1000));
 
   const host = getDeviceHost();

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -715,9 +715,15 @@ export const SSH_OPTS = [
 const SSH_MAX_RETRIES = 3;
 const SSH_RETRY_BASE_DELAY_MS = 2000;
 const SSH_COMMAND_TIMEOUT_MS = 15000;
+const REMOTE_APP_PATH = "/userdata/jetkvm/bin/jetkvm_app";
+const REMOTE_DEBUG_APP_PATH = "/userdata/jetkvm/bin/jetkvm_app_debug";
 
 function escapeForSingleQuotedShell(cmd: string): string {
   return cmd.replace(/'/g, "'\\''");
+}
+
+function shellSingleQuote(value: string): string {
+  return `'${escapeForSingleQuotedShell(value)}'`;
 }
 
 export async function sshExec(cmd: string, ignoreErrors = false): Promise<string> {
@@ -787,15 +793,30 @@ export async function restoreSSHDevState(state: SSHDevState): Promise<void> {
   }
 }
 
+async function getRestartAppPathViaSSH(): Promise<string> {
+  const configuredPath = process.env.E2E_REMOTE_APP_PATH;
+  if (configuredPath) return configuredPath;
+
+  const runningDebug = await sshExec(
+    `for exe in /proc/[0-9]*/exe; do ` +
+      `target=$(readlink "$exe" 2>/dev/null || true); ` +
+      `case "$target" in */jetkvm_app_debug) echo 1; exit 0;; esac; ` +
+      `done`,
+    true,
+  );
+  return runningDebug.trim() === "1" ? REMOTE_DEBUG_APP_PATH : REMOTE_APP_PATH;
+}
+
 export async function restartAppViaSSH(): Promise<void> {
-  await sshExec("killall jetkvm_app", true);
+  const appPath = await getRestartAppPathViaSSH();
+  await sshExec("killall jetkvm_app jetkvm_app_debug", true);
   await new Promise(r => setTimeout(r, 500));
   // Rotate last.log into last.log.prev before respawning so a later teardown
   // can still recover the previous session's output if a subsequent restart
   // truncates the live log. Combined into one SSH call to save a round-trip.
   await sshExec(
     "[ -s /userdata/jetkvm/last.log ] && mv /userdata/jetkvm/last.log /userdata/jetkvm/last.log.prev; " +
-      "setsid env LD_LIBRARY_PATH=/oem/usr/lib:/oem/lib /userdata/jetkvm/bin/jetkvm_app > /userdata/jetkvm/last.log 2>&1 &",
+      `setsid env LD_LIBRARY_PATH=/oem/usr/lib:/oem/lib ${shellSingleQuote(appPath)} > /userdata/jetkvm/last.log 2>&1 &`,
     true,
   );
   await new Promise(r => setTimeout(r, 1000));

--- a/ui/e2e/remote-agent/ra-audio.spec.ts
+++ b/ui/e2e/remote-agent/ra-audio.spec.ts
@@ -8,6 +8,7 @@ import {
 import { createRemoteAgent, type AudioDeviceInfo } from "./remote-agent";
 
 const agent = createRemoteAgent();
+const USB_ENUMERATION_SETTLE_MS = 3_000;
 
 test.beforeAll(async () => {
   test.skip(!agent, "JETKVM_REMOTE_HOST not set");
@@ -18,12 +19,57 @@ test.afterEach(async () => {
   await agent?.stopAudioTone().catch(() => undefined);
 });
 
+async function waitForJetKvmAudioDevice(context: string, timeoutMs = 15_000) {
+  const deadline = Date.now() + timeoutMs;
+  let devices: AudioDeviceInfo[] = [];
+
+  while (Date.now() < deadline) {
+    devices = await agent!.getAudioDevices();
+    const jetkvmDevice = devices.find(d => d.is_jetkvm);
+    if (jetkvmDevice) return jetkvmDevice;
+    await new Promise(r => setTimeout(r, 1_000));
+  }
+
+  throw new Error(
+    `No JetKVM USB ALSA playback device on remote host ${context}: ${JSON.stringify(devices)}`,
+  );
+}
+
+test("USB audio device remains attached when streaming audio is toggled", async ({ page }) => {
+  test.setTimeout(45_000);
+
+  await page.goto("/", { waitUntil: "networkidle" });
+  await waitForWebRTCReady(page);
+
+  try {
+    await callJsonRpc(page, "setAudioConfig", { params: { enabled: false } });
+    await page.waitForTimeout(USB_ENUMERATION_SETTLE_MS);
+    await waitForJetKvmAudioDevice("with streaming disabled");
+
+    await callJsonRpc(page, "setAudioConfig", { params: { enabled: true } });
+    await page.waitForTimeout(USB_ENUMERATION_SETTLE_MS);
+    await waitForJetKvmAudioDevice("after enabling streaming");
+
+    await callJsonRpc(page, "setAudioConfig", { params: { enabled: false } });
+    await page.waitForTimeout(USB_ENUMERATION_SETTLE_MS);
+    await waitForJetKvmAudioDevice("after disabling streaming");
+  } finally {
+    await callJsonRpc(page, "setAudioConfig", { params: { enabled: false } }).catch(
+      () => undefined,
+    );
+  }
+});
+
 test("audio works end-to-end", async ({ page }) => {
   test.setTimeout(60_000);
 
-  // Audio is opt-in via device config (Settings → Audio → Enable Audio).
-  // First connect with audio off, flip the setting via RPC, then reload so
-  // the new SDP exchange picks up the freshly-enabled track.
+  await waitForJetKvmAudioDevice("before enabling streaming");
+
+  // Audio streaming is opt-in via device config (Settings -> Audio -> Enable
+  // Audio). The USB audio device class is controlled separately by Settings ->
+  // Hardware, so enabling streaming should not force host USB re-enumeration.
+  // Connect with audio off, flip the setting via RPC, then reload so the new
+  // SDP exchange picks up the freshly-enabled track.
   await page.goto("/", { waitUntil: "networkidle" });
   await waitForWebRTCReady(page);
   await callJsonRpc(page, "setAudioConfig", { params: { enabled: true } });
@@ -32,21 +78,6 @@ test("audio works end-to-end", async ({ page }) => {
     await page.reload({ waitUntil: "networkidle" });
     await waitForWebRTCReady(page);
     await waitForAudioStream(page);
-
-    // The UAC gadget is only presented to the host while audio is enabled,
-    // so the capability check must run after setAudioConfig — and the host
-    // needs a few seconds to enumerate the new USB function.
-    let devices: AudioDeviceInfo[] = [];
-    const enumerateDeadline = Date.now() + 15_000;
-    while (Date.now() < enumerateDeadline) {
-      devices = await agent!.getAudioDevices();
-      if (devices.some(d => d.is_jetkvm)) break;
-      await new Promise(r => setTimeout(r, 1000));
-    }
-    test.skip(
-      !devices.some(d => d.is_jetkvm),
-      `No JetKVM USB ALSA playback device on remote host: ${JSON.stringify(devices)}`,
-    );
 
     const before = (await page.evaluate(() => window.__kvmTestHooks?.getInboundAudioStats())) ?? {
       bytesReceived: 0,

--- a/usb.go
+++ b/usb.go
@@ -16,7 +16,6 @@ func effectiveUsbDevices() *usbgadget.Devices {
 	}
 
 	devices := *config.UsbDevices
-	devices.Audio = config.AudioEnabled && config.UsbDevices.Audio
 	return &devices
 }
 


### PR DESCRIPTION
## Summary
- keep USB audio gadget presence controlled by USB device config, not the streaming audio toggle
- have `getAudioConfig` report effective audio streamability
- add a remote-agent regression for toggling streaming while the host keeps seeing JetKVM USB audio

## Validation
- `make test_e2e DEVICE_IP=192.168.1.231 JETKVM_REMOTE_HOST=tony@192.168.1.135`

Fixes #1496

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes USB gadget composition and JSON-RPC audio behavior (host enumeration vs WebRTC streaming), though scope is limited and covered by new e2e regression.
> 
> **Overview**
> **USB audio gadget presence is decoupled from the streaming toggle.** `effectiveUsbDevices()` no longer clears the audio function when `AudioEnabled` is off, so the host keeps seeing the JetKVM USB audio device unless **Hardware → USB** disables it. Toggling streaming only updates config, may call `stopAudio()`, and saves—**no USB gadget reconfigure or host re-enumeration**.
> 
> **`getAudioConfig`** now reports **`effectiveAudioEnabled()`** (USB audio allowed **and** streaming enabled), so the UI/RPC reflects whether audio can actually stream.
> 
> **E2E:** SSH restarts detect **`jetkvm_app` vs `jetkvm_app_debug`**, kill both binaries, and a new remote-agent test asserts the JetKVM ALSA device stays present while **`setAudioConfig`** is toggled; the end-to-end audio test is updated to match the new model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 607a54d220d08611e82e0830c069e22a05fdb58e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->