### PR TITLE
fix: only recover USB gadget when a data host is present

### DIFF
--- a/internal/usbgadget/host_present_test.go
+++ b/internal/usbgadget/host_present_test.go
@@ -1,0 +1,85 @@
+package usbgadget
+
+import "testing"
+
+func TestExtconHostState(t *testing.T) {
+	tests := []struct {
+		name        string
+		payload     string
+		wantPresent bool
+		wantKnown   bool
+	}{
+		{
+			name:        "no host (all zero)",
+			payload:     "USB=0\nUSB-HOST=0\nUSB_VBUS_EN=0\nSDP=0\nCDP=0\nDCP=0\nSLOW-CHARGER=0\n",
+			wantPresent: false,
+			wantKnown:   true,
+		},
+		{
+			name:        "real host (SDP set)",
+			payload:     "USB=1\nUSB-HOST=1\nUSB_VBUS_EN=1\nSDP=1\nCDP=0\nDCP=0\nSLOW-CHARGER=0\n",
+			wantPresent: true,
+			wantKnown:   true,
+		},
+		{
+			name:        "USB-HOST set but no SDP",
+			payload:     "USB=1\nUSB-HOST=1\nUSB_VBUS_EN=1\nSDP=0\nCDP=0\nDCP=0\nSLOW-CHARGER=0\n",
+			wantPresent: true,
+			wantKnown:   true,
+		},
+		{
+			name:        "charger only (DCP, VBUS on) -> not a host",
+			payload:     "USB=1\nUSB-HOST=0\nUSB_VBUS_EN=1\nSDP=0\nCDP=0\nDCP=1\nSLOW-CHARGER=0\n",
+			wantPresent: false,
+			wantKnown:   true,
+		},
+		{
+			name:        "charger only (SLOW-CHARGER) -> not a host",
+			payload:     "USB=1\nUSB-HOST=0\nUSB_VBUS_EN=1\nSDP=0\nCDP=0\nDCP=0\nSLOW-CHARGER=1\n",
+			wantPresent: false,
+			wantKnown:   true,
+		},
+		{
+			name:        "VBUS only, no host-capable/charger cable -> known no host",
+			payload:     "USB=1\nUSB_VBUS_EN=1\n",
+			wantPresent: false,
+			wantKnown:   true,
+		},
+		{
+			name:        "empty payload -> unknown (fall back)",
+			payload:     "",
+			wantPresent: false,
+			wantKnown:   false,
+		},
+		{
+			name:        "host-capable lines all zero -> known no host",
+			payload:     "USB=0\nUSB-HOST=0\nSDP=0\nCDP=0\n",
+			wantPresent: false,
+			wantKnown:   true,
+		},
+		{
+			name:        "malformed value ignored, no known cable -> unknown",
+			payload:     "USB_VBUS_EN=notanumber\n",
+			wantPresent: false,
+			wantKnown:   false,
+		},
+		{
+			name:        "recognizable host cable + malformed charger -> known host",
+			payload:     "SDP=1\nDCP=notanumber\n",
+			wantPresent: true,
+			wantKnown:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			present, known := extconHostState(tt.payload)
+			if present != tt.wantPresent || known != tt.wantKnown {
+				t.Fatalf(
+					"extconHostState(%q) = (%v, %v), want (%v, %v)",
+					tt.payload, present, known, tt.wantPresent, tt.wantKnown,
+				)
+			}
+		})
+	}
+}

--- a/internal/usbgadget/udc.go
+++ b/internal/usbgadget/udc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -90,6 +91,61 @@ func (u *UsbGadget) GetUsbState() (state string) {
 		return "unknown"
 	}
 	return strings.TrimSpace(string(stateBytes))
