### PR TITLE
Fix native failsafe activation

### DIFF
--- a/.devcontainer/install-deps.sh
+++ b/.devcontainer/install-deps.sh
@@ -50,12 +50,12 @@ sudo apt-get update && \
     sudo apt-get install -y --no-install-recommends "${APT_PACKAGES[@]}" && \
     sudo rm -rf /var/lib/apt/lists/*
 
-# Install buildkit
-BUILDKIT_VERSION="v0.2.5"
+# Install buildkit from the latest rv1106-system GitHub release.
+BUILDKIT_URL="https://github.com/jetkvm/rv1106-system/releases/latest/download/kvm-native-buildkit.tar.zst"
 BUILDKIT_TMPDIR="$(mktemp -d)"
 pushd "${BUILDKIT_TMPDIR}" > /dev/null
 
-wget https://github.com/jetkvm/rv1106-system/releases/download/${BUILDKIT_VERSION}/buildkit.tar.zst && \
+wget -O buildkit.tar.zst "${BUILDKIT_URL}" && \
     sudo mkdir -p /opt/jetkvm-native-buildkit && \
     sudo tar --use-compress-program="unzstd --long=31" -xvf buildkit.tar.zst -C /opt/jetkvm-native-buildkit && \
     rm buildkit.tar.zst

--- a/failsafe.go
+++ b/failsafe.go
@@ -3,9 +3,8 @@ package kvm
 import (
 	"io"
 	"os"
-	"strings"
 
-	"github.com/jetkvm/kvm/internal/supervisor"
+	"github.com/jetkvm/kvm/internal/failsafe"
 	"github.com/jetkvm/kvm/internal/sync"
 )
 
@@ -79,18 +78,14 @@ func checkFailsafeReason() {
 		failsafeCrashLog = content
 		_ = os.Remove(lastCrashPath)
 
-		// TODO: read the goroutine stack trace and check which goroutine is panicking
+		reason, activate := failsafe.ClassifyCrashLog(failsafeCrashLog)
+		if !activate {
+			l.Info().Str("reason", reason).Msg("last crash log does not activate failsafe mode")
+			return
+		}
+
 		failsafeModeActive = true
-		if strings.Contains(failsafeCrashLog, supervisor.FailsafeReasonVideoMaxRestartAttemptsReached) {
-			failsafeModeReason = "video"
-			return
-		}
-		if strings.Contains(failsafeCrashLog, "runtime.cgocall") {
-			failsafeModeReason = "video"
-			return
-		} else {
-			failsafeModeReason = "unknown"
-		}
+		failsafeModeReason = reason
 	})
 }
 

--- a/internal/failsafe/classifier.go
+++ b/internal/failsafe/classifier.go
@@ -1,0 +1,20 @@
+package failsafe
+
+import (
+	"strings"
+
+	"github.com/jetkvm/kvm/internal/supervisor"
+)
+
+const (
+	ReasonNative  = "native"
+	ReasonUnknown = "unknown"
+)
+
+func ClassifyCrashLog(crashLog string) (string, bool) {
+	if strings.Contains(crashLog, supervisor.FailsafeReasonNativeMaxRestartAttemptsReached) {
+		return ReasonNative, true
+	}
+
+	return ReasonUnknown, false
+}

--- a/internal/failsafe/classifier_test.go
+++ b/internal/failsafe/classifier_test.go
@@ -1,0 +1,54 @@
+package failsafe
+
+import (
+	"testing"
+
+	"github.com/jetkvm/kvm/internal/supervisor"
+)
+
+func TestClassifyCrashLog(t *testing.T) {
+	tests := []struct {
+		name     string
+		crashLog string
+		reason   string
+		active   bool
+	}{
+		{
+			name:     "native restart exhaustion marker activates native failsafe",
+			crashLog: "max restart attempts reached, exiting: " + supervisor.FailsafeReasonNativeMaxRestartAttemptsReached,
+			reason:   ReasonNative,
+			active:   true,
+		},
+		{
+			name:     "empty crash log is diagnostic only",
+			crashLog: "",
+			reason:   ReasonUnknown,
+			active:   false,
+		},
+		{
+			name: "native looking crash without marker is diagnostic only",
+			crashLog: `goroutine 1 [syscall]:
+runtime.cgocall()
+github.com/jetkvm/kvm/internal/native.NewNative(...)`,
+			reason: ReasonUnknown,
+			active: false,
+		},
+		{
+			name: "network monitor crash is diagnostic only",
+			crashLog: `SIGILL: illegal instruction
+github.com/vishvananda/netlink.(*Handle).LinkByName
+github.com/jetkvm/kvm/pkg/nmlite.(*InterfaceManager).monitorInterfaceState`,
+			reason: ReasonUnknown,
+			active: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason, active := ClassifyCrashLog(tt.crashLog)
+			if reason != tt.reason || active != tt.active {
+				t.Fatalf("ClassifyCrashLog() = (%q, %v), want (%q, %v)", reason, active, tt.reason, tt.active)
+			}
+		})
+	}
+}

--- a/internal/native/proxy.go
+++ b/internal/native/proxy.go
@@ -459,7 +459,7 @@ func (p *NativeProxy) restartProcess() error {
 	logger := p.logger.With().Uint("attempt", p.restarts).Uint("maxAttempts", p.options.MaxRestartAttempts).Logger()
 
 	if p.restarts >= p.options.MaxRestartAttempts {
-		logger.Fatal().Msgf("max restart attempts reached, exiting: %s", supervisor.FailsafeReasonVideoMaxRestartAttemptsReached)
+		logger.Fatal().Msgf("max restart attempts reached, exiting: %s", supervisor.FailsafeReasonNativeMaxRestartAttemptsReached)
 		return fmt.Errorf("max restart attempts reached")
 	}
 

--- a/internal/supervisor/consts.go
+++ b/internal/supervisor/consts.go
@@ -8,5 +8,5 @@ const (
 	ErrorDumpTemplate = "jetkvm-%s.log"              // The error dump template is the template for the error dump file
 	AppLogPath        = "/userdata/jetkvm/last.log"  // The application stdout/stderr log file
 
-	FailsafeReasonVideoMaxRestartAttemptsReached = "failsafe::video.max_restart_attempts_reached"
+	FailsafeReasonNativeMaxRestartAttemptsReached = "failsafe::native.max_restart_attempts_reached"
 )

--- a/ui/e2e/failsafe.spec.ts
+++ b/ui/e2e/failsafe.spec.ts
@@ -1,0 +1,116 @@
+import { test, expect, type Page } from "@playwright/test";
+
+import {
+  dismissSessionTakeoverDialog,
+  ensureLocalAuthMode,
+  restartAppViaSSH,
+  sshExec,
+} from "./helpers";
+
+const CRASHDUMP_DIR = "/userdata/jetkvm/crashdump";
+const LAST_CRASH_LOG = `${CRASHDUMP_DIR}/last-crash.log`;
+const TEST_CRASH_PREFIX = `${CRASHDUMP_DIR}/e2e-failsafe`;
+const NATIVE_FAILSAFE_SENTINEL = "failsafe::native.max_restart_attempts_reached";
+const NATIVE_FAILSAFE_COPY = "Native stack disabled after repeated failures.";
+
+async function prepareConfiguredDevice(page: Page): Promise<void> {
+  await clearTestCrashdump();
+  await restartAppViaSSH();
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await ensureLocalAuthMode(page, { mode: "noPassword" });
+  await dismissSessionTakeoverDialog(page);
+}
+
+async function writeSupervisorCrashLog(name: string, content: string): Promise<void> {
+  const path = `${TEST_CRASH_PREFIX}-${name}.log`;
+  const encoded = Buffer.from(content).toString("base64");
+  await sshExec(
+    `mkdir -p ${CRASHDUMP_DIR} && ` +
+      `rm -f ${LAST_CRASH_LOG} ${path} && ` +
+      `printf %s ${encoded} | base64 -d > ${path} && ` +
+      `ln -s ${path} ${LAST_CRASH_LOG} && sync`,
+  );
+}
+
+async function clearTestCrashdump(): Promise<void> {
+  await sshExec(`rm -f ${LAST_CRASH_LOG} ${TEST_CRASH_PREFIX}-*.log && sync`, true);
+}
+
+async function expectNativeFailsafeOverlay(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await dismissSessionTakeoverDialog(page);
+  await expect(page.getByText(NATIVE_FAILSAFE_COPY)).toBeVisible({ timeout: 30000 });
+}
+
+async function expectNoNativeFailsafeOverlay(page: Page): Promise<void> {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+  await dismissSessionTakeoverDialog(page);
+  await expect(page.getByText(NATIVE_FAILSAFE_COPY)).toBeHidden({ timeout: 15000 });
+}
+
+async function readAppLog(): Promise<string> {
+  return sshExec("cat /userdata/jetkvm/last.log", true);
+}
+
+async function lastCrashLogState(): Promise<string> {
+  return sshExec(
+    `if [ -e ${LAST_CRASH_LOG} ] || [ -L ${LAST_CRASH_LOG} ]; then echo present; else echo missing; fi`,
+    true,
+  ).then(output => output.trim());
+}
+
+test.describe("Failsafe startup classification", () => {
+  test.setTimeout(180000);
+  test.describe.configure({ mode: "serial" });
+
+  test.beforeEach(async ({ page }) => {
+    await prepareConfiguredDevice(page);
+  });
+
+  test.afterEach(async () => {
+    await clearTestCrashdump();
+    await restartAppViaSSH();
+  });
+
+  test("plain app crash log is diagnostic only", async ({ page }) => {
+    await writeSupervisorCrashLog(
+      "plain-crash",
+      `SIGILL: illegal instruction
+github.com/vishvananda/netlink.(*Handle).LinkByName
+github.com/jetkvm/kvm/pkg/nmlite.(*InterfaceManager).monitorInterfaceState
+`,
+    );
+
+    await restartAppViaSSH();
+    await expectNoNativeFailsafeOverlay(page);
+
+    const log = await readAppLog();
+    expect(log).not.toContain("failsafe mode activated");
+    expect(await lastCrashLogState()).toBe("missing");
+  });
+
+  test("native restart exhaustion activates failsafe once", async ({ page }) => {
+    await writeSupervisorCrashLog(
+      "native-restart-exhausted",
+      `max restart attempts reached, exiting: ${NATIVE_FAILSAFE_SENTINEL}
+`,
+    );
+
+    await restartAppViaSSH();
+    await expectNativeFailsafeOverlay(page);
+
+    let log = await readAppLog();
+    expect(log).toContain("failsafe mode active, using empty native interface");
+    expect(await lastCrashLogState()).toBe("missing");
+
+    await restartAppViaSSH();
+    await expectNoNativeFailsafeOverlay(page);
+
+    log = await readAppLog();
+    expect(log).not.toContain("failsafe mode activated");
+    expect(log).not.toContain("failsafe mode active, using empty native interface");
+  });
+});

--- a/ui/src/components/FailSafeModeBanner.tsx
+++ b/ui/src/components/FailSafeModeBanner.tsx
@@ -9,8 +9,8 @@ interface FailsafeModeBannerProps {
 export function FailsafeModeBanner({ reason }: FailsafeModeBannerProps) {
   const getReasonMessage = () => {
     switch (reason) {
-      case "video":
-        return "Failsafe Mode Active: Video-related settings are currently unavailable";
+      case "native":
+        return "Failsafe Mode Active: Native settings are currently unavailable";
       default:
         return "Failsafe Mode Active: Some settings may be unavailable";
     }

--- a/ui/src/components/FailSafeModeOverlay.tsx
+++ b/ui/src/components/FailSafeModeOverlay.tsx
@@ -38,10 +38,9 @@ export function FailSafeModeOverlay({ reason }: FailSafeModeOverlayProps) {
 
   const getReasonCopy = () => {
     switch (reason) {
-      case "video":
+      case "native":
         return {
-          message:
-            "We've detected an issue with the video capture process. Your device is still running and accessible, but video streaming is temporarily unavailable.",
+          message: "Native stack disabled after repeated failures.",
         };
       default:
         return {
@@ -60,7 +59,7 @@ export function FailSafeModeOverlay({ reason }: FailSafeModeOverlayProps) {
     try {
       // Open GitHub issue
       const issueBody = `## Issue Description
-The \`${reason}\` process encountered an error and failsafe mode was activated.
+The \`${reason}\` stack encountered repeated failures and failsafe mode was activated.
 
 **Reason:** \`${reason}\`
 **Timestamp:** ${new Date().toISOString()}

--- a/ui/src/hooks/useJsonRpc.ts
+++ b/ui/src/hooks/useJsonRpc.ts
@@ -36,7 +36,7 @@ let requestCounter = 0;
 
 // Map of blocked RPC methods by failsafe reason
 const blockedMethodsByReason: Record<string, string[]> = {
-  video: [
+  native: [
     "setStreamQualityFactor",
     "setVideoCodecPreference",
     "getEDID",

--- a/ui/src/routes/devices.$id.settings.tsx
+++ b/ui/src/routes/devices.$id.settings.tsx
@@ -36,7 +36,7 @@ export default function SettingsRoute() {
     ref: scrollContainerRef as React.RefObject<HTMLDivElement>,
   });
   const { isFailsafeMode, reason: failsafeReason } = useFailsafeModeStore();
-  const isVideoDisabled = isFailsafeMode && failsafeReason === "video";
+  const isNativeDisabled = isFailsafeMode && failsafeReason === "native";
 
   // Handle scroll position to show/hide gradients
   const handleScroll = () => {
@@ -158,14 +158,14 @@ export default function SettingsRoute() {
                 </FeatureFlag>
                 <div
                   className={cx("shrink-0", {
-                    "cursor-not-allowed opacity-50": isVideoDisabled,
+                    "cursor-not-allowed opacity-50": isNativeDisabled,
                   })}
                 >
                   <NavLink
                     to="video"
                     className={({ isActive }) =>
                       cx(isActive ? "active" : "", {
-                        "pointer-events-none": isVideoDisabled,
+                        "pointer-events-none": isNativeDisabled,
                       })
                     }
                   >
@@ -185,14 +185,14 @@ export default function SettingsRoute() {
                 </div>
                 <div
                   className={cx("shrink-0", {
-                    "cursor-not-allowed opacity-50": isVideoDisabled,
+                    "cursor-not-allowed opacity-50": isNativeDisabled,
                   })}
                 >
                   <NavLink
                     to="hardware"
                     className={({ isActive }) =>
                       cx(isActive ? "active" : "", {
-                        "pointer-events-none": isVideoDisabled,
+                        "pointer-events-none": isNativeDisabled,
                       })
                     }
                   >

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -1094,7 +1094,7 @@ export default function KvmIdRoute() {
           )}
 
           <div className="relative flex h-full w-full overflow-hidden">
-            {isFailsafeMode && failsafeReason === "video" ? null : (
+            {isFailsafeMode && failsafeReason === "native" ? null : (
               <WebRTCVideo
                 hasConnectionIssues={!!ConnectionStatusElement}
                 hideStatusBar={hideStatusBar}


### PR DESCRIPTION
## Summary
- Require the native restart-exhaustion sentinel before startup activates failsafe mode.
- Rename the failsafe reason from video to native and update the related UI blocking/copy.
- Add classifier unit coverage plus real-device E2E coverage for diagnostic crashes, native restart exhaustion, and one-shot recovery after restart.
- Download the native buildkit from the latest rv1106-system release asset.

## Root Cause
Startup treated any supervisor `last-crash.log` as enough to activate failsafe mode, with an additional `runtime.cgocall` heuristic. That allowed unrelated app crashes to disable native-backed features even when the native process had not exhausted its restart budget.

## Validation
- `GOCACHE=/tmp/go-cache-kvm-failsafe go test ./...`
- `bash -n .devcontainer/install-deps.sh`
- `make test_e2e DEVICE_IP=192.168.1.231 JETKVM_REMOTE_HOST=tony@192.168.1.135` (71 passed on the real device)
- `wget --spider -T 20 https://github.com/jetkvm/rv1106-system/releases/latest/download/kvm-native-buildkit.tar.zst`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the device enters recovery mode and which UI/RPC paths are blocked, which can affect video and native settings after crashes; behavior is narrowed intentionally with new tests.
> 
> **Overview**
> Tightens **startup failsafe** so unrelated supervisor crash logs no longer disable native-backed features. Crash handling now goes through `failsafe.ClassifyCrashLog`, which **only** turns on failsafe when `last-crash.log` contains the native max-restart sentinel; the old `runtime.cgocall` / broad “video” heuristics are removed.
> 
> The failsafe reason is renamed **`video` → `native`** end-to-end: supervisor marker string, native proxy fatal exit message, UI copy/overlays, JSON-RPC method blocks, and settings nav disabling for video/hardware. On native failsafe, the main device view **hides** the WebRTC video element while showing the recovery overlay.
> 
> Adds **unit tests** for the classifier and **Playwright E2E** on a real device (diagnostic-only crash vs sentinel activation and one-shot recovery after restart). Devcontainer install pulls the native buildkit from the **latest** `rv1106-system` release asset instead of a pinned tarball.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b2f46a29f7a26e4e870d4729878892a619c3640e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->