### PR TITLE
fix(cdc-acm): don't warn when serial console gadget is disabled

### DIFF
--- a/cdc_acm_console.go
+++ b/cdc_acm_console.go
@@ -15,6 +15,14 @@ func handleCDCACMChannel(d *webrtc.DataChannel) {
 
 	var f *os.File
 	d.OnOpen(func() {
+		// When the serial console gadget is disabled (the default), /dev/ttyGS0
+		// does not exist. Skip quietly instead of warning on every channel open.
+		if config == nil || config.UsbDevices == nil || !config.UsbDevices.SerialConsole {
+			scopedLogger.Debug().Msg("CDC-ACM console is not enabled in USB device configuration")
+			d.Close()
+			return
+		}
+
 		var err error
 		f, err = os.OpenFile(cdcACMDevicePath, os.O_RDWR, 0)
 		if err != nil {


### PR DESCRIPTION
## What
When the USB serial console gadget is disabled (the default config), /dev/ttyGS0 does not exist, but every CDC-ACM data channel open logs a warning:

    WRN Failed to open CDC-ACM device error="open /dev/ttyGS0: no such file or directory"

This repeats on every client session and fills the log with noise for a configuration that is working as intended.

## How
`handleCDCACMChannel` now checks `config.UsbDevices.SerialConsole` before trying to open the device. If the gadget is disabled it logs a single Debug line and closes the channel. The Warn path is preserved for the genuine failure case (gadget enabled but the device could not be opened).

## Testing
Built with the buildkit toolchain and deployed on a JetKVM (v2, system 0.2.8) running a 0.5.8-based build: with the serial console disabled, the warning no longer appears across multiple client sessions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