+}
+
+// HostPresent reports whether a USB data host is physically connected to the
+// port, based on the USB PHY extcon cable state. The UDC state reads
+// "not attached" both when no host is plugged in (the supported idle state,
+// #1540) and when a host is present but failed to enumerate (e.g. powered via
+// the ATX/DC extension, #128); only the extcon cable state tells them apart.
+func (u *UsbGadget) HostPresent() bool {
+	stateBytes, err := os.ReadFile("/sys/class/extcon/extcon0/state")
+	if err == nil {
+		if hostPresent, known := extconHostState(string(stateBytes)); known {
+			return hostPresent
+		}
+	}
+
+	// No usable extcon state: any link state other than "not attached" implies
+	// a host.
+	state := u.GetUsbState()
+	return state != USBStateNotAttached && state != USBStateUnknown
+}
+
+// extconHostState classifies an extcon `state` payload as host-present/absent.
+// known is false when the payload had no recognizable cable state (empty, or a
+// kernel that names cables differently), so the caller can fall back to the UDC
+// state instead of wrongly concluding "no host".
+func extconHostState(payload string) (hostPresent bool, known bool) {
+	var sawHostCable, sawNonDataCable bool
+	for _, line := range strings.Split(payload, "\n") {
+		key, val, ok := strings.Cut(strings.TrimSpace(line), "=")
+		if !ok {
+			continue
+		}
+		enabled, err := strconv.Atoi(strings.TrimSpace(val))
+		if err != nil {
+			continue
+		}
+		switch key {
+		case "USB-HOST", "SDP", "CDP":
+			sawHostCable = true
+			if enabled != 0 {
+				return true, true
+			}
+		case "DCP", "SLOW-CHARGER", "USB_VBUS_EN":
+			if enabled != 0 {
+				sawNonDataCable = true
+			}
+		}
+	}
+	// Recognizable cable state present: a host-capable line set to 0 or a
+	// charger-only line means no data host.
+	if sawHostCable || sawNonDataCable {
+		return false, true
+	}
+	// No recognizable cable state at all -> unknown.
+	return false, false
 }
 
 // IsUDCBound checks if the UDC state is bound.

--- a/usb.go
+++ b/usb.go
@@ -185,6 +185,13 @@ func attemptUSBRecovery(state string) string {
 		return state
 	}
 
+	// No host connected: bouncing the gadget cannot help and leaks dentries on
+	// the RV1106 vendor kernel (#1540). Recover only when a host is present.
+	if gadget == nil || !gadget.HostPresent() {
+		usbLogger.Trace().Msg("USB gadget not attached and no host present; skipping recovery")
+		return state
+	}
+
 	usbLogger.Warn().Msg("USB gadget is detached while USB emulation should be enabled; rebinding USB gadget")
 
 	if err := gadget.RebindUsb(true); err != nil {
@@ -222,6 +229,16 @@ func attemptUSBRecovery(state string) string {
 	}
 
 	if tryReopenKeyboard(delays, "udc_rebind") {
+		return gadget.GetUsbState()
+	}
+
+	// Escalate to a full configfs reconfigure only while a host is attached (
+	// the UDC has left "not attached"); in a no-host idle state it cannot
+	// succeed and only leaks configfs dentries. With a host present and a wedged
+	// HID chardev (#1366) it is the strongest repair.
+	currentState := gadget.GetUsbState()
+	if currentState == usbgadget.USBStateNotAttached || currentState == usbgadget.USBStateUnknown {
+		usbLogger.Warn().Msg("keyboard HID file not ready after UDC rebind; no host attached, keeping gadget bound")
 		return gadget.GetUsbState()
 	}
 


### PR DESCRIPTION
Fixes #1540 
Fixes #1534 

### Summary

The USB watchdog recovers a gadget that reads 'not attached' by rebinding the UDC and, on a failed HID chardev reopen, reconfiguring the configfs gadget. On the Rockchip RV1106 vendor kernel (5.10.160) this loop leaks live-refcounted dentries even before the configfs reconfigure is reached, about 85 dentries/min with no host attached, until the 204MB device thrashes and appears dead (#1540). This is the upstream 'tree-in-dcache' controlled leak that Al Viro's DCACHE_PERSISTENT series addresses.

---

This was for now tested with my local JetKVM hooked up to a desktop pc that spends a lot of the day off, hence I was running into the issue as described. A better fix would be a kernel that has the issue mentioned above fixed but for now this seems fairly solid without having any downsides as far as I can see. The commits that added the code (#128) were taken into account and should still be correct.

Please note that the code was implemented with the help of an LLM, which also helped in the debugging session as I was off by quite a bit.

### Checklist
- [ ] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green
