### PR TITLE
reduce time sync log noise

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions/setup-go@v6
         with:
-          go-version: "^1.25.1"
+          go-version: "1.25.x"
       - run: mkdir -p static && touch static/.gitkeep
       - uses: golangci/golangci-lint-action@v8
         with:

--- a/internal/timesync/http.go
+++ b/internal/timesync/http.go
@@ -99,8 +99,8 @@ func (t *TimeSync) queryMultipleHttp(urls []string, timeout time.Duration) (now 
 				metricHttpTotalCancelCount.Inc()
 				results <- nil
 			} else {
-				scopedLogger.Warn().
-					Str("error", err.Error()).
+				scopedLogger.Debug().
+					Err(err).
 					Int("status", status).
 					Msg("failed to query HTTP server")
 				results <- nil

--- a/internal/timesync/ntp.go
+++ b/internal/timesync/ntp.go
@@ -122,8 +122,8 @@ func (t *TimeSync) queryMultipleNTP(servers []string, timeout time.Duration) (no
 			// query the server
 			now, response, err := queryNtpServer(server, timeout)
 			if err != nil {
-				scopedLogger.Warn().
-					Str("error", err.Error()).
+				scopedLogger.Debug().
+					Err(err).
 					Msg("failed to query NTP server")
 				results <- nil
 				return


### PR DESCRIPTION
## Summary

- Demote per-endpoint NTP query failures from `WARN` to `DEBUG`
- Demote per-endpoint HTTP time query failures from `WARN` to `DEBUG`
- Pin the lint workflow to Go `1.25.x` so `golangci-lint v2.4` does not run under Go 1.26

## Why

When time sync cannot reach external NTP/HTTP sources, each sync attempt currently emits a warning for every attempted server or URL. In diagnostics from #1500, that repeated endpoint-level logging dominated the crash log. The aggregate `failed to sync system time` log remains at the normal level, so operators still see the sync failure without a burst of per-source warnings.

The lint workflow previously used `^1.25.1`, which allowed `actions/setup-go` to install Go 1.26. The prebuilt `golangci-lint v2.4` binary is built with Go 1.25 and panicked when analyzing files requiring Go 1.26, so the workflow now stays on the Go 1.25 minor line.

## Validation

- `GOCACHE=/tmp/go-build-cache go test ./internal/timesync`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only logging changes in time sync plus a minor CI Go version pin; no auth, data, or sync behavior changes.
> 
> **Overview**
> **Reduces time-sync log noise** when NTP or HTTP time sources are unreachable. Per-endpoint failures in `internal/timesync/ntp.go` and `internal/timesync/http.go` now log at **DEBUG** (with `Err(err)` instead of WARN + string error). **NTP kiss-of-death** handling stays at WARN.
> 
> The aggregate **`failed to sync system time`** error in `timesync.go` is unchanged, so operators still see sync failure without a burst of per-server warnings.
> 
> CI **Go lint** workflow pins **`go-version`** from `^1.25.1` to **`1.25.x`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1cab877493c824fbc8b59edcf73eed258ba3ddbc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->