### PR TITLE
feat: add Num Lock / Caps Lock toggle buttons in InfoBar

### DIFF
--- a/ui/e2e/infobar-lock-toggles.spec.ts
+++ b/ui/e2e/infobar-lock-toggles.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from "@playwright/test";
+
+import { ensureLocalAuthMode, waitForWebRTCReady, getLedState, waitForLedState } from "./helpers";
+
+test.describe("InfoBar lock toggle buttons", () => {
+  test.setTimeout(60_000);
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto("/");
+    await page.waitForLoadState("networkidle");
+    await ensureLocalAuthMode(page, { mode: "noPassword" });
+    await waitForWebRTCReady(page);
+  });
+
+  test("Caps Lock toggle button sends scancode and reflects LED state", async ({ page }) => {
+    const initial = await getLedState(page);
+    expect(initial, "LED state should be available").not.toBeNull();
+    const initialCapsLock = initial!.caps_lock;
+
+    const capsBtn = page.getByTestId("caps-lock-toggle");
+    await expect(capsBtn).toBeVisible();
+
+    await capsBtn.click();
+    await waitForLedState(page, "caps_lock", !initialCapsLock);
+
+    await capsBtn.click();
+    await waitForLedState(page, "caps_lock", initialCapsLock);
+  });
+
+  test("Num Lock toggle button sends scancode and reflects LED state", async ({ page }) => {
+    const initial = await getLedState(page);
+    expect(initial, "LED state should be available").not.toBeNull();
+    const initialNumLock = initial!.num_lock;
+
+    const numBtn = page.getByTestId("num-lock-toggle");
+    await expect(numBtn).toBeVisible();
+
+    await numBtn.click();
+    await waitForLedState(page, "num_lock", !initialNumLock);
+
+    await numBtn.click();
+    await waitForLedState(page, "num_lock", initialNumLock);
+  });
+});

--- a/ui/src/components/InfoBar.tsx
+++ b/ui/src/components/InfoBar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import {
   useHidStore,
@@ -9,9 +9,11 @@ import {
   VideoState,
 } from "@hooks/stores";
 import { useHidRpc } from "@hooks/useHidRpc";
+import { useJsonRpc } from "@/hooks/useJsonRpc";
 import { keys, modifiers } from "@/keyboardMappings";
 import { cx } from "@/cva.config";
 import { m } from "@localizations/messages.js";
+import { Button } from "@components/Button";
 
 export default function InfoBar() {
   const { keysDownState } = useHidStore();
@@ -31,6 +33,18 @@ export default function InfoBar() {
   const { keyboardLedState, usbState } = useHidStore();
   const { isTurnServerInUse, peerConnection, peerConnectionState } = useRTCStore();
   const { hdmiState } = useVideoStore();
+
+  const { send } = useJsonRpc();
+
+  const sendLockKey = useCallback(
+    (keyCode: number) => {
+      send("keypressReport", { key: keyCode, press: true });
+      setTimeout(() => {
+        send("keypressReport", { key: keyCode, press: false });
+      }, 20);
+    },
+    [send],
+  );
 
   const [videoCodec, setVideoCodec] = useState<string | null>(null);
   const [videoBitrate, setVideoBitrate] = useState<string | null>(null);
@@ -211,27 +225,21 @@ export default function InfoBar() {
             </div>
           )}
 
-          <div
-            className={cx(
-              "shrink-0 p-1 px-1.5 text-xs",
-              keyboardLedState.caps_lock
-                ? "text-black dark:text-white"
-                : "text-slate-800/20 dark:text-slate-300/20",
-            )}
-          >
-            {m.info_caps_lock()}
-          </div>
+          <Button
+            size="XS"
+            theme={keyboardLedState.caps_lock ? "primary" : "light"}
+            text={m.info_caps_lock()}
+            onClick={() => sendLockKey(keys.CapsLock)}
+            data-testid="caps-lock-toggle"
+          />
 
-          <div
-            className={cx(
-              "shrink-0 p-1 px-1.5 text-xs",
-              keyboardLedState.num_lock
-                ? "text-black dark:text-white"
-                : "text-slate-800/20 dark:text-slate-300/20",
-            )}
-          >
-            {m.info_num_lock()}
-          </div>
+          <Button
+            size="XS"
+            theme={keyboardLedState.num_lock ? "primary" : "light"}
+            text={m.info_num_lock()}
+            onClick={() => sendLockKey(keys.NumLock)}
+            data-testid="num-lock-toggle"
+          />
 
           <div
             className={cx(


### PR DESCRIPTION
## Summary
Adds interactive Num Lock and Caps Lock toggle buttons to the InfoBar. Previously the InfoBar only showed non-interactive lock-state indicators; there was no way to toggle the remote lock state from the UI.

Fixes #1464

## Change
- Turn the existing Caps Lock / Num Lock indicators into `Button`s.
- On click, send the lock-key scancode as a press+release pair via the existing `keypressReport` JSON-RPC path (the same backend handler the HID-RPC path reaches).
- Each button's active state is bound to the remote LED state (`keyboardLedState.caps_lock` / `.num_lock`) — primary theme when on, light when off.

The button sends the raw scancode (like the e2e keyboard harness), not through the virtual-keyboard widget's keymap layer, so it is unaffected by the separately-reported virtual-keyboard Caps Lock issue.

## Scope
UI-only. No backend/HID/gadget changes and no new state plumbing (reuses `keyboardLedState`).

## Testing
- `npm run lint` — passes (0 errors).
- `npm run build:device` — passes (tsc + vite).
- Added a device-gated e2e (`ui/e2e/infobar-lock-toggles.spec.ts`) that clicks each toggle and asserts the LED state flips via the existing `waitForLedState` harness. Runs where `JETKVM_URL` is set; skips gracefully otherwise.