### PR TITLE
fix: surface out_of_range error for unsupported HDMI resolution (>1080p)

### DIFF
--- a/native.go
+++ b/native.go
@@ -37,6 +37,7 @@ func initNative(systemVersion *semver.Version, appVersion *semver.Version) {
 			_ = reapplyHostDisplayAdvertisement("native_restarted")
 		},
 		OnVideoStateChange: func(state native.VideoState) {
+			state = unsupportedResolutionState(state)
 			lastVideoState = state
 			triggerVideoStateUpdate()
 			requestDisplayUpdate(false, "video_state_changed")

--- a/video.go
+++ b/video.go
@@ -37,6 +37,14 @@ func rpcGetVideoState() (native.VideoState, error) {
 	return lastVideoState, nil
 }
 
+func unsupportedResolutionState(state native.VideoState) native.VideoState {
+	if state.Error == "" && (state.Width > 1920 || state.Height > 1080) {
+		state.Error = "out_of_range"
+		state.Ready = false
+	}
+	return state
+}
+
 var (
 	hostDisplayAdvertiseLock = sync.Mutex{}
 	hostDisplayAdvertised    bool

--- a/video_test.go
+++ b/video_test.go
@@ -1,0 +1,47 @@
+//go:build linux && arm
+
+package kvm
+
+import (
+	"testing"
+
+	"github.com/jetkvm/kvm/internal/native"
+)
+
+func TestUnsupportedResolutionState(t *testing.T) {
+	tests := []struct {
+		name  string
+		input native.VideoState
+		want  native.VideoState
+	}{
+		{
+			name:  "1920x1080 no error unchanged",
+			input: native.VideoState{Ready: true, Width: 1920, Height: 1080},
+			want:  native.VideoState{Ready: true, Width: 1920, Height: 1080},
+		},
+		{
+			name:  "3840x2160 no error becomes out_of_range",
+			input: native.VideoState{Ready: true, Width: 3840, Height: 2160},
+			want:  native.VideoState{Ready: false, Error: "out_of_range", Width: 3840, Height: 2160},
+		},
+		{
+			name:  "1920x1080 no_signal unchanged",
+			input: native.VideoState{Ready: false, Error: "no_signal", Width: 1920, Height: 1080},
+			want:  native.VideoState{Ready: false, Error: "no_signal", Width: 1920, Height: 1080},
+		},
+		{
+			name:  "3840x2160 no_lock keeps no_lock",
+			input: native.VideoState{Ready: false, Error: "no_lock", Width: 3840, Height: 2160},
+			want:  native.VideoState{Ready: false, Error: "no_lock", Width: 3840, Height: 2160},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := unsupportedResolutionState(tt.input)
+			if got != tt.want {
+				t.Errorf("unsupportedResolutionState(%+v) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Problem
When the HDMI source resolution exceeds 1920x1080, the native layer reports real `Width`/`Height` but leaves `Error` empty, so the video state is never classified as `out_of_range`. The UI then hangs indefinitely on "Loading video stream…" instead of showing the incompatible-resolution error.

Fixes #1482

## Change
- Add a small pure helper `unsupportedResolutionState` in `video.go`: when `Error == ""` and `Width > 1920 || Height > 1080`, set `Error = "out_of_range"` and `Ready = false`.
- Apply it in `OnVideoStateChange` before `lastVideoState` is stored/emitted, so the existing `out_of_range` → `HDMIErrorOverlay` pipeline lights up and `rpcGetVideoState` reports the same state for automation.

The classification is only applied when no more specific error is already present (`no_signal`/`no_lock` still win), and it is idempotent.

## Scope
- Go-only, additive: one helper + one call site. No change to the event payload, the UI, or MQTT.
- No frame-rate/interlaced handling and no device-side C detection (possible follow-up).

## Testing
- Added `TestUnsupportedResolutionState` (table-driven): 1920x1080/no-error unchanged; 3840x2160/no-error → `out_of_range`, `Ready=false`; existing `no_signal`/`no_lock` preserved.
- Device manual check: a >1080p source shows the resolution error overlay instead of an indefinite loading state.