### PR TITLE
Send X-Device-SKU on the cloud signaling connection

### DIFF
--- a/cloud.go
+++ b/cloud.go
@@ -327,6 +327,7 @@ func runWebsocketClient() error {
 	header := http.Header{}
 	header.Set("X-Device-ID", GetDeviceID())
 	header.Set("X-App-Version", builtAppVersion)
+	header.Set("X-Device-SKU", GetDeviceSKU())
 	header.Set("Authorization", "Bearer "+config.CloudToken)
 	dialCtx, cancelDial := context.WithTimeout(context.Background(), CloudWebSocketConnectTimeout)
 


### PR DESCRIPTION
Adds one header to the cloud WebSocket dial in `cloud.go`:

```go
header.Set("X-Device-SKU", GetDeviceSKU())
```

`GetDeviceSKU()` already exists and is what the update check sends as the `sku` query parameter: it reads `/etc/jetkvm-sku` and falls back to `jetkvm-v2`. This sends the same value alongside `X-Device-ID` and `X-App-Version` so the cloud can tell hardware variants apart on the connection itself, the way it already learns the app version.

No behaviour change on the device. `go vet` and `gofmt` clean. No test added: the dial has no test harness and the change is a single request header.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single additive HTTP header on cloud WebSocket connect; reuses existing SKU helper with no auth or local logic changes.
> 
> **Overview**
> Cloud WebSocket dials now include an **`X-Device-SKU`** header alongside **`X-Device-ID`** and **`X-App-Version`**, using the existing **`GetDeviceSKU()`** value (from `/etc/jetkvm-sku`, default **`jetkvm-v2`**).
> 
> This lets the cloud identify hardware variant on the signaling connection itself, matching the SKU already sent on update/OTA flows. **No on-device behavior change** beyond the extra request header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11cf297f77494a0eee9078805b62644948ec8bc1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->