### PR TITLE
refactor: signaling adapter interface, drop legacy HTTP session signaling

### DIFF
--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -12,8 +12,6 @@ import type { LoaderFunction, LoaderFunctionArgs, Params } from "react-router";
 import { useInterval } from "usehooks-ts";
 import { FocusTrap } from "focus-trap-react";
 import { motion, AnimatePresence } from "framer-motion";
-import pkg from "react-use-websocket";
-const useWebSocket = pkg.default ?? pkg;
 
 import { cx } from "@/cva.config";
 import { CLOUD_API } from "@/ui.config";
@@ -58,7 +56,7 @@ import { m } from "@localizations/messages.js";
 import { doRpcHidHandshake, useHidRpc } from "@hooks/useHidRpc";
 import useKeyboard from "@hooks/useKeyboard";
 import { registerTestHandlers, cleanupTestHooks } from "@/test/testHooks";
-import { isLinuxDesktop } from "@/utils";
+import { useSignaling } from "@/webrtc/signaling";
 
 export type AuthMode = "password" | "noPassword" | null;
 
@@ -109,29 +107,6 @@ const loader: LoaderFunction = ({ params }: LoaderFunctionArgs) => {
   return isOnDevice ? deviceLoader() : cloudLoader(params);
 };
 
-/**
- * Removes H.265 from each video transceiver's preferred codec list so the
- * generated SDP offer does not advertise it. Called immediately before
- * createOffer() on Linux only — see jetkvm/kvm#1413 for context.
- */
-function stripH265FromVideoTransceivers(pc: RTCPeerConnection) {
-  try {
-    const caps = RTCRtpReceiver.getCapabilities?.("video");
-    if (!caps) return;
-    const filtered = caps.codecs.filter(c => c.mimeType !== "video/H265");
-    if (filtered.length === caps.codecs.length) return;
-
-    for (const t of pc.getTransceivers()) {
-      // addTransceiver("video", ...) populates receiver.track with kind "video".
-      if (t.receiver.track?.kind !== "video") continue;
-      t.setCodecPreferences(filtered);
-    }
-    console.debug("[setupPeerConnection] Linux: stripped H.265 from video codec preferences");
-  } catch (e) {
-    console.warn("[setupPeerConnection] setCodecPreferences failed", e);
-  }
-}
-
 export default function KvmIdRoute() {
   const loaderResp = useLoaderData();
   // Depending on the mode, we set the appropriate variables
@@ -171,7 +146,6 @@ export default function KvmIdRoute() {
     peerConnection,
     setPeerConnection,
     peerConnectionState,
-    setPeerConnectionState,
     setMediaStream,
     bumpMediaStreamTrackVersion,
     setRpcDataChannel,
@@ -188,475 +162,130 @@ export default function KvmIdRoute() {
   } = useRTCStore();
 
   const location = useLocation();
-  const isLegacySignalingEnabled = useRef(false);
-  const [connectionFailed, setConnectionFailed] = useState(false);
   const [displayHostname, setDisplayHostname] = useState<string | null>(null);
 
   const navigate = useNavigate();
   const { otaState, setOtaState, setModalView } = useUpdateStore();
 
-  const [loadingMessage, setLoadingMessage] = useState(m.connecting_to_device());
-  const cleanupAndStopReconnecting = useCallback(
-    function cleanupAndStopReconnecting() {
-      console.log("Closing peer connection");
-
-      setConnectionFailed(true);
-      if (peerConnection) {
-        setPeerConnectionState(peerConnection.connectionState);
-      }
-      connectionFailedRef.current = true;
-
-      peerConnection?.close();
-      signalingAttempts.current = 0;
-    },
-    [peerConnection, setPeerConnectionState],
-  );
-
-  // We need to track connectionFailed in a ref to avoid stale closure issues
-  // This is necessary because syncRemoteSessionDescription is a callback that captures
-  // the connectionFailed value at creation time, but we need the latest value
-  // when the function is actually called. Without this ref, the function would use
-  // a stale value of connectionFailed in some conditions.
-  //
-  // We still need the state variable for UI rendering, so we sync the ref with the state.
-  // This pattern is a workaround for what useEvent hook would solve more elegantly
-  // (which would give us a callback that always has access to latest state without re-creation).
-  const connectionFailedRef = useRef(false);
-  useEffect(() => {
-    connectionFailedRef.current = connectionFailed;
-  }, [connectionFailed]);
-
-  const signalingAttempts = useRef(0);
-  const setRemoteSessionDescription = useCallback(
-    async function setRemoteSessionDescription(
-      pc: RTCPeerConnection,
-      remoteDescription: RTCSessionDescriptionInit,
-    ) {
-      setLoadingMessage(m.setting_remote_description());
-
-      try {
-        await pc.setRemoteDescription(new RTCSessionDescription(remoteDescription));
-        console.log(
-          "[setRemoteSessionDescription] Remote description set successfully to: " +
-            remoteDescription.sdp,
-        );
-        setLoadingMessage(m.establishing_secure_connection());
-      } catch (error) {
-        console.error("[setRemoteSessionDescription] Failed to set remote description:", error);
-        cleanupAndStopReconnecting();
-        return;
-      }
-
-      // Replace the interval-based check with a more reliable approach
-      let attempts = 0;
-      const checkInterval = setInterval(() => {
-        attempts++;
-
-        // When vivaldi has disabled "Broadcast IP for Best WebRTC Performance", this never connects
-        if (pc.sctp?.state === "connected") {
-          console.log("[setRemoteSessionDescription] Remote description set");
-          clearInterval(checkInterval);
-          setLoadingMessage(m.connection_established());
-        } else if (attempts >= 10) {
-          console.warn(
-            "[setRemoteSessionDescription] Failed to establish connection after 10 attempts",
-            {
-              connectionState: pc.connectionState,
-              iceConnectionState: pc.iceConnectionState,
-            },
-          );
-          cleanupAndStopReconnecting();
-          clearInterval(checkInterval);
-        } else {
-          console.log("[setRemoteSessionDescription] Waiting for connection, state:", {
-            connectionState: pc.connectionState,
-            iceConnectionState: pc.iceConnectionState,
-          });
+  // Everything that must be part of the initial offer is attached here; the
+  // signaling adapter owns the peer connection itself.
+  const attachPeerConnection = useCallback(
+    (pc: RTCPeerConnection) => {
+      pc.ontrack = function (event) {
+        // Assemble a single canonical MediaStream from every incoming track.
+        // We don't trust event.streams[0]: when the answer SDP omits a=msid
+        // for a track (pion does this for audio in some configurations),
+        // Firefox hands us a fresh synthetic stream that would overwrite the
+        // canonical one and strip tracks already attached to it.
+        let stream = useRTCStore.getState().mediaStream;
+        if (!stream) {
+          stream = new MediaStream();
+          setMediaStream(stream);
         }
-      }, 1000);
-    },
-    [cleanupAndStopReconnecting],
-  );
-
-  const ignoreOffer = useRef(false);
-  const isSettingRemoteAnswerPending = useRef(false);
-  const makingOffer = useRef(false);
-  const reconnectAttemptsRef = useRef(2000);
-  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
-
-  const reconnectInterval = (attempt: number) => {
-    // Exponential backoff with a max of 10 seconds between attempts
-    return Math.min(500 * 2 ** attempt, 10000);
-  };
-
-  const { sendMessage, getWebSocket } = useWebSocket(
-    isOnDevice
-      ? `${wsProtocol}//${window.location.host}/webrtc/signaling/client`
-      : `${CLOUD_API.replace("http", "ws")}/webrtc/signaling/client?id=${params.id}`,
-    {
-      heartbeat: true,
-      retryOnError: true,
-      reconnectAttempts: reconnectAttemptsRef.current,
-      reconnectInterval: reconnectInterval,
-      onReconnectStop: (numAttempts: number) => {
-        console.debug("Reconnect stopped after ", numAttempts, "attempts");
-        cleanupAndStopReconnecting();
-      },
-
-      shouldReconnect(event: WebSocketEventMap["close"]) {
-        console.debug("[Websocket] shouldReconnect", event);
-        return !isLegacySignalingEnabled.current;
-      },
-
-      onClose(event: WebSocketEventMap["close"]) {
-        console.debug("[Websocket] onClose", event);
-        // We don't want to close everything down, we wait for the reconnect to stop instead
-      },
-
-      onError(event: WebSocketEventMap["error"]) {
-        console.error("[Websocket] onError", event);
-        // We don't want to close everything down, we wait for the reconnect to stop instead
-      },
-
-      onOpen() {
-        console.debug("[Websocket] onOpen");
-        // We want to clear the reboot state when the websocket connection is opened
-        // Currently the flow is:
-        // 1. User clicks reboot
-        // 2. Device sends event 'willReboot'
-        // 3. We set the reboot state
-        // 4. Reboot modal is shown
-        // 5. WS tries to reconnect
-        // 6. WS reconnects
-        // 7. This function is called and now we clear the reboot state
-        setRebootState({ isRebooting: false, postRebootAction: null });
-      },
-
-      onMessage(event: WebSocketEventMap["message"]) {
-        const message = event;
-        if (message.data === "pong") return;
-
-        /*
-          Currently the signaling process is as follows:
-            After open, the other side will send a `device-metadata` message with the device version
-            If the device version is not set, we can assume the device is using the legacy signaling
-            Otherwise, we can assume the device is using the new signaling
-
-            If the device is using the legacy signaling, we close the websocket connection
-            and use the legacy HTTPSignaling function to get the remote session description
-
-            If the device is using the new signaling, we don't need to do anything special, but continue to use the websocket connection
-            to chat with the other peer about the connection
-        */
-
-        const parsedMessage = JSON.parse(message.data);
-
-        if (parsedMessage.type === "device-metadata") {
-          const { deviceVersion } = parsedMessage.data;
-          console.debug("[Websocket] Received device-metadata message");
-          console.debug("[Websocket] Device version", deviceVersion);
-          // If the device version is not set, we can assume the device is using the legacy signaling
-          if (!deviceVersion) {
-            console.log("[Websocket] Device is using legacy signaling");
-
-            // Now we don't need the websocket connection anymore, as we've established that we need to use the legacy signaling
-            // which does everything over HTTP(at least from the perspective of the client)
-            isLegacySignalingEnabled.current = true;
-            getWebSocket()?.close();
-          } else {
-            console.log("[Websocket] Device is using new signaling");
-            isLegacySignalingEnabled.current = false;
-          }
-
-          setupPeerConnection();
+        if (!stream.getTracks().some(t => t.id === event.track.id)) {
+          stream.addTrack(event.track);
+          bumpMediaStreamTrackVersion();
         }
+      };
 
-        if (!peerConnection) return;
+      setTransceiver(pc.addTransceiver("video", { direction: "recvonly" }));
+      // Always offer audio; the backend gates it on device config and leaves
+      // the m-line inactive when disabled.
+      pc.addTransceiver("audio", { direction: "recvonly" });
 
-        if (parsedMessage.type === "answer") {
-          console.debug("[Websocket] Received answer");
-          const readyForOffer =
-            // If we're making an offer, we don't want to accept an answer
-            !makingOffer &&
-            // If the peer connection is stable or we're setting the remote answer pending, we're ready for an offer
-            (peerConnection?.signalingState === "stable" || isSettingRemoteAnswerPending.current);
+      const rpcDataChannel = pc.createDataChannel("rpc");
+      rpcDataChannel.onclose = () => {
+        console.log("rpcDataChannel has closed");
+        setRpcDataChannel(null);
+      };
+      rpcDataChannel.onerror = (ev: Event) =>
+        console.error(`Error on DataChannel '${rpcDataChannel.label}': ${ev.type}`);
+      rpcDataChannel.onopen = () => {
+        setRpcDataChannel(rpcDataChannel);
+      };
 
-          // If we're not ready for an offer, we don't want to accept an offer
-          ignoreOffer.current = parsedMessage.type === "offer" && !readyForOffer;
-          if (ignoreOffer.current) return;
+      const rpcHidChannel = pc.createDataChannel("hidrpc");
+      rpcHidChannel.binaryType = "arraybuffer";
+      rpcHidChannel.onclose = () => console.log("rpcHidChannel has closed");
+      rpcHidChannel.onerror = (ev: Event) =>
+        console.error(`Error on rpcHidChannel '${rpcHidChannel.label}': ${ev.type}`);
+      rpcHidChannel.onopen = () => {
+        setRpcHidChannel(rpcHidChannel);
+      };
+      doRpcHidHandshake(rpcHidChannel, setRpcHidProtocolVersion);
 
-          // Set so we don't accept an answer while we're setting the remote description
-          isSettingRemoteAnswerPending.current = parsedMessage.type === "answer";
-          console.debug(
-            "[Websocket] Setting remote answer pending",
-            isSettingRemoteAnswerPending.current,
-          );
-
-          const sd = atob(parsedMessage.data);
-          const remoteSessionDescription = JSON.parse(sd);
-
-          setRemoteSessionDescription(
-            peerConnection,
-            new RTCSessionDescription(remoteSessionDescription),
-          );
-
-          // Reset the remote answer pending flag
-          isSettingRemoteAnswerPending.current = false;
-        } else if (parsedMessage.type === "new-ice-candidate") {
-          console.debug("[Websocket] Received new-ice-candidate");
-          const candidate = parsedMessage.data;
-          peerConnection.addIceCandidate(candidate);
-        }
-      },
-    },
-  );
-
-  const sendWebRTCSignal = useCallback(
-    (type: string, data: unknown) => {
-      // Second argument tells the library not to queue the message, and send it once the connection is established again.
-      // We have event handlers that handle the connection set up, so we don't need to queue the message.
-      sendMessage(JSON.stringify({ type, data }), false);
-    },
-    [sendMessage],
-  );
-
-  const legacyHTTPSignaling = useCallback(
-    async (pc: RTCPeerConnection) => {
-      const sd = btoa(JSON.stringify(pc.localDescription));
-
-      // Legacy mode == UI in cloud with updated code connecting to older device version.
-      // In device mode, old devices wont serve this JS, and on newer devices legacy mode wont be enabled
-      const sessionUrl = `${CLOUD_API}/webrtc/session`;
-
-      console.log("Trying to get remote session description");
-      setLoadingMessage(
-        m.getting_remote_session_description({ attempt: signalingAttempts.current + 1 }),
-      );
-      const res = await api.POST(sessionUrl, {
-        sd,
-        // When on device, we don't need to specify the device id, as it's already known
-        ...(isOnDevice ? {} : { id: params.id }),
+      const rpcHidUnreliableChannel = pc.createDataChannel("hidrpc-unreliable-ordered", {
+        ordered: true,
+        maxRetransmits: 0,
       });
-
-      const json = await res.json();
-      if (res.status === 401) return navigate(isOnDevice ? "/login-local" : "/login");
-      if (!res.ok) {
-        console.error("Error getting SDP", { status: res.status, json });
-        cleanupAndStopReconnecting();
-        return;
-      }
-
-      console.debug("Successfully got Remote Session Description. Setting.");
-      setLoadingMessage(m.setting_remote_session_description());
-
-      const decodedSd = atob(json.sd);
-      const parsedSd = JSON.parse(decodedSd);
-      setRemoteSessionDescription(pc, new RTCSessionDescription(parsedSd));
-    },
-    [cleanupAndStopReconnecting, navigate, params.id, setRemoteSessionDescription],
-  );
-
-  const setupPeerConnection = useCallback(async () => {
-    console.debug("[setupPeerConnection] Setting up peer connection");
-    setConnectionFailed(false);
-    setLoadingMessage(m.connecting_to_device());
-
-    // Drop the previous PC's MediaStream — its tracks are ended and
-    // would sit ahead of the new live tracks, breaking playback.
-    setMediaStream(null);
-
-    let pc: RTCPeerConnection;
-    try {
-      console.debug("[setupPeerConnection] Creating peer connection");
-      setLoadingMessage(m.creating_peer_connection());
-      pc = new RTCPeerConnection({
-        // We only use STUN or TURN servers if we're in the cloud
-        ...(isInCloud && iceConfig?.iceServers ? { iceServers: [iceConfig?.iceServers] } : {}),
-      });
-
-      setPeerConnectionState(pc.connectionState);
-      console.debug("[setupPeerConnection] Peer connection created", pc);
-      setLoadingMessage(m.setting_up_connection_to_device());
-    } catch (e) {
-      console.error(`[setupPeerConnection] Error creating peer connection: ${String(e)}`);
-      setTimeout(() => {
-        cleanupAndStopReconnecting();
-      }, 1000);
-      return;
-    }
-
-    // Set up event listeners and data channels
-    pc.onconnectionstatechange = () => {
-      console.debug("[setupPeerConnection] Connection state changed", pc.connectionState);
-      setPeerConnectionState(pc.connectionState);
-    };
-
-    pc.onnegotiationneeded = async () => {
-      try {
-        console.debug("[setupPeerConnection] Creating offer");
-        makingOffer.current = true;
-
-        if (isLinuxDesktop()) {
-          stripH265FromVideoTransceivers(pc);
-        }
-
-        const offer = await pc.createOffer();
-        await pc.setLocalDescription(offer);
-        const sd = btoa(JSON.stringify(pc.localDescription));
-        const isNewSignalingEnabled = isLegacySignalingEnabled.current === false;
-        if (isNewSignalingEnabled) {
-          sendWebRTCSignal("offer", { sd: sd });
-        } else {
-          console.log("Legacy signaling. Waiting for ICE Gathering to complete...");
-        }
-      } catch (e) {
+      rpcHidUnreliableChannel.binaryType = "arraybuffer";
+      rpcHidUnreliableChannel.onclose = () => console.log("rpcHidUnreliableChannel has closed");
+      rpcHidUnreliableChannel.onerror = (ev: Event) =>
         console.error(
-          `[setupPeerConnection] Error creating offer: ${String(e)}`,
-          new Date().toISOString(),
+          `Error on rpcHidUnreliableChannel '${rpcHidUnreliableChannel.label}': ${ev.type}`,
         );
-        cleanupAndStopReconnecting();
-      } finally {
-        makingOffer.current = false;
-      }
-    };
+      rpcHidUnreliableChannel.onopen = () => {
+        setRpcHidUnreliableChannel(rpcHidUnreliableChannel);
+      };
 
-    pc.onicecandidate = ({ candidate }) => {
-      if (!candidate) return;
-      if (candidate.candidate === "") return;
-      sendWebRTCSignal("new-ice-candidate", candidate);
-    };
-
-    pc.onicegatheringstatechange = event => {
-      const pc = event.currentTarget as RTCPeerConnection;
-      if (pc.iceGatheringState === "complete") {
-        console.debug("ICE Gathering completed");
-        setLoadingMessage(m.ice_gathering_completed());
-
-        if (isLegacySignalingEnabled.current) {
-          // We can now start the https/ws connection to get the remote session description from the KVM device
-          legacyHTTPSignaling(pc);
-        }
-      } else if (pc.iceGatheringState === "gathering") {
-        console.debug("ICE Gathering Started");
-        setLoadingMessage(m.gathering_ice_candidates());
-      }
-    };
-
-    pc.ontrack = function (event) {
-      // Assemble a single canonical MediaStream from every incoming track.
-      // We don't trust event.streams[0]: when the answer SDP omits a=msid
-      // for a track (pion does this for audio in some configurations),
-      // Firefox hands us a fresh synthetic stream that would overwrite the
-      // canonical one and strip tracks already attached to it.
-      let stream = useRTCStore.getState().mediaStream;
-      if (!stream) {
-        stream = new MediaStream();
-        setMediaStream(stream);
-      }
-      if (!stream.getTracks().some(t => t.id === event.track.id)) {
-        stream.addTrack(event.track);
-        bumpMediaStreamTrackVersion();
-      }
-    };
-
-    setTransceiver(pc.addTransceiver("video", { direction: "recvonly" }));
-    // Always offer audio; the backend gates it on device config and leaves
-    // the m-line inactive when disabled.
-    pc.addTransceiver("audio", { direction: "recvonly" });
-
-    const rpcDataChannel = pc.createDataChannel("rpc");
-    rpcDataChannel.onclose = () => {
-      console.log("rpcDataChannel has closed");
-      setRpcDataChannel(null);
-    };
-    rpcDataChannel.onerror = (ev: Event) =>
-      console.error(`Error on DataChannel '${rpcDataChannel.label}': ${ev.type}`);
-    rpcDataChannel.onopen = () => {
-      setRpcDataChannel(rpcDataChannel);
-    };
-
-    const rpcHidChannel = pc.createDataChannel("hidrpc");
-    rpcHidChannel.binaryType = "arraybuffer";
-    rpcHidChannel.onclose = () => console.log("rpcHidChannel has closed");
-    rpcHidChannel.onerror = (ev: Event) =>
-      console.error(`Error on rpcHidChannel '${rpcHidChannel.label}': ${ev.type}`);
-    rpcHidChannel.onopen = () => {
-      setRpcHidChannel(rpcHidChannel);
-    };
-    doRpcHidHandshake(rpcHidChannel, setRpcHidProtocolVersion);
-
-    const rpcHidUnreliableChannel = pc.createDataChannel("hidrpc-unreliable-ordered", {
-      ordered: true,
-      maxRetransmits: 0,
-    });
-    rpcHidUnreliableChannel.binaryType = "arraybuffer";
-    rpcHidUnreliableChannel.onclose = () => console.log("rpcHidUnreliableChannel has closed");
-    rpcHidUnreliableChannel.onerror = (ev: Event) =>
-      console.error(
-        `Error on rpcHidUnreliableChannel '${rpcHidUnreliableChannel.label}': ${ev.type}`,
+      const rpcHidUnreliableNonOrderedChannel = pc.createDataChannel(
+        "hidrpc-unreliable-nonordered",
+        {
+          ordered: false,
+          maxRetransmits: 0,
+        },
       );
-    rpcHidUnreliableChannel.onopen = () => {
-      setRpcHidUnreliableChannel(rpcHidUnreliableChannel);
-    };
+      rpcHidUnreliableNonOrderedChannel.binaryType = "arraybuffer";
+      rpcHidUnreliableNonOrderedChannel.onclose = () =>
+        console.log("rpcHidUnreliableNonOrderedChannel has closed");
+      rpcHidUnreliableNonOrderedChannel.onerror = (ev: Event) =>
+        console.error(
+          `Error on rpcHidUnreliableNonOrderedChannel '${rpcHidUnreliableNonOrderedChannel.label}': ${ev.type}`,
+        );
+      rpcHidUnreliableNonOrderedChannel.onopen = () => {
+        setRpcHidUnreliableNonOrderedChannel(rpcHidUnreliableNonOrderedChannel);
+      };
 
-    const rpcHidUnreliableNonOrderedChannel = pc.createDataChannel("hidrpc-unreliable-nonordered", {
-      ordered: false,
-      maxRetransmits: 0,
-    });
-    rpcHidUnreliableNonOrderedChannel.binaryType = "arraybuffer";
-    rpcHidUnreliableNonOrderedChannel.onclose = () =>
-      console.log("rpcHidUnreliableNonOrderedChannel has closed");
-    rpcHidUnreliableNonOrderedChannel.onerror = (ev: Event) =>
-      console.error(
-        `Error on rpcHidUnreliableNonOrderedChannel '${rpcHidUnreliableNonOrderedChannel.label}': ${ev.type}`,
-      );
-    rpcHidUnreliableNonOrderedChannel.onopen = () => {
-      setRpcHidUnreliableNonOrderedChannel(rpcHidUnreliableNonOrderedChannel);
-    };
+      // Create terminal channel as part of initial offer
+      const terminalDataChannel = pc.createDataChannel("terminal");
+      terminalDataChannel.onclose = () => console.log("terminalDataChannel has closed");
+      terminalDataChannel.onerror = (ev: Event) =>
+        console.error(`Error on terminalDataChannel '${terminalDataChannel.label}': ${ev.type}`);
+      terminalDataChannel.onopen = () => {
+        setTerminalChannel(terminalDataChannel);
+      };
+    },
+    [
+      bumpMediaStreamTrackVersion,
+      setMediaStream,
+      setRpcDataChannel,
+      setRpcHidChannel,
+      setRpcHidUnreliableNonOrderedChannel,
+      setRpcHidUnreliableChannel,
+      setRpcHidProtocolVersion,
+      setTerminalChannel,
+      setTransceiver,
+    ],
+  );
 
-    // Create terminal channel as part of initial offer
-    const terminalDataChannel = pc.createDataChannel("terminal");
-    terminalDataChannel.onclose = () => console.log("terminalDataChannel has closed");
-    terminalDataChannel.onerror = (ev: Event) =>
-      console.error(`Error on terminalDataChannel '${terminalDataChannel.label}': ${ev.type}`);
-    terminalDataChannel.onopen = () => {
-      setTerminalChannel(terminalDataChannel);
-    };
+  // We only use STUN or TURN servers if we're in the cloud
+  const iceServers = useMemo(
+    () => (isInCloud && iceConfig?.iceServers ? [iceConfig.iceServers] : undefined),
+    [iceConfig?.iceServers],
+  );
 
-    setPeerConnection(pc);
-  }, [
-    cleanupAndStopReconnecting,
-    iceConfig?.iceServers,
-    legacyHTTPSignaling,
-    sendWebRTCSignal,
-    setMediaStream,
-    bumpMediaStreamTrackVersion,
-    setPeerConnection,
-    setPeerConnectionState,
-    setRpcDataChannel,
-    setRpcHidChannel,
-    setRpcHidUnreliableNonOrderedChannel,
-    setRpcHidUnreliableChannel,
-    setRpcHidProtocolVersion,
-    setTerminalChannel,
-    setTransceiver,
-  ]);
-
-  useEffect(() => {
-    if (peerConnectionState === "failed") {
-      console.warn("Connection failed, closing peer connection");
-      cleanupAndStopReconnecting();
-    }
-  }, [peerConnectionState, cleanupAndStopReconnecting]);
+  const {
+    connect: setupPeerConnection,
+    loadingMessage,
+    connectionFailed,
+  } = useSignaling({
+    deviceId: params.id,
+    iceServers,
+    onPeerConnection: attachPeerConnection,
+  });
 
   // Cleanup effect
   const { clearInboundRtpStats, clearCandidatePairStats } = useRTCStore();
-
-  useEffect(() => {
-    return () => {
-      peerConnection?.close();
-    };
-  }, [peerConnection]);
 
   // For some reason, we have to have this unmount separate from the cleanup effect above
   useEffect(() => {

--- a/ui/src/webrtc/signaling/index.ts
+++ b/ui/src/webrtc/signaling/index.ts
@@ -1,0 +1,22 @@
+import type { SignalingHook, SignalingOptions } from "./types";
+import { useWebSocketSignaling } from "./useWebSocketSignaling";
+
+export type { SignalingController, SignalingHook, SignalingOptions } from "./types";
+
+export type SignalingKind = "jetkvm-websocket";
+
+const adapters: Record<SignalingKind, SignalingHook> = {
+  "jetkvm-websocket": useWebSocketSignaling,
+};
+
+export const DEFAULT_SIGNALING: SignalingKind = "jetkvm-websocket";
+
+/**
+ * Resolve the signaling adapter for a session. `kind` must be stable for the
+ * lifetime of the calling component: adapters are hooks, so switching kinds
+ * between renders is not supported.
+ */
+export function useSignaling(options: SignalingOptions, kind: SignalingKind = DEFAULT_SIGNALING) {
+  const useAdapter = adapters[kind];
+  return useAdapter(options);
+}

--- a/ui/src/webrtc/signaling/types.ts
+++ b/ui/src/webrtc/signaling/types.ts
@@ -1,0 +1,43 @@
+/**
+ * Signaling adapters own the RTCPeerConnection lifecycle: creating the peer,
+ * exchanging session descriptions and ICE candidates with the device, and
+ * deciding when a connection attempt has failed. The device route only
+ * attaches what it needs to a freshly created peer (transceivers, data
+ * channels, track handling) through `onPeerConnection`.
+ *
+ * Adapters publish the peer and its connection state through the RTC store,
+ * so everything downstream of the store is unaware of which adapter is in use.
+ */
+
+export interface SignalingOptions {
+  /** Device identifier; used to address the device when not on-device. */
+  readonly deviceId: string;
+  /** ICE servers for this session. Omitted on the local network. */
+  readonly iceServers?: RTCIceServer[];
+  /**
+   * Called synchronously for every new RTCPeerConnection, after the adapter
+   * has installed its own handlers and before negotiation starts. Anything
+   * that must be part of the initial offer (transceivers, data channels) is
+   * added here.
+   */
+  readonly onPeerConnection: (pc: RTCPeerConnection) => void;
+}
+
+export interface SignalingController {
+  /**
+   * Create a new peer connection and negotiate it with the device. Safe to
+   * call again after a failure; any previous peer is discarded.
+   */
+  readonly connect: () => Promise<void>;
+  /** Progress text for the connection overlay. */
+  readonly loadingMessage: string;
+  /** True once the adapter has given up on the current attempt. */
+  readonly connectionFailed: boolean;
+}
+
+/**
+ * An adapter is a React hook so it can hold state, subscribe to the stores
+ * and run effects for its transport. The hook identity must not change for
+ * the lifetime of the route.
+ */
+export type SignalingHook = (options: SignalingOptions) => SignalingController;

--- a/ui/src/webrtc/signaling/useWebSocketSignaling.ts
+++ b/ui/src/webrtc/signaling/useWebSocketSignaling.ts
@@ -1,0 +1,440 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useNavigate } from "react-router";
+import pkg from "react-use-websocket";
+
+import { CLOUD_API } from "@/ui.config";
+import api from "@/api";
+import { isOnDevice } from "@/main";
+import { useRTCStore, useUiStore } from "@hooks/stores";
+import { m } from "@localizations/messages.js";
+import { isLinuxDesktop } from "@/utils";
+
+import type { SignalingHook } from "./types";
+
+const useWebSocket = pkg.default ?? pkg;
+
+/**
+ * Removes H.265 from each video transceiver's preferred codec list so the
+ * generated SDP offer does not advertise it. Called immediately before
+ * createOffer() on Linux only — see jetkvm/kvm#1413 for context.
+ */
+function stripH265FromVideoTransceivers(pc: RTCPeerConnection) {
+  try {
+    const caps = RTCRtpReceiver.getCapabilities?.("video");
+    if (!caps) return;
+    const filtered = caps.codecs.filter(c => c.mimeType !== "video/H265");
+    if (filtered.length === caps.codecs.length) return;
+
+    for (const t of pc.getTransceivers()) {
+      // addTransceiver("video", ...) populates receiver.track with kind "video".
+      if (t.receiver.track?.kind !== "video") continue;
+      t.setCodecPreferences(filtered);
+    }
+    console.debug("[setupPeerConnection] Linux: stripped H.265 from video codec preferences");
+  } catch (e) {
+    console.warn("[setupPeerConnection] setCodecPreferences failed", e);
+  }
+}
+
+const reconnectInterval = (attempt: number) => {
+  // Exponential backoff with a max of 10 seconds between attempts
+  return Math.min(500 * 2 ** attempt, 10000);
+};
+
+/**
+ * JetKVM's stock signaling: the browser is the offerer and talks to the
+ * device (directly, or relayed by the cloud) over a WebSocket at
+ * `/webrtc/signaling/client`. Devices that predate the WebSocket flow answer
+ * the `device-metadata` message without a version, in which case the offer
+ * is posted over HTTP once ICE gathering completes.
+ */
+export const useWebSocketSignaling: SignalingHook = ({
+  deviceId,
+  iceServers,
+  onPeerConnection,
+}) => {
+  const {
+    peerConnection,
+    setPeerConnection,
+    peerConnectionState,
+    setPeerConnectionState,
+    setMediaStream,
+  } = useRTCStore();
+  const setRebootState = useUiStore(state => state.setRebootState);
+  const navigate = useNavigate();
+
+  const isLegacySignalingEnabled = useRef(false);
+  const [connectionFailed, setConnectionFailed] = useState(false);
+  const [loadingMessage, setLoadingMessage] = useState(m.connecting_to_device());
+
+  const cleanupAndStopReconnecting = useCallback(
+    function cleanupAndStopReconnecting() {
+      console.log("Closing peer connection");
+
+      setConnectionFailed(true);
+      if (peerConnection) {
+        setPeerConnectionState(peerConnection.connectionState);
+      }
+      connectionFailedRef.current = true;
+
+      peerConnection?.close();
+      signalingAttempts.current = 0;
+    },
+    [peerConnection, setPeerConnectionState],
+  );
+
+  // We need to track connectionFailed in a ref to avoid stale closure issues
+  // This is necessary because syncRemoteSessionDescription is a callback that captures
+  // the connectionFailed value at creation time, but we need the latest value
+  // when the function is actually called. Without this ref, the function would use
+  // a stale value of connectionFailed in some conditions.
+  //
+  // We still need the state variable for UI rendering, so we sync the ref with the state.
+  // This pattern is a workaround for what useEvent hook would solve more elegantly
+  // (which would give us a callback that always has access to latest state without re-creation).
+  const connectionFailedRef = useRef(false);
+  useEffect(() => {
+    connectionFailedRef.current = connectionFailed;
+  }, [connectionFailed]);
+
+  const signalingAttempts = useRef(0);
+  const setRemoteSessionDescription = useCallback(
+    async function setRemoteSessionDescription(
+      pc: RTCPeerConnection,
+      remoteDescription: RTCSessionDescriptionInit,
+    ) {
+      setLoadingMessage(m.setting_remote_description());
+
+      try {
+        await pc.setRemoteDescription(new RTCSessionDescription(remoteDescription));
+        console.log(
+          "[setRemoteSessionDescription] Remote description set successfully to: " +
+            remoteDescription.sdp,
+        );
+        setLoadingMessage(m.establishing_secure_connection());
+      } catch (error) {
+        console.error("[setRemoteSessionDescription] Failed to set remote description:", error);
+        cleanupAndStopReconnecting();
+        return;
+      }
+
+      // Replace the interval-based check with a more reliable approach
+      let attempts = 0;
+      const checkInterval = setInterval(() => {
+        attempts++;
+
+        // When vivaldi has disabled "Broadcast IP for Best WebRTC Performance", this never connects
+        if (pc.sctp?.state === "connected") {
+          console.log("[setRemoteSessionDescription] Remote description set");
+          clearInterval(checkInterval);
+          setLoadingMessage(m.connection_established());
+        } else if (attempts >= 10) {
+          console.warn(
+            "[setRemoteSessionDescription] Failed to establish connection after 10 attempts",
+            {
+              connectionState: pc.connectionState,
+              iceConnectionState: pc.iceConnectionState,
+            },
+          );
+          cleanupAndStopReconnecting();
+          clearInterval(checkInterval);
+        } else {
+          console.log("[setRemoteSessionDescription] Waiting for connection, state:", {
+            connectionState: pc.connectionState,
+            iceConnectionState: pc.iceConnectionState,
+          });
+        }
+      }, 1000);
+    },
+    [cleanupAndStopReconnecting],
+  );
+
+  const ignoreOffer = useRef(false);
+  const isSettingRemoteAnswerPending = useRef(false);
+  const makingOffer = useRef(false);
+  const reconnectAttemptsRef = useRef(2000);
+  const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
+
+  const { sendMessage, getWebSocket } = useWebSocket(
+    isOnDevice
+      ? `${wsProtocol}//${window.location.host}/webrtc/signaling/client`
+      : `${CLOUD_API.replace("http", "ws")}/webrtc/signaling/client?id=${deviceId}`,
+    {
+      heartbeat: true,
+      retryOnError: true,
+      reconnectAttempts: reconnectAttemptsRef.current,
+      reconnectInterval: reconnectInterval,
+      onReconnectStop: (numAttempts: number) => {
+        console.debug("Reconnect stopped after ", numAttempts, "attempts");
+        cleanupAndStopReconnecting();
+      },
+
+      shouldReconnect(event: WebSocketEventMap["close"]) {
+        console.debug("[Websocket] shouldReconnect", event);
+        return !isLegacySignalingEnabled.current;
+      },
+
+      onClose(event: WebSocketEventMap["close"]) {
+        console.debug("[Websocket] onClose", event);
+        // We don't want to close everything down, we wait for the reconnect to stop instead
+      },
+
+      onError(event: WebSocketEventMap["error"]) {
+        console.error("[Websocket] onError", event);
+        // We don't want to close everything down, we wait for the reconnect to stop instead
+      },
+
+      onOpen() {
+        console.debug("[Websocket] onOpen");
+        // We want to clear the reboot state when the websocket connection is opened
+        // Currently the flow is:
+        // 1. User clicks reboot
+        // 2. Device sends event 'willReboot'
+        // 3. We set the reboot state
+        // 4. Reboot modal is shown
+        // 5. WS tries to reconnect
+        // 6. WS reconnects
+        // 7. This function is called and now we clear the reboot state
+        setRebootState({ isRebooting: false, postRebootAction: null });
+      },
+
+      onMessage(event: WebSocketEventMap["message"]) {
+        const message = event;
+        if (message.data === "pong") return;
+
+        /*
+          Currently the signaling process is as follows:
+            After open, the other side will send a `device-metadata` message with the device version
+            If the device version is not set, we can assume the device is using the legacy signaling
+            Otherwise, we can assume the device is using the new signaling
+
+            If the device is using the legacy signaling, we close the websocket connection
+            and use the legacy HTTPSignaling function to get the remote session description
+
+            If the device is using the new signaling, we don't need to do anything special, but continue to use the websocket connection
+            to chat with the other peer about the connection
+        */
+
+        const parsedMessage = JSON.parse(message.data);
+
+        if (parsedMessage.type === "device-metadata") {
+          const { deviceVersion } = parsedMessage.data;
+          console.debug("[Websocket] Received device-metadata message");
+          console.debug("[Websocket] Device version", deviceVersion);
+          // If the device version is not set, we can assume the device is using the legacy signaling
+          if (!deviceVersion) {
+            console.log("[Websocket] Device is using legacy signaling");
+
+            // Now we don't need the websocket connection anymore, as we've established that we need to use the legacy signaling
+            // which does everything over HTTP(at least from the perspective of the client)
+            isLegacySignalingEnabled.current = true;
+            getWebSocket()?.close();
+          } else {
+            console.log("[Websocket] Device is using new signaling");
+            isLegacySignalingEnabled.current = false;
+          }
+
+          setupPeerConnection();
+        }
+
+        if (!peerConnection) return;
+
+        if (parsedMessage.type === "answer") {
+          console.debug("[Websocket] Received answer");
+          const readyForOffer =
+            // If we're making an offer, we don't want to accept an answer
+            !makingOffer &&
+            // If the peer connection is stable or we're setting the remote answer pending, we're ready for an offer
+            (peerConnection?.signalingState === "stable" || isSettingRemoteAnswerPending.current);
+
+          // If we're not ready for an offer, we don't want to accept an offer
+          ignoreOffer.current = parsedMessage.type === "offer" && !readyForOffer;
+          if (ignoreOffer.current) return;
+
+          // Set so we don't accept an answer while we're setting the remote description
+          isSettingRemoteAnswerPending.current = parsedMessage.type === "answer";
+          console.debug(
+            "[Websocket] Setting remote answer pending",
+            isSettingRemoteAnswerPending.current,
+          );
+
+          const sd = atob(parsedMessage.data);
+          const remoteSessionDescription = JSON.parse(sd);
+
+          setRemoteSessionDescription(
+            peerConnection,
+            new RTCSessionDescription(remoteSessionDescription),
+          );
+
+          // Reset the remote answer pending flag
+          isSettingRemoteAnswerPending.current = false;
+        } else if (parsedMessage.type === "new-ice-candidate") {
+          console.debug("[Websocket] Received new-ice-candidate");
+          const candidate = parsedMessage.data;
+          peerConnection.addIceCandidate(candidate);
+        }
+      },
+    },
+  );
+
+  const sendWebRTCSignal = useCallback(
+    (type: string, data: unknown) => {
+      // Second argument tells the library not to queue the message, and send it once the connection is established again.
+      // We have event handlers that handle the connection set up, so we don't need to queue the message.
+      sendMessage(JSON.stringify({ type, data }), false);
+    },
+    [sendMessage],
+  );
+
+  const legacyHTTPSignaling = useCallback(
+    async (pc: RTCPeerConnection) => {
+      const sd = btoa(JSON.stringify(pc.localDescription));
+
+      // Legacy mode == UI in cloud with updated code connecting to older device version.
+      // In device mode, old devices wont serve this JS, and on newer devices legacy mode wont be enabled
+      const sessionUrl = `${CLOUD_API}/webrtc/session`;
+
+      console.log("Trying to get remote session description");
+      setLoadingMessage(
+        m.getting_remote_session_description({
+          attempt: signalingAttempts.current + 1,
+        }),
+      );
+      const res = await api.POST(sessionUrl, {
+        sd,
+        // When on device, we don't need to specify the device id, as it's already known
+        ...(isOnDevice ? {} : { id: deviceId }),
+      });
+
+      const json = await res.json();
+      if (res.status === 401) return navigate(isOnDevice ? "/login-local" : "/login");
+      if (!res.ok) {
+        console.error("Error getting SDP", { status: res.status, json });
+        cleanupAndStopReconnecting();
+        return;
+      }
+
+      console.debug("Successfully got Remote Session Description. Setting.");
+      setLoadingMessage(m.setting_remote_session_description());
+
+      const decodedSd = atob(json.sd);
+      const parsedSd = JSON.parse(decodedSd);
+      setRemoteSessionDescription(pc, new RTCSessionDescription(parsedSd));
+    },
+    [cleanupAndStopReconnecting, deviceId, navigate, setRemoteSessionDescription],
+  );
+
+  const setupPeerConnection = useCallback(async () => {
+    console.debug("[setupPeerConnection] Setting up peer connection");
+    setConnectionFailed(false);
+    setLoadingMessage(m.connecting_to_device());
+
+    // Drop the previous PC's MediaStream — its tracks are ended and
+    // would sit ahead of the new live tracks, breaking playback.
+    setMediaStream(null);
+
+    let pc: RTCPeerConnection;
+    try {
+      console.debug("[setupPeerConnection] Creating peer connection");
+      setLoadingMessage(m.creating_peer_connection());
+      pc = new RTCPeerConnection({
+        ...(iceServers ? { iceServers } : {}),
+      });
+
+      setPeerConnectionState(pc.connectionState);
+      console.debug("[setupPeerConnection] Peer connection created", pc);
+      setLoadingMessage(m.setting_up_connection_to_device());
+    } catch (e) {
+      console.error(`[setupPeerConnection] Error creating peer connection: ${String(e)}`);
+      setTimeout(() => {
+        cleanupAndStopReconnecting();
+      }, 1000);
+      return;
+    }
+
+    // Set up event listeners and data channels
+    pc.onconnectionstatechange = () => {
+      console.debug("[setupPeerConnection] Connection state changed", pc.connectionState);
+      setPeerConnectionState(pc.connectionState);
+    };
+
+    pc.onnegotiationneeded = async () => {
+      try {
+        console.debug("[setupPeerConnection] Creating offer");
+        makingOffer.current = true;
+
+        if (isLinuxDesktop()) {
+          stripH265FromVideoTransceivers(pc);
+        }
+
+        const offer = await pc.createOffer();
+        await pc.setLocalDescription(offer);
+        const sd = btoa(JSON.stringify(pc.localDescription));
+        const isNewSignalingEnabled = isLegacySignalingEnabled.current === false;
+        if (isNewSignalingEnabled) {
+          sendWebRTCSignal("offer", { sd: sd });
+        } else {
+          console.log("Legacy signaling. Waiting for ICE Gathering to complete...");
+        }
+      } catch (e) {
+        console.error(
+          `[setupPeerConnection] Error creating offer: ${String(e)}`,
+          new Date().toISOString(),
+        );
+        cleanupAndStopReconnecting();
+      } finally {
+        makingOffer.current = false;
+      }
+    };
+
+    pc.onicecandidate = ({ candidate }) => {
+      if (!candidate) return;
+      if (candidate.candidate === "") return;
+      sendWebRTCSignal("new-ice-candidate", candidate);
+    };
+
+    pc.onicegatheringstatechange = event => {
+      const pc = event.currentTarget as RTCPeerConnection;
+      if (pc.iceGatheringState === "complete") {
+        console.debug("ICE Gathering completed");
+        setLoadingMessage(m.ice_gathering_completed());
+
+        if (isLegacySignalingEnabled.current) {
+          // We can now start the https/ws connection to get the remote session description from the KVM device
+          legacyHTTPSignaling(pc);
+        }
+      } else if (pc.iceGatheringState === "gathering") {
+        console.debug("ICE Gathering Started");
+        setLoadingMessage(m.gathering_ice_candidates());
+      }
+    };
+
+    onPeerConnection(pc);
+
+    setPeerConnection(pc);
+  }, [
+    cleanupAndStopReconnecting,
+    iceServers,
+    legacyHTTPSignaling,
+    onPeerConnection,
+    sendWebRTCSignal,
+    setMediaStream,
+    setPeerConnection,
+    setPeerConnectionState,
+  ]);
+
+  useEffect(() => {
+    if (peerConnectionState === "failed") {
+      console.warn("Connection failed, closing peer connection");
+      cleanupAndStopReconnecting();
+    }
+  }, [peerConnectionState, cleanupAndStopReconnecting]);
+
+  useEffect(() => {
+    return () => {
+      peerConnection?.close();
+    };
+  }, [peerConnection]);
+
+  return { connect: setupPeerConnection, loadingMessage, connectionFailed };
+};

--- a/ui/src/webrtc/signaling/useWebSocketSignaling.ts
+++ b/ui/src/webrtc/signaling/useWebSocketSignaling.ts
@@ -1,9 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useNavigate } from "react-router";
 import pkg from "react-use-websocket";
 
 import { CLOUD_API } from "@/ui.config";
-import api from "@/api";
 import { isOnDevice } from "@/main";
 import { useRTCStore, useUiStore } from "@hooks/stores";
 import { m } from "@localizations/messages.js";
@@ -44,9 +42,9 @@ const reconnectInterval = (attempt: number) => {
 /**
  * JetKVM's stock signaling: the browser is the offerer and talks to the
  * device (directly, or relayed by the cloud) over a WebSocket at
- * `/webrtc/signaling/client`. Devices that predate the WebSocket flow answer
- * the `device-metadata` message without a version, in which case the offer
- * is posted over HTTP once ICE gathering completes.
+ * `/webrtc/signaling/client`. The device announces itself with a
+ * `device-metadata` message, after which the browser sends its offer and
+ * trickles ICE candidates over the same socket.
  */
 export const useWebSocketSignaling: SignalingHook = ({
   deviceId,
@@ -61,9 +59,7 @@ export const useWebSocketSignaling: SignalingHook = ({
     setMediaStream,
   } = useRTCStore();
   const setRebootState = useUiStore(state => state.setRebootState);
-  const navigate = useNavigate();
 
-  const isLegacySignalingEnabled = useRef(false);
   const [connectionFailed, setConnectionFailed] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState(m.connecting_to_device());
 
@@ -78,7 +74,6 @@ export const useWebSocketSignaling: SignalingHook = ({
       connectionFailedRef.current = true;
 
       peerConnection?.close();
-      signalingAttempts.current = 0;
     },
     [peerConnection, setPeerConnectionState],
   );
@@ -97,7 +92,6 @@ export const useWebSocketSignaling: SignalingHook = ({
     connectionFailedRef.current = connectionFailed;
   }, [connectionFailed]);
 
-  const signalingAttempts = useRef(0);
   const setRemoteSessionDescription = useCallback(
     async function setRemoteSessionDescription(
       pc: RTCPeerConnection,
@@ -155,7 +149,7 @@ export const useWebSocketSignaling: SignalingHook = ({
   const reconnectAttemptsRef = useRef(2000);
   const wsProtocol = window.location.protocol === "https:" ? "wss:" : "ws:";
 
-  const { sendMessage, getWebSocket } = useWebSocket(
+  const { sendMessage } = useWebSocket(
     isOnDevice
       ? `${wsProtocol}//${window.location.host}/webrtc/signaling/client`
       : `${CLOUD_API.replace("http", "ws")}/webrtc/signaling/client?id=${deviceId}`,
@@ -171,7 +165,7 @@ export const useWebSocketSignaling: SignalingHook = ({
 
       shouldReconnect(event: WebSocketEventMap["close"]) {
         console.debug("[Websocket] shouldReconnect", event);
-        return !isLegacySignalingEnabled.current;
+        return true;
       },
 
       onClose(event: WebSocketEventMap["close"]) {
@@ -202,37 +196,15 @@ export const useWebSocketSignaling: SignalingHook = ({
         const message = event;
         if (message.data === "pong") return;
 
-        /*
-          Currently the signaling process is as follows:
-            After open, the other side will send a `device-metadata` message with the device version
-            If the device version is not set, we can assume the device is using the legacy signaling
-            Otherwise, we can assume the device is using the new signaling
-
-            If the device is using the legacy signaling, we close the websocket connection
-            and use the legacy HTTPSignaling function to get the remote session description
-
-            If the device is using the new signaling, we don't need to do anything special, but continue to use the websocket connection
-            to chat with the other peer about the connection
-        */
-
+        // After open, the other side sends a `device-metadata` message once the
+        // device is reachable. That is our cue to create the peer and offer;
+        // the answer and ICE candidates then arrive over the same socket.
         const parsedMessage = JSON.parse(message.data);
 
         if (parsedMessage.type === "device-metadata") {
           const { deviceVersion } = parsedMessage.data;
           console.debug("[Websocket] Received device-metadata message");
           console.debug("[Websocket] Device version", deviceVersion);
-          // If the device version is not set, we can assume the device is using the legacy signaling
-          if (!deviceVersion) {
-            console.log("[Websocket] Device is using legacy signaling");
-
-            // Now we don't need the websocket connection anymore, as we've established that we need to use the legacy signaling
-            // which does everything over HTTP(at least from the perspective of the client)
-            isLegacySignalingEnabled.current = true;
-            getWebSocket()?.close();
-          } else {
-            console.log("[Websocket] Device is using new signaling");
-            isLegacySignalingEnabled.current = false;
-          }
 
           setupPeerConnection();
         }
@@ -286,44 +258,6 @@ export const useWebSocketSignaling: SignalingHook = ({
     [sendMessage],
   );
 
-  const legacyHTTPSignaling = useCallback(
-    async (pc: RTCPeerConnection) => {
-      const sd = btoa(JSON.stringify(pc.localDescription));
-
-      // Legacy mode == UI in cloud with updated code connecting to older device version.
-      // In device mode, old devices wont serve this JS, and on newer devices legacy mode wont be enabled
-      const sessionUrl = `${CLOUD_API}/webrtc/session`;
-
-      console.log("Trying to get remote session description");
-      setLoadingMessage(
-        m.getting_remote_session_description({
-          attempt: signalingAttempts.current + 1,
-        }),
-      );
-      const res = await api.POST(sessionUrl, {
-        sd,
-        // When on device, we don't need to specify the device id, as it's already known
-        ...(isOnDevice ? {} : { id: deviceId }),
-      });
-
-      const json = await res.json();
-      if (res.status === 401) return navigate(isOnDevice ? "/login-local" : "/login");
-      if (!res.ok) {
-        console.error("Error getting SDP", { status: res.status, json });
-        cleanupAndStopReconnecting();
-        return;
-      }
-
-      console.debug("Successfully got Remote Session Description. Setting.");
-      setLoadingMessage(m.setting_remote_session_description());
-
-      const decodedSd = atob(json.sd);
-      const parsedSd = JSON.parse(decodedSd);
-      setRemoteSessionDescription(pc, new RTCSessionDescription(parsedSd));
-    },
-    [cleanupAndStopReconnecting, deviceId, navigate, setRemoteSessionDescription],
-  );
-
   const setupPeerConnection = useCallback(async () => {
     console.debug("[setupPeerConnection] Setting up peer connection");
     setConnectionFailed(false);
@@ -370,12 +304,7 @@ export const useWebSocketSignaling: SignalingHook = ({
         const offer = await pc.createOffer();
         await pc.setLocalDescription(offer);
         const sd = btoa(JSON.stringify(pc.localDescription));
-        const isNewSignalingEnabled = isLegacySignalingEnabled.current === false;
-        if (isNewSignalingEnabled) {
-          sendWebRTCSignal("offer", { sd: sd });
-        } else {
-          console.log("Legacy signaling. Waiting for ICE Gathering to complete...");
-        }
+        sendWebRTCSignal("offer", { sd: sd });
       } catch (e) {
         console.error(
           `[setupPeerConnection] Error creating offer: ${String(e)}`,
@@ -398,11 +327,6 @@ export const useWebSocketSignaling: SignalingHook = ({
       if (pc.iceGatheringState === "complete") {
         console.debug("ICE Gathering completed");
         setLoadingMessage(m.ice_gathering_completed());
-
-        if (isLegacySignalingEnabled.current) {
-          // We can now start the https/ws connection to get the remote session description from the KVM device
-          legacyHTTPSignaling(pc);
-        }
       } else if (pc.iceGatheringState === "gathering") {
         console.debug("ICE Gathering Started");
         setLoadingMessage(m.gathering_ice_candidates());
@@ -415,7 +339,6 @@ export const useWebSocketSignaling: SignalingHook = ({
   }, [
     cleanupAndStopReconnecting,
     iceServers,
-    legacyHTTPSignaling,
     onPeerConnection,
     sendWebRTCSignal,
     setMediaStream,

--- a/web.go
+++ b/web.go
@@ -198,22 +198,6 @@ func setupRouter() *gin.Engine {
 	protected := r.Group("/")
 	protected.Use(protectedMiddleware())
 	{
-		/*
-		 * Legacy WebRTC session endpoint
-		 *
-		 * This endpoint is maintained for backward compatibility when users upgrade from a version
-		 * using the legacy HTTP-based signaling method to the new WebSocket-based signaling method.
-		 *
-		 * During the upgrade process, when the "Rebooting device after update..." message appears,
-		 * the browser still runs the previous JavaScript code which polls this endpoint to establish
-		 * a new WebRTC session. Once the session is established, the page will automatically reload
-		 * with the updated code.
-		 *
-		 * Without this endpoint, the stale JavaScript would fail to establish a connection,
-		 * causing users to see the "Rebooting device after update..." message indefinitely
-		 * until they manually refresh the page, leading to a confusing user experience.
-		 */
-		protected.POST("/webrtc/session", handleWebRTCSession)
 		protected.GET("/webrtc/signaling/client", handleLocalWebRTCSignal)
 		protected.POST("/cloud/register", handleCloudRegister)
 		protected.GET("/cloud/state", handleCloudState)
@@ -244,43 +228,6 @@ func setupRouter() *gin.Engine {
 
 // TODO: support multiple sessions?
 var currentSession *Session
-
-func handleWebRTCSession(c *gin.Context) {
-	var req WebRTCSessionRequest
-
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusBadRequest, gin.H{"error": "Invalid request body"})
-		return
-	}
-
-	session, err := newSession(SessionConfig{MDNSMode: config.NetworkConfig.MDNSMode.String})
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
-		return
-	}
-
-	sd, err := session.ExchangeOffer(req.Sd)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err})
-		return
-	}
-	if currentSession != nil {
-		writeJSONRPCEvent("otherSessionConnected", nil, currentSession)
-		gadget.CancelAllAutoReleaseTimers()
-		_ = rpcKeyboardReport(0, keyboardClearStateKeys)
-		peerConn := currentSession.peerConnection
-		go func() {
-			time.Sleep(1 * time.Second)
-			_ = peerConn.Close()
-		}()
-	}
-
-	// Cancel any ongoing keyboard macro when session changes
-	cancelKeyboardMacro()
-
-	currentSession = session
-	c.JSON(http.StatusOK, gin.H{"sd": sd})
-}
 
 var (
 	pingMessage = []byte("ping")


### PR DESCRIPTION
Moves WebRTC signaling behind an adapter interface and removes the legacy HTTP session signaling.

## Signaling adapter

New `ui/src/webrtc/signaling/`:

- `types.ts`: the adapter interface. An adapter owns the peer connection and reports it through the RTC store.
- `useWebSocketSignaling.ts`: the existing WebSocket flow, moved unchanged.
- `index.ts`: `useSignaling()` picks an adapter by kind. One entry today.

`devices.$id.tsx` keeps only what it attaches to a new peer: transceivers, data channels, media stream. 1189 → 819 lines.

## Legacy HTTP signaling removed

- UI: the fallback that posted the offer to `/webrtc/session` when `device-metadata` had no version.
- Go: the `POST /webrtc/session` handler.

Every bundle since WebSocket signaling negotiates over the socket, and the reboot overlay reloads the page after the health check. A tab running JavaScript older than that needs a manual refresh after upgrading to this version.

## Left out

- Two unused localization keys, `getting_remote_session_description` and `setting_remote_session_description`.
- `onPeerConnection` assumes the browser makes the offer. An adapter where the device offers needs a small change to the interface.

## Checks

`tsc`, `oxlint`, `oxfmt`, `go vet`, `gofmt` clean. Device build succeeds. E2E pending.
