### PR TITLE
fix: preserve virtual media during USB reconfiguration

### DIFF
--- a/internal/usbgadget/mass_storage.go
+++ b/internal/usbgadget/mass_storage.go
@@ -1,5 +1,11 @@
 package usbgadget
 
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
 var massStorageBaseConfig = gadgetConfigItem{
 	order:      3000,
 	device:     "mass_storage.usb0",
@@ -23,4 +29,27 @@ var massStorageLun0Config = gadgetConfigItem{
 		// Vendor (8 chars), product (16 chars)
 		"inquiry_string": "JetKVM  Virtual Media",
 	},
+}
+
+func (u *UsbGadget) SetMassStorageBackingFile(imagePath string) error {
+	u.configLock.Lock()
+	defer u.configLock.Unlock()
+
+	item, ok := u.configMap["mass_storage_lun0"]
+	if !ok {
+		return fmt.Errorf("mass storage LUN config not found")
+	}
+	if _, ok := item.attrs["file"]; !ok {
+		return fmt.Errorf("mass storage backing file config not found")
+	}
+
+	backingFilePath := filepath.Join(u.kvmGadgetPath, filepath.Join(item.path...), "file")
+	if err := os.WriteFile(backingFilePath, []byte(imagePath), 0644); err != nil {
+		return fmt.Errorf("failed to set mass storage backing file: %w", err)
+	}
+
+	item.attrs["file"] = imagePath
+	u.configMap["mass_storage_lun0"] = item
+
+	return nil
 }

