### PR TITLE
go.mod: bump insomniacslk/dhcp past the nclient4 ReadFrom panic fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/google/uuid v1.6.0
 	github.com/guregu/null/v6 v6.0.0
 	github.com/gwatts/rootcerts v0.0.0-20250901182336-dc5ae18bd79f
-	github.com/insomniacslk/dhcp v0.0.0-20250919081422-f80a1952f48e
+	github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82
 	github.com/mdlayher/ndp v1.1.0
 	github.com/pion/ice/v4 v4.1.0
 	github.com/pion/logging v0.2.4

--- a/go.sum
+++ b/go.sum
@@ -84,8 +84,8 @@ github.com/gwatts/rootcerts v0.0.0-20250901182336-dc5ae18bd79f h1:08t2PbrkDgW2+m
 github.com/gwatts/rootcerts v0.0.0-20250901182336-dc5ae18bd79f/go.mod h1:5Kt9XkWvkGi2OHOq0QsGxebHmhCcqJ8KCbNg/a6+n+g=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714 h1:/jC7qQFrv8CrSJVmaolDVOxTfS9kc36uB6H40kdbQq8=
 github.com/hugelgupf/socketpair v0.0.0-20190730060125-05d35a94e714/go.mod h1:2Goc3h8EklBH5mspfHFxBnEoURQCGzQQH1ga9Myjvis=
-github.com/insomniacslk/dhcp v0.0.0-20250919081422-f80a1952f48e h1:nu5z6Kg+gMNW6tdqnVjg/QEJ8Nw71IJQqOtWj00XHEU=
-github.com/insomniacslk/dhcp v0.0.0-20250919081422-f80a1952f48e/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82 h1:y5aU8Uvl7eyM5WNgdQvRxbMJb+zo7pD+S72/Yo4pvnQ=
+github.com/insomniacslk/dhcp v0.0.0-20260719225207-c76316d4aa82/go.mod h1:qfvBmyDNp+/liLEYWRvqny/PEz9hGe2Dz833eXILSmo=
 github.com/jonboulle/clockwork v0.5.0 h1:Hyh9A8u51kptdkR+cqRpT1EebBwTn1oK9YfGYbdFz6I=
 github.com/jonboulle/clockwork v0.5.0/go.mod h1:3mZlmanh0g2NDKO5TWZVJAfofYk64M7XN3SzBPjZF60=
 github.com/josharian/native v1.0.1-0.20221213033349-c1e37c09b531/go.mod h1:7X/raswPFr05uY3HiLlYeyQntB6OO7E/d2Cu7qoaN2w=


### PR DESCRIPTION
The DHCPv4 client in `pkg/nmlite/jetdhcpc` builds its nclient4 client with `nclient4.New` (`dhcp4.go`), without `WithUnicast`, so both `client.Request` and `client.Renew` read replies through `BroadcastRawUDPConn.ReadFrom`.

The pin here (`v0.0.0-20250919081422-f80a1952f48e`) predates the fix. There `ReadFrom` subtracted the 8-byte UDP header from the IPv4 payload length without checking the payload was at least 8 bytes, so a short or malformed reply gave a negative slice bound and panicked. That's insomniacslk/dhcp#583, which I wrote (merged 2026-07-19). The fixed path drops the malformed frame and keeps reading instead of passing a negative length to `buf.Consume`.

This moves the module to the #583 merge commit; only go.mod and go.sum change. I haven't reproduced this against a running JetKVM, and whether a hostile reply reaches the client depends on the DHCP setup on the link, so it's defense in depth for the lease and renew path rather than a confirmed remote crash. Verified with `go build ./pkg/...` and `go vet ./pkg/nmlite/jetdhcpc/...`; a full `go build ./...` also needs the RK native libraries and generated frontend assets, which are unrelated to this change.
