### PR TITLE
fix(serial): recover ATX/DC extension workers from transient read errors

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -23,7 +23,7 @@ var consoleBroker *ConsoleBroker
 
 func mountATXControl() error {
 	_ = port.SetMode(defaultMode)
-	go runATXControl()
+	go runATXControl(port)
 
 	return nil
 }
@@ -40,16 +40,35 @@ var (
 	btnPWRState bool
 )
 
-func runATXControl() {
+func runATXControl(p serial.Port) {
 	scopedLogger := serialLogger.With().Str("service", "atx_control").Logger()
 
-	reader := bufio.NewReader(port)
+	reader := bufio.NewReader(p)
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
+			// If the global port has been swapped out (unmount or extension
+			// switch replaces it via reopenSerialPort), the read error is an
+			// intentional shutdown signal for this worker: stop quietly.
+			if port != p {
+				scopedLogger.Debug().Msg("Serial port replaced, stopping ATX control worker")
+				return
+			}
+			// Otherwise the read failed transiently. Back off and retry with a
+			// fresh reader instead of terminating the goroutine permanently.
 			scopedLogger.Warn().Err(err).Msg("Error reading from serial port")
-			return
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			reader = bufio.NewReader(p)
+			continue
 		}
+		// Successful read: reset the backoff.
+		backoff = time.Second
 
 		// Each line should be 4 binary digits + newline
 		if len(line) != 5 {
@@ -141,7 +160,7 @@ func pressATXResetButton(duration time.Duration) error {
 func mountDCControl() error {
 	_ = port.SetMode(defaultMode)
 	registerDCMetrics()
-	go runDCControl()
+	go runDCControl(port)
 	return nil
 }
 
@@ -161,16 +180,35 @@ func getDCState() DCPowerState {
 	return dcState
 }
 
-func runDCControl() {
+func runDCControl(p serial.Port) {
 	scopedLogger := serialLogger.With().Str("service", "dc_control").Logger()
-	reader := bufio.NewReader(port)
+	reader := bufio.NewReader(p)
 	hasRestoreFeature := false
+	backoff := time.Second
+	const maxBackoff = 30 * time.Second
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil {
+			// If the global port has been swapped out (unmount or extension
+			// switch replaces it via reopenSerialPort), the read error is an
+			// intentional shutdown signal for this worker: stop quietly.
+			if port != p {
+				scopedLogger.Debug().Msg("Serial port replaced, stopping DC control worker")
+				return
+			}
+			// Otherwise the read failed transiently. Back off and retry with a
+			// fresh reader instead of terminating the goroutine permanently.
 			scopedLogger.Warn().Err(err).Msg("Error reading from serial port")
-			return
+			time.Sleep(backoff)
+			backoff *= 2
+			if backoff > maxBackoff {
+				backoff = maxBackoff
+			}
+			reader = bufio.NewReader(p)
+			continue
 		}
+		// Successful read: reset the backoff.
+		backoff = time.Second
 
 		// Split the line by semicolon
 		parts := strings.Split(strings.TrimSpace(line), ";")


### PR DESCRIPTION
## What
`runATXControl` and `runDCControl` exit permanently on the first serial read error. After any transient UART hiccup the extension stays silent until the app restarts, with only a single Warn line as evidence. To users this looks like a dead ATX/DC board.

## How
Both workers now take the port they were started with as a parameter. On a read error they distinguish two cases:

- the global port was swapped (unmount / extension switch via `reopenSerialPort`) — the worker stops quietly, matching the existing implicit-shutdown design;
- otherwise the error is treated as transient: warn, back off (1s doubling, capped at 30s), rebuild the reader and keep reading. The backoff resets after any successful read.

No new synchronization is introduced: the global `port` is read the same way the existing press/command paths already access it.

## Testing
- Built and deployed on a JetKVM (v2, system 0.2.8) on a 0.5.8-based build; both workers run stably.
- Full E2E of the recovery path (unplug/replug the extension mid-session) is pending on my unit — its ATX board is currently not powering up (that investigation is what surfaced this bug). Happy to re-test once the board is replaced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