--- a/internal/usbgadget/mass_storage_test.go
+++ b/internal/usbgadget/mass_storage_test.go
@@ -1,0 +1,67 @@
+package usbgadget
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+)
+
+func TestSetMassStorageBackingFileIsPreservedInReconfigurationPlan(t *testing.T) {
+	gadgetPath := t.TempDir()
+	functionPath := filepath.Join(gadgetPath, "functions", "mass_storage.usb0", "lun.0")
+	if err := os.MkdirAll(functionPath, 0755); err != nil {
+		t.Fatalf("create mass storage function path: %v", err)
+	}
+
+	lunConfig := massStorageLun0Config
+	lunConfig.attrs = make(gadgetAttributes, len(massStorageLun0Config.attrs))
+	for key, value := range massStorageLun0Config.attrs {
+		lunConfig.attrs[key] = value
+	}
+
+	logger := zerolog.Nop()
+	gadget := &UsbGadget{
+		kvmGadgetPath: gadgetPath,
+		configC1Path:  filepath.Join(t.TempDir(), "configs", "c.1"),
+		configMap: map[string]gadgetConfigItem{
+			"mass_storage_lun0": lunConfig,
+		},
+		enabledDevices: Devices{MassStorage: true},
+		log:            &logger,
+	}
+	imagePath := "/userdata/jetkvm/images/talos.raw"
+
+	if err := gadget.SetMassStorageBackingFile(imagePath); err != nil {
+		t.Fatalf("set mass storage backing file: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(functionPath, "file"))
+	if err != nil {
+		t.Fatalf("read live mass storage backing file: %v", err)
+	}
+	if string(got) != imagePath {
+		t.Fatalf("live mass storage backing file = %q, want %q", got, imagePath)
+	}
+
+	if err := gadget.newUsbGadgetTransaction(true); err != nil {
+		t.Fatalf("create gadget transaction: %v", err)
+	}
+	t.Cleanup(func() {
+		gadget.tx = nil
+	})
+	gadget.tx.WriteGadgetConfig()
+
+	backingFilePath := filepath.Join(functionPath, "file")
+	for _, change := range gadget.tx.c.Changes {
+		if change.Path != backingFilePath {
+			continue
+		}
+		if string(change.ExpectedContent) != imagePath {
+			t.Fatalf("planned mass storage backing file = %q, want %q", change.ExpectedContent, imagePath)
+		}
+		return
+	}
+
+	t.Fatalf("reconfiguration plan does not contain mass storage backing file %q", backingFilePath)
+}

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -24,10 +24,6 @@ import (
 	"github.com/psanford/httpreadat"
 )
 
-func writeFile(path string, data string) error {
-	return os.WriteFile(path, []byte(data), 0644)
-}
-
 func getMassStorageImage() (string, error) {
 	massStorageFunctionPath, err := gadget.GetPath("mass_storage_lun0")
 	if err != nil {
@@ -42,12 +38,7 @@ func getMassStorageImage() (string, error) {
 }
 
 func setMassStorageImage(imagePath string) error {
-	massStorageFunctionPath, err := gadget.GetPath("mass_storage_lun0")
-	if err != nil {
-		return fmt.Errorf("failed to get mass storage path: %w", err)
-	}
-
-	if err := writeFile(path.Join(massStorageFunctionPath, "file"), imagePath); err != nil {
+	if err := gadget.SetMassStorageBackingFile(imagePath); err != nil {
 		return fmt.Errorf("failed to set image path: %w", err)
 	}
 	return nil

--- a/usb_mass_storage_arm_test.go
+++ b/usb_mass_storage_arm_test.go
@@ -14,18 +14,19 @@ import (
 func TestMountedMassStorageImageSurvivesGadgetReconfiguration(t *testing.T) {
 	const gadgetPath = "/sys/kernel/config/usb_gadget/jetkvm"
 	backingFilePath := filepath.Join(gadgetPath, "functions", "mass_storage.usb0", "lun.0", "file")
-	originalBackingFile, err := os.ReadFile(backingFilePath)
-	if err != nil {
-		t.Fatalf("read original mass storage backing file: %v", err)
-	}
 
 	originalGadget := gadget
 	var testGadget *usbgadget.UsbGadget
+	var originalBackingFile []byte
 	var imagePath string
 	t.Cleanup(func() {
 		if testGadget != nil {
 			gadget = testGadget
-			if err := setMassStorageImage(string(originalBackingFile)); err != nil {
+			restoredBackingFile := string(originalBackingFile)
+			if strings.TrimSpace(restoredBackingFile) == "" {
+				restoredBackingFile = "\n"
+			}
+			if err := setMassStorageImage(restoredBackingFile); err != nil {
 				t.Errorf("restore mass storage backing file: %v", err)
 			}
 			if err := testGadget.Close(); err != nil {
@@ -66,6 +67,10 @@ func TestMountedMassStorageImageSurvivesGadgetReconfiguration(t *testing.T) {
 		t.Fatal("initialize USB gadget")
 	}
 	gadget = testGadget
+	originalBackingFile, err := os.ReadFile(backingFilePath)
+	if err != nil {
+		t.Fatalf("read original mass storage backing file: %v", err)
+	}
 
 	image, err := os.CreateTemp("", "jetkvm-mass-storage-*.img")
 	if err != nil {

--- a/usb_mass_storage_arm_test.go
+++ b/usb_mass_storage_arm_test.go
@@ -1,0 +1,97 @@
+//go:build arm && linux
+
+package kvm
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jetkvm/kvm/internal/usbgadget"
+)
+
+func TestMountedMassStorageImageSurvivesGadgetReconfiguration(t *testing.T) {
+	const gadgetPath = "/sys/kernel/config/usb_gadget/jetkvm"
+	backingFilePath := filepath.Join(gadgetPath, "functions", "mass_storage.usb0", "lun.0", "file")
+	originalBackingFile, err := os.ReadFile(backingFilePath)
+	if err != nil {
+		t.Fatalf("read original mass storage backing file: %v", err)
+	}
+
+	originalGadget := gadget
+	var testGadget *usbgadget.UsbGadget
+	var imagePath string
+	t.Cleanup(func() {
+		if testGadget != nil {
+			gadget = testGadget
+			if err := setMassStorageImage(string(originalBackingFile)); err != nil {
+				t.Errorf("restore mass storage backing file: %v", err)
+			}
+			if err := testGadget.Close(); err != nil {
+				t.Errorf("close USB gadget: %v", err)
+			}
+		} else if err := os.WriteFile(backingFilePath, originalBackingFile, 0644); err != nil {
+			t.Errorf("restore mass storage backing file: %v", err)
+		}
+		gadget = originalGadget
+
+		restoredBackingFile, err := os.ReadFile(backingFilePath)
+		if err != nil {
+			t.Errorf("read restored mass storage backing file: %v", err)
+		} else if strings.TrimSpace(string(restoredBackingFile)) != strings.TrimSpace(string(originalBackingFile)) {
+			t.Errorf("restored mass storage backing file = %q, want %q", restoredBackingFile, originalBackingFile)
+		}
+		if imagePath != "" {
+			if err := os.Remove(imagePath); err != nil && !os.IsNotExist(err) {
+				t.Errorf("remove temporary image: %v", err)
+			}
+		}
+	})
+
+	devices := &usbgadget.Devices{
+		AbsoluteMouse: true,
+		RelativeMouse: true,
+		Keyboard:      true,
+		MassStorage:   true,
+	}
+	config := &usbgadget.Config{
+		VendorId:     "0x1d6b",
+		ProductId:    "0x0104",
+		Manufacturer: "JetKVM",
+		Product:      "USB Emulation Device",
+	}
+	testGadget = usbgadget.NewUsbGadget("jetkvm", devices, config, nil)
+	if testGadget == nil {
+		t.Fatal("initialize USB gadget")
+	}
+	gadget = testGadget
+
+	image, err := os.CreateTemp("", "jetkvm-mass-storage-*.img")
+	if err != nil {
+		t.Fatalf("create temporary image: %v", err)
+	}
+	imagePath = image.Name()
+	if err := image.Truncate(1024 * 1024); err != nil {
+		image.Close()
+		t.Fatalf("size temporary image: %v", err)
+	}
+	if err := image.Close(); err != nil {
+		t.Fatalf("close temporary image: %v", err)
+	}
+
+	if err := setMassStorageImage(imagePath); err != nil {
+		t.Fatalf("set mass storage image: %v", err)
+	}
+	if err := gadget.UpdateGadgetConfig(); err != nil {
+		t.Fatalf("reconfigure USB gadget: %v", err)
+	}
+
+	got, err := os.ReadFile(backingFilePath)
+	if err != nil {
+		t.Fatalf("read mass storage backing file after reconfiguration: %v", err)
+	}
+	if strings.TrimSpace(string(got)) != imagePath {
+		t.Fatalf("mass storage backing file after reconfiguration = %q, want %q", got, imagePath)
+	}
+}


### PR DESCRIPTION
Fixes #1559

### Summary

Keep mass-storage backing-file changes synchronized between configfs and the in-memory gadget configuration so rebuilding the USB gadget does not silently detach mounted media.

Route virtual-media updates through the synchronized helper and add unit and ARM device regression tests covering the complete reconfiguration transaction.

### Testing

- `go test ./...`
- `go vet ./...`
- `go test -race ./internal/usbgadget`
- `TestSetMassStorageBackingFileIsPreservedInReconfigurationPlan` verifies the live configfs write and subsequent reconfiguration plan.
- `TestMountedMassStorageImageSurvivesGadgetReconfiguration` on a real JetKVM:
  - unpatched build lost the backing file after `UpdateGadgetConfig()`;
  - patched build preserved it.
- Linux host regression test:
  - stable 0.5.8 lost the mounted ISO after changing USB identifiers;
  - patched build preserved the ISO through JetKVM → Logitech → JetKVM identifier changes.

### Checklist

- [ ] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
