### PR TITLE
Set video codec before native stream start

### DIFF
--- a/e2e/remote-agent/main.go
+++ b/e2e/remote-agent/main.go
@@ -512,10 +512,17 @@ func getDisplayInfo() []DisplayInfo {
 var aplayDeviceRE = regexp.MustCompile(`^card ([0-9]+): ([^ ]+) \[(.*)\], device ([0-9]+): .*\[(.*)\]`)
 
 func isJetKVMUSBAudioDevice(d AudioDeviceInfo) bool {
-	if strings.EqualFold(strings.TrimSpace(d.USBID), "1d6b:0104") {
+	usbID := strings.ToLower(strings.TrimSpace(d.USBID))
+	if usbID == "1d6b:0104" {
 		return true
 	}
-	return strings.Contains(strings.ToLower(d.Name+" "+d.Description), "jetkvm usb emulation device")
+
+	deviceText := strings.ToLower(d.Name + " " + d.Description)
+	if usbID == "0573:1573" && strings.Contains(deviceText, "usb audio and hid") {
+		return true
+	}
+
+	return strings.Contains(deviceText, "jetkvm usb emulation device")
 }
 
 func listAudioDevices() []AudioDeviceInfo {

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -2555,39 +2555,39 @@ test.describe("Remote Host Agent", () => {
   // ═══════════════════════════════════════════
 
   test("usb: serial console CDC-ACM toggle creates and removes ttyACM on host", async () => {
-    test.setTimeout(30_000);
+    test.setTimeout(90_000);
 
     test.skip(!process.env.JETKVM_REMOTE_HOST, "JETKVM_REMOTE_HOST not set");
 
-    // Ensure serial console is off initially
-    await callJsonRpc(sharedPage, "setUsbDevices", {
-      devices: { ...USB_DEVICES_DEFAULT, serial_console: false },
-    });
-
     // Verify the host does NOT see a ttyACM device
-    const beforeACM = await waitForRemoteHostTtyACM(false);
+    const beforeACM = await usbReconfigWithRetry(
+      "setUsbDevices",
+      { devices: { ...USB_DEVICES_DEFAULT, serial_console: false } },
+      attemptMs => waitForRemoteHostTtyACM(false, attemptMs),
+      45_000,
+    );
     expect(beforeACM).toBe("");
 
-    // Enable serial console
-    await callJsonRpc(sharedPage, "setUsbDevices", {
-      devices: { ...USB_DEVICES_DEFAULT, serial_console: true },
-    });
-
     // Verify the host now sees a ttyACM device
-    const afterACM = await waitForRemoteHostTtyACM(true);
+    const afterACM = await usbReconfigWithRetry(
+      "setUsbDevices",
+      { devices: { ...USB_DEVICES_DEFAULT, serial_console: true } },
+      attemptMs => waitForRemoteHostTtyACM(true, attemptMs),
+      45_000,
+    );
     expect(afterACM).toContain("ttyACM");
 
     // Verify /dev/ttyGS0 exists on the KVM device
     const afterGS0 = (await sshExec("ls /dev/ttyGS0 2>/dev/null || echo MISSING", true)).trim();
     expect(afterGS0).toBe("/dev/ttyGS0");
 
-    // Disable serial console
-    await callJsonRpc(sharedPage, "setUsbDevices", {
-      devices: { ...USB_DEVICES_DEFAULT, serial_console: false },
-    });
-
     // Verify the host no longer sees a ttyACM device
-    const removedACM = await waitForRemoteHostTtyACM(false);
+    const removedACM = await usbReconfigWithRetry(
+      "setUsbDevices",
+      { devices: { ...USB_DEVICES_DEFAULT, serial_console: false } },
+      attemptMs => waitForRemoteHostTtyACM(false, attemptMs),
+      45_000,
+    );
     expect(removedACM).toBe("");
 
     // Verify other USB functions still work (keyboard, mouse)

--- a/ui/e2e/remote-agent/remote-agent.ts
+++ b/ui/e2e/remote-agent/remote-agent.ts
@@ -578,7 +578,7 @@ export class RemoteAgent {
 
     if (needsBuild) {
       console.log("[remote-agent] Building remote-agent binary...");
-      execSync("GOOS=linux GOARCH=amd64 go build -o remote-agent .", {
+      execSync("GOOS=linux GOARCH=amd64 go build -buildvcs=false -o remote-agent .", {
         cwd: agentDir,
         stdio: "inherit",
       });

--- a/webrtc.go
+++ b/webrtc.go
@@ -602,7 +602,7 @@ func newSession(config SessionConfig) (*Session, error) {
 				isConnected = true
 				onActiveSessionsChanged()
 				if incrActiveSessions() == 1 {
-					onFirstSessionConnected()
+					onFirstSessionConnected(session)
 				}
 				onSessionConnected(session)
 				if mqttManager != nil {
@@ -665,10 +665,22 @@ func onActiveSessionsChanged() {
 // capture is a shared pipeline; starting it again on a handoff connect (count
 // 1→2) would issue redundant native start calls and re-run the sleep-mode
 // re-lock wait while video is already streaming.
-func onFirstSessionConnected() {
+func sessionVideoCodecType(session *Session) int {
+	if session.codecMimeType == webrtc.MimeTypeH265 {
+		return 1
+	}
+	return 0
+}
+
+func startNativeVideoForSession(session *Session) {
+	_ = nativeInstance.VideoSetCodecType(sessionVideoCodecType(session))
+	_ = nativeInstance.VideoStart()
+}
+
+func onFirstSessionConnected(session *Session) {
 	stopVideoSleepModeTicker()
 	_ = setHostDisplayAdvertised(true, "first_session_connected", false)
-	_ = nativeInstance.VideoStart()
+	startNativeVideoForSession(session)
 }
 
 // onSessionConnected runs per session when ICE reaches Connected. Uses the
@@ -677,11 +689,6 @@ func onFirstSessionConnected() {
 // connected can fire before then, racing the assignment.
 func onSessionConnected(session *Session) {
 	notifyFailsafeMode(session)
-	if session.codecMimeType == webrtc.MimeTypeH265 {
-		_ = nativeInstance.VideoSetCodecType(1)
-	} else {
-		_ = nativeInstance.VideoSetCodecType(0)
-	}
 	if session.AudioTrack != nil {
 		startAudio(session.AudioTrack)
 	}

--- a/webrtc_test.go
+++ b/webrtc_test.go
@@ -1,0 +1,63 @@
+//go:build linux && arm
+
+package kvm
+
+import (
+	"reflect"
+	"strconv"
+	"testing"
+
+	"github.com/jetkvm/kvm/internal/native"
+	"github.com/pion/webrtc/v4"
+)
+
+type recordingNative struct {
+	native.EmptyNativeInterface
+	calls []string
+}
+
+func (n *recordingNative) VideoSetCodecType(codecType int) error {
+	n.calls = append(n.calls, "set-codec:"+strconv.Itoa(codecType))
+	return nil
+}
+
+func (n *recordingNative) VideoStart() error {
+	n.calls = append(n.calls, "start")
+	return nil
+}
+
+func TestStartNativeVideoForSessionSetsCodecBeforeStart(t *testing.T) {
+	tests := []struct {
+		name  string
+		codec string
+		want  []string
+	}{
+		{
+			name:  "h264",
+			codec: webrtc.MimeTypeH264,
+			want:  []string{"set-codec:0", "start"},
+		},
+		{
+			name:  "h265",
+			codec: webrtc.MimeTypeH265,
+			want:  []string{"set-codec:1", "start"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			originalNative := nativeInstance
+			recorder := &recordingNative{}
+			nativeInstance = recorder
+			t.Cleanup(func() {
+				nativeInstance = originalNative
+			})
+
+			startNativeVideoForSession(&Session{codecMimeType: tt.codec})
+
+			if !reflect.DeepEqual(recorder.calls, tt.want) {
+				t.Fatalf("native calls = %v, want %v", recorder.calls, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Set the native video codec before starting the shared video pipeline on the first active WebRTC session.
- Stop applying codec changes on later session connects while video is already running.
- Tighten remote-agent e2e coverage around USB reconfiguration retries, remote-agent builds, and the current USB audio gadget identity.

## Root Cause
Auto codec negotiation can select H265, but the native video pipeline was starting before the codec type was applied. That can leave the browser receiving RTP without decodable frames until a later reconnect.

## Validation
- Targeted remote-agent e2e passed against the device and remote host.
- Remote-agent amd64 build with `-buildvcs=false`.
- Playwright remote-agent specs parse cleanly.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes first-session native video startup order and codec selection, which affects all viewers’ initial decode path; scope is narrow and covered by a targeted unit test plus e2e tweaks.
> 
> **Overview**
> Fixes **H.265 auto-negotiation** leaving the browser with RTP but no decodable frames by applying the native codec **before** `VideoStart()` when the **first** WebRTC session connects, using that session’s negotiated MIME type.
> 
> **`onFirstSessionConnected`** now takes the connecting `*Session` and calls new helpers `startNativeVideoForSession` / `sessionVideoCodecType`; **`onSessionConnected`** no longer calls `VideoSetCodecType` on every ICE connect (avoids redundant native work while video is already running). **`webrtc_test.go`** records native call order for H.264 vs H.265.
> 
> E2E/support: remote-agent **`isJetKVMUSBAudioDevice`** also matches USB **`0573:1573`** (“usb audio and hid”); CDC-ACM spec uses **`usbReconfigWithRetry`** and longer timeouts; remote-agent **`go build`** adds **`-buildvcs=false`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc618fbd2e8b182d67648af72321ccc6d289b23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->