### PR TITLE
Validate URL mounts before mounting

### DIFF
--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -35,6 +35,7 @@ import {
   type RemoteAgent,
   type MouseEvent as RAMouseEvent,
   type KeyboardEvent as RAKeyboardEvent,
+  type MountInfo,
 } from "./remote-agent";
 
 /** Run a command on the remote host (the machine whose display is captured by the KVM). */
@@ -154,6 +155,10 @@ function remoteHostSupportsS3(): { supported: boolean; reason?: string } {
   }
 
   return { supported: true };
+}
+
+function mountKey(mount: MountInfo): string {
+  return `${mount.device}|${mount.mount_point}`;
 }
 
 function enableRemoteHostUSBWake(options: { includeRootHub?: boolean } = {}): void {
@@ -2325,6 +2330,9 @@ test.describe("Remote Host Agent", () => {
   // VIRTUAL MEDIA
   // ═══════════════════════════════════════════
 
+  const MISSING_IMAGE_URL = "https://deb.debian.org/debian/jetkvm-missing-image.iso";
+  const MISSING_IMAGE_ERROR = /The URL is not available/;
+
   test("virtual-media: mount ISO from URL and verify, then unmount", async () => {
     test.setTimeout(60_000);
 
@@ -2360,6 +2368,59 @@ test.describe("Remote Host Agent", () => {
 
     const finalDevices = await agent!.getUSBDevices();
     expect(finalDevices.length).toBeGreaterThan(0);
+  });
+
+  test("virtual-media: unavailable URL is rejected without mounting", async () => {
+    test.setTimeout(30_000);
+
+    try {
+      await callJsonRpc(sharedPage, "unmountImage");
+    } catch {
+      /* ok if nothing mounted */
+    }
+
+    const stateBefore = (await callJsonRpc(sharedPage, "getVirtualMediaState")) as null | object;
+    expect(stateBefore).toBeNull();
+
+    const baselineMounts = new Set((await agent!.getMounts()).map(mountKey));
+
+    await expect(
+      callJsonRpc(sharedPage, "mountWithHTTP", { url: MISSING_IMAGE_URL, mode: "CDROM" }),
+    ).rejects.toThrow(MISSING_IMAGE_ERROR);
+
+    const stateAfter = (await callJsonRpc(sharedPage, "getVirtualMediaState")) as null | object;
+    expect(stateAfter).toBeNull();
+
+    await agent!.waitForMount(mount => !baselineMounts.has(mountKey(mount)), false, 5_000);
+  });
+
+  test("virtual-media: URL mount form shows unavailable image error", async () => {
+    test.setTimeout(30_000);
+
+    try {
+      await callJsonRpc(sharedPage, "unmountImage");
+    } catch {
+      /* ok if nothing mounted */
+    }
+
+    const baselineMounts = new Set((await agent!.getMounts()).map(mountKey));
+
+    await sharedPage.getByRole("button", { name: "Virtual Media" }).click();
+    await sharedPage.getByRole("button", { name: "Add New Media" }).click();
+    await sharedPage.getByRole("button", { name: "Continue" }).click();
+    await sharedPage.getByPlaceholder("https://example.com/image.iso").fill(MISSING_IMAGE_URL);
+    await sharedPage.getByRole("button", { name: "Mount URL" }).click();
+
+    await expect(sharedPage.getByRole("heading", { name: "Mount Error" })).toBeVisible();
+    await expect(sharedPage.getByText(MISSING_IMAGE_ERROR)).toBeVisible();
+
+    const stateAfter = (await callJsonRpc(sharedPage, "getVirtualMediaState")) as null | object;
+    expect(stateAfter).toBeNull();
+
+    await agent!.waitForMount(mount => !baselineMounts.has(mountKey(mount)), false, 5_000);
+
+    await sharedPage.getByRole("button", { name: "Close" }).click();
+    await ensureRpcReady(sharedPage);
   });
 
   test("virtual-media: mount ISO as Disk mode preserves keyboard (#560)", async () => {

--- a/ui/src/routes/devices.$id.mount.tsx
+++ b/ui/src/routes/devices.$id.mount.tsx
@@ -70,7 +70,11 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
 
     setMountInProgress(true);
     send("mountWithHTTP", { url, mode }, (resp: JsonRpcResponse) => {
-      if ("error" in resp) triggerError(resp.error.message);
+      if ("error" in resp) {
+        triggerError(typeof resp.error.data === "string" ? resp.error.data : resp.error.message);
+        setMountInProgress(false);
+        return;
+      }
 
       clearMountMediaState();
       syncRemoteVirtualMediaState()
@@ -335,8 +339,9 @@ function UrlView({
       icon: UbuntuIcon,
     },
     {
-      name: "Debian 13 Trixie",
-      url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.4.0-amd64-netinst.iso",
+      name: "Debian 13 Trixie Netinst",
+      // Debian netinst filenames are point-release pinned in /current/.
+      url: "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-13.5.0-amd64-netinst.iso",
       icon: DebianIcon,
     },
     {

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	neturl "net/url"
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -195,13 +197,105 @@ func getMassStorageCDROMEnabled() (bool, error) {
 }
 
 type VirtualMediaUrlInfo struct {
-	Usable bool
-	Reason string //only populated if Usable is false
-	Size   int64
+	Usable bool   `json:"usable"`
+	Reason string `json:"reason,omitempty"`
+	Size   int64  `json:"size"`
 }
 
-func rpcCheckMountUrl(url string) (*VirtualMediaUrlInfo, error) {
-	return nil, errors.New("not implemented")
+func rpcCheckMountUrl(rawURL string) (*VirtualMediaUrlInfo, error) {
+	rawURL = strings.TrimSpace(rawURL)
+	parsedURL, err := neturl.Parse(rawURL)
+	if err != nil || parsedURL.Scheme == "" || parsedURL.Host == "" {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "Enter a valid HTTP or HTTPS image URL.",
+		}, nil
+	}
+	if parsedURL.Scheme != "http" && parsedURL.Scheme != "https" {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "Only HTTP and HTTPS image URLs can be mounted.",
+		}, nil
+	}
+
+	req, err := http.NewRequest(http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check url: %w", err)
+	}
+	req.Header.Set("Range", "bytes=0-0")
+
+	resp, err := (&http.Client{Timeout: 10 * time.Second}).Do(req)
+	if err != nil {
+		logger.Warn().Err(err).Str("url", rawURL).Msg("failed to check virtual media url")
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL is not available. Check the image URL and try again.",
+		}, nil
+	}
+	if err := resp.Body.Close(); err != nil {
+		logger.Warn().Err(err).Str("url", rawURL).Msg("failed to close virtual media url check response")
+	}
+
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		status := fmt.Sprintf("HTTP %d", resp.StatusCode)
+		if statusText := http.StatusText(resp.StatusCode); statusText != "" {
+			status += " " + statusText
+		}
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: fmt.Sprintf("The URL is not available (%s). Check the image URL and try again.", status),
+		}, nil
+	}
+
+	if resp.StatusCode != http.StatusPartialContent {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL is available, but the server does not support byte-range requests.",
+		}, nil
+	}
+
+	contentRange := strings.TrimSpace(resp.Header.Get("Content-Range"))
+	if strings.HasSuffix(contentRange, "/*") {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL is available, but the server did not report the image size.",
+		}, nil
+	}
+
+	rangeFields := strings.Fields(contentRange)
+	if len(rangeFields) != 2 || strings.ToLower(rangeFields[0]) != "bytes" {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL is available, but the server returned an unreadable range response.",
+		}, nil
+	}
+
+	rangeParts := strings.Split(rangeFields[1], "/")
+	if len(rangeParts) != 2 || rangeParts[1] == "*" {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL is available, but the server returned an unreadable range response.",
+		}, nil
+	}
+
+	size, err := strconv.ParseInt(rangeParts[1], 10, 64)
+	if err != nil {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL is available, but the server returned an unreadable range response.",
+		}, nil
+	}
+	if size <= 0 {
+		return &VirtualMediaUrlInfo{
+			Usable: false,
+			Reason: "The URL points to an empty file.",
+		}, nil
+	}
+
+	return &VirtualMediaUrlInfo{
+		Usable: true,
+		Size:   size,
+	}, nil
 }
 
 type VirtualMediaSource string
@@ -332,17 +426,30 @@ func setInitialVirtualMediaState() error {
 }
 
 func prepareHTTPMount(url string, mode VirtualMediaMode) error {
+	url = strings.TrimSpace(url)
+
+	virtualMediaStateMutex.RLock()
+	alreadyMounted := currentVirtualMediaState != nil
+	virtualMediaStateMutex.RUnlock()
+	if alreadyMounted {
+		return fmt.Errorf("another virtual media is already mounted")
+	}
+
+	urlInfo, err := rpcCheckMountUrl(url)
+	if err != nil {
+		return err
+	}
+	if !urlInfo.Usable {
+		return errors.New(urlInfo.Reason)
+	}
+
 	virtualMediaStateMutex.Lock()
 	defer virtualMediaStateMutex.Unlock()
 	if currentVirtualMediaState != nil {
 		return fmt.Errorf("another virtual media is already mounted")
 	}
 	httpRangeReader = httpreadat.New(url)
-	n, err := httpRangeReader.Size()
-	if err != nil {
-		return fmt.Errorf("failed to use http url: %w", err)
-	}
-	logger.Info().Str("url", url).Int64("size", n).Msg("using remote url")
+	logger.Info().Str("url", url).Int64("size", urlInfo.Size).Msg("using remote url")
 
 	if err := setMassStorageMode(mode == CDROM); err != nil {
 		return fmt.Errorf("failed to set mass storage mode: %w", err)
@@ -352,7 +459,7 @@ func prepareHTTPMount(url string, mode VirtualMediaMode) error {
 		Source: HTTP,
 		Mode:   mode,
 		URL:    url,
-		Size:   n,
+		Size:   urlInfo.Size,
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Replace the stale Debian shortcut with the stable netboot image.
- Probe URL mounts with a one-byte range request before mounting so missing or unusable images are rejected.
- Surface friendly URL mount failures in the dialog and keep mount state unchanged after failures.
- Add remote-agent coverage for rejected unavailable URLs without new mounts.

## Validation
- `git diff --check`
- `go test ./...`
- `make check`
- Remote-agent run reached and passed the successful URL mount and direct unavailable URL/no-new-mount checks; the broader run also reported remote-host audio setup failures unrelated to this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes virtual media mount path and outbound HTTP from the device; failures are safer but a bad probe could block valid mirrors that lack range support.
> 
> **Overview**
> HTTP virtual media mounts are **validated before** NBD/USB setup: the backend implements `rpcCheckMountUrl` with a `bytes=0-0` range request and rejects invalid schemes, unreachable URLs, non-206 responses, missing `Content-Range` size, and empty images. **`prepareHTTPMount`** runs that check (and blocks double-mount) before creating the range reader and updating mount state, so bad URLs fail without partial mounts.
> 
> The mount dialog **surfaces** server-provided error text (`error.data` when present) and **clears** the in-progress state on URL mount failure. The Debian Trixie shortcut ISO URL is bumped to **13.5.0** netinst.
> 
> Remote-agent E2E adds RPC and UI tests that unavailable URLs show *The URL is not available* and leave virtual media state and host mounts unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72f15ebc2e6e69b22f06077b7b8f4d6c86523358. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->