### PR TITLE
fix(ui): stop leaking JSON-RPC callbacks

### DIFF
--- a/ui/src/hooks/useJsonRpc.ts
+++ b/ui/src/hooks/useJsonRpc.ts
@@ -87,7 +87,14 @@ export function useJsonRpc(onRequest?: (payload: JsonRpcRequest) => void) {
       // Store the callback if it exists
       if (callback) callbackStore.set(payload.id, callback);
 
-      rpcDataChannel.send(JSON.stringify(payload));
+      // The channel can close between the readyState check and the send.
+      // Drop the callback so it cannot wait forever for a reply.
+      try {
+        rpcDataChannel.send(JSON.stringify(payload));
+      } catch (error) {
+        callbackStore.delete(payload.id);
+        console.error(`Failed to send RPC method "${method}"`, error);
+      }
     },
     [rpcDataChannel, isFailsafeMode, reason],
   );
@@ -110,8 +117,9 @@ export function useJsonRpc(onRequest?: (payload: JsonRpcRequest) => void) {
 
       const callback = callbackStore.get(payload.id);
       if (callback) {
-        callback(payload);
+        // Delete first so a throwing callback cannot leave its entry behind.
         callbackStore.delete(payload.id);
+        callback(payload);
       }
     };
 


### PR DESCRIPTION
Two ways a callback stayed in `callbackStore` forever:

- `send()` registered the callback before `rpcDataChannel.send()`, which throws while the channel is closing.
- On a reply the callback ran before its entry was removed, so a throwing callback leaked as well.

Drop the callback when the send throws, and delete the entry before invoking the callback. No signature change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized error-handling in the JSON-RPC hook; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes **memory leaks** in `useJsonRpc` where pending RPC callbacks could remain in `callbackStore` indefinitely.
> 
> **On send:** wraps `rpcDataChannel.send()` in try/catch and **removes** the stored callback if send throws (e.g. channel closed after the `readyState` check).
> 
> **On reply:** **deletes** the map entry **before** invoking the callback so a throwing handler cannot leave a stale entry behind.
> 
> No API changes to `send` or hook consumers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53e2a7da4ffac10ff0ef0a124d0f157d7d4253d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->