### PR TITLE
fix(ui): recreate serial and CDC-ACM console channels per peer connection

### DIFF
--- a/serial.go
+++ b/serial.go
@@ -692,8 +692,11 @@ func handleSerialChannel(dataChannel *webrtc.DataChannel) {
 	dataChannel.OnClose(func() {
 		scopedLogger.Info().Msg("Serial channel closed")
 
+		// A replacement channel may already own the sink: this close can
+		// run after the new session's OnOpen when the old peer went away
+		// without a clean shutdown.
 		if consoleBroker != nil {
-			consoleBroker.SetSink(nil)
+			consoleBroker.ClearSink(dataChannelSink{dataChannel: dataChannel})
 		}
 	})
 }

--- a/serial_console_helpers.go
+++ b/serial_console_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -224,9 +225,13 @@ type consoleEvent struct {
 }
 
 type ConsoleBroker struct {
-	sink Sink
-	in   chan consoleEvent
-	done chan struct{}
+	// sinkLock makes a conditional clear atomic with a replacement: the old
+	// channel's OnClose and the new channel's OnOpen run on their own
+	// goroutines.
+	sinkLock sync.Mutex
+	sink     Sink
+	in       chan consoleEvent
+	done     chan struct{}
 
 	// pause control
 	terminalPaused bool
@@ -272,9 +277,23 @@ func NewConsoleBroker(s Sink, norm NormalizationOptions) *ConsoleBroker {
 	}
 }
 
-func (b *ConsoleBroker) Start()                                   { go b.loop() }
-func (b *ConsoleBroker) Close()                                   { close(b.done) }
-func (b *ConsoleBroker) SetSink(s Sink)                           { b.sink = s }
+func (b *ConsoleBroker) Start() { go b.loop() }
+func (b *ConsoleBroker) Close() { close(b.done) }
+func (b *ConsoleBroker) SetSink(s Sink) {
+	b.sinkLock.Lock()
+	defer b.sinkLock.Unlock()
+	b.sink = s
+}
+
+// ClearSink detaches s, and leaves the sink alone when another one has
+// replaced it since.
+func (b *ConsoleBroker) ClearSink(s Sink) {
+	b.sinkLock.Lock()
+	defer b.sinkLock.Unlock()
+	if b.sink == s {
+		b.sink = nil
+	}
+}
 func (b *ConsoleBroker) SetNormOptions(norm NormalizationOptions) { b.norm = norm }
 func (b *ConsoleBroker) SetTerminalPaused(v bool) {
 	if b == nil {

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -2673,6 +2673,15 @@ test.describe("Remote Host Agent", () => {
       /* no reader running */
     }
     const ttyAfter = await waitForRemoteHostTtyACM(true);
+    // Same ModemManager probe wait as above; returns at once when the port
+    // did not re-enumerate.
+    await expect
+      .poll(() => remoteHostExec(`sudo lsof -t ${ttyAfter} 2>/dev/null || true`).trim(), {
+        message: `waiting for ${ttyAfter} to be free of host processes`,
+        timeout: 30_000,
+        intervals: [1000],
+      })
+      .toBe("");
     remoteHostExec(`sudo stty -F ${ttyAfter} 9600 raw -echo`);
     remoteHostExec(`sudo bash -c 'nohup cat ${ttyAfter} > /tmp/cdcacm_rx.txt 2>/dev/null &'`);
 
@@ -2688,7 +2697,7 @@ test.describe("Remote Host Agent", () => {
 
     // Test receiving data: send from remote host to ttyACM
     const replyString = `reply_${Date.now()}`;
-    remoteHostExec(`sudo bash -c 'echo ${replyString} > ${ttyACM}'`);
+    remoteHostExec(`sudo bash -c 'echo ${replyString} > ${ttyAfter}'`);
     await new Promise(r => setTimeout(r, 2000));
 
     // Take a screenshot for visual review

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -2606,9 +2606,9 @@ test.describe("Remote Host Agent", () => {
   // USB SERIAL CONSOLE UI
   // ═══════════════════════════════════════════
 
-  test("usb: USB Serial Console terminal sends and receives data via ttyGS0", async () => {
+  test("usb: USB Serial Console terminal sends and receives data via ttyGS0, also after a reconnect", async () => {
     // Budget for the ModemManager-probe wait plus typed-string retries.
-    test.setTimeout(120_000);
+    test.setTimeout(150_000);
 
     test.skip(!process.env.JETKVM_REMOTE_HOST, "JETKVM_REMOTE_HOST not set");
 
@@ -2658,6 +2658,33 @@ test.describe("Remote Host Agent", () => {
       const received = remoteHostExec("sudo cat /tmp/cdcacm_rx.txt 2>/dev/null || true").trim();
       expect(received).toContain(sentString);
     }).toPass({ timeout: 20_000 });
+
+    // An app restart drops the peer connection and the UI sets up a new one
+    // without a reload. The console must follow it: a data channel left over
+    // from the old connection is dead and the typed string never arrives.
+    await restartAppViaSSH();
+    await waitForWebRTCReady(sharedPage);
+
+    // The host may have re-enumerated the gadget, so point a fresh reader at
+    // the port. Kill the old one first or two readers split the data.
+    try {
+      remoteHostExec("sudo pkill -f 'cat /dev/ttyAC[M]'");
+    } catch {
+      /* no reader running */
+    }
+    const ttyAfter = await waitForRemoteHostTtyACM(true);
+    remoteHostExec(`sudo stty -F ${ttyAfter} 9600 raw -echo`);
+    remoteHostExec(`sudo bash -c 'nohup cat ${ttyAfter} > /tmp/cdcacm_rx.txt 2>/dev/null &'`);
+
+    await sharedPage.keyboard.press("Escape");
+    await cdcButton.click();
+    await expect(async () => {
+      const sentString = `e2e_reconnect_${Date.now()}`;
+      await sharedPage.keyboard.type(sentString, { delay: 50 });
+      await new Promise(r => setTimeout(r, 1000));
+      const received = remoteHostExec("sudo cat /tmp/cdcacm_rx.txt 2>/dev/null || true").trim();
+      expect(received).toContain(sentString);
+    }).toPass({ timeout: 30_000 });
 
     // Test receiving data: send from remote host to ttyACM
     const replyString = `reply_${Date.now()}`;

--- a/ui/e2e/serial-console-takeover.spec.ts
+++ b/ui/e2e/serial-console-takeover.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Browser, type Page } from "@playwright/test";
+import {
+  callJsonRpc,
+  ensureNoPasswordViaAPI,
+  ensureRpcReady,
+  sshExec,
+  waitForWebRTCReady,
+} from "./helpers";
+
+// Every session opens a serial data channel and the device makes it the
+// console broker's sink. On a takeover the device closes the replaced peer
+// connection a second after answering the new one, so the old channel's
+// close lands after the new channel became the sink. That close used to
+// clear the sink unconditionally and the new session's console went silent.
+
+declare global {
+  interface Window {
+    __e2eSerial?: { dc: RTCDataChannel; rx: string[] };
+  }
+}
+
+// Hooks the page's own serial channel so the test can watch what the device
+// sends on it without going through the terminal UI.
+async function hookSerialChannel(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const create = RTCPeerConnection.prototype.createDataChannel;
+    RTCPeerConnection.prototype.createDataChannel = function (label, init) {
+      const dc = create.call(this, label, init);
+      if (label === "serial") {
+        const hook = { dc, rx: [] as string[] };
+        dc.addEventListener("message", e => hook.rx.push(String(e.data)));
+        window.__e2eSerial = hook;
+      }
+      return dc;
+    };
+  });
+}
+
+// The device writes only to the channel that owns the sink. With echo on,
+// what a session sends comes back to it through the broker, which makes sink
+// ownership observable end to end.
+async function expectEcho(page: Page, tag: string): Promise<void> {
+  const text = `${tag}_${Date.now()}`;
+  await page.evaluate(text => {
+    const hook = window.__e2eSerial;
+    if (!hook || hook.dc.readyState !== "open") throw new Error("serial channel not open");
+    hook.dc.send(JSON.stringify({ type: "serial", data: `${text}\n` }));
+  }, text);
+  await expect
+    .poll(
+      async () =>
+        (await page.evaluate(() => window.__e2eSerial?.rx ?? [])).some(m => m.includes(text)),
+      {
+        message: `${tag}: echo should arrive on this session's serial channel`,
+        timeout: 5_000,
+      },
+    )
+    .toBe(true);
+}
+
+const SERIAL_SETTINGS_PATH = "/userdata/serialSettings.json";
+
+// The device's built-in defaults; getSerialSettings errors until a settings
+// file exists.
+const DEFAULT_SERIAL_SETTINGS = {
+  baudRate: 115200,
+  dataBits: 8,
+  parity: "none",
+  stopBits: "1",
+  terminator: { label: "LF (\\n)", value: "\n" },
+  hideSerialSettings: false,
+  enableEcho: false,
+  normalizeMode: "names",
+  normalizeLineEnd: "keep",
+  tabRender: "",
+  preserveANSI: true,
+  showNLTag: false,
+  buttons: [],
+};
+
+test.describe("serial console sink across a session takeover", () => {
+  let hadSettingsFile = false;
+  let settings: Record<string, unknown> = DEFAULT_SERIAL_SETTINGS;
+
+  async function withPage(browser: Browser, fn: (page: Page) => Promise<void>): Promise<void> {
+    const page = await browser.newPage();
+    try {
+      await page.goto("/", { waitUntil: "networkidle" });
+      await ensureRpcReady(page);
+      await fn(page);
+    } finally {
+      await page.close();
+    }
+  }
+
+  test.beforeAll(async ({ browser }) => {
+    await ensureNoPasswordViaAPI();
+    hadSettingsFile =
+      (await sshExec(`[ -f ${SERIAL_SETTINGS_PATH} ] && echo yes || echo no`)).trim() === "yes";
+    await withPage(browser, async page => {
+      if (hadSettingsFile) {
+        settings = (await callJsonRpc(page, "getSerialSettings")) as Record<string, unknown>;
+      }
+      await callJsonRpc(page, "setSerialSettings", { settings: { ...settings, enableEcho: true } });
+    });
+  });
+
+  test.afterAll(async ({ browser }) => {
+    await withPage(browser, async page => {
+      await callJsonRpc(page, "setSerialSettings", { settings });
+    });
+    if (!hadSettingsFile) await sshExec(`rm -f ${SERIAL_SETTINGS_PATH}`, true);
+  });
+
+  test("the new session keeps its serial sink when the replaced session's channel closes", async ({
+    browser,
+  }) => {
+    test.setTimeout(60_000);
+
+    const first = await browser.newPage();
+    await hookSerialChannel(first);
+    await first.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(first);
+    await expectEcho(first, "first");
+
+    const second = await browser.newPage();
+    await hookSerialChannel(second);
+    await second.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(second);
+    await expectEcho(second, "second");
+
+    // The device closes the first peer connection a second after the
+    // takeover. The browser reports the channel closed once that happened.
+    await expect
+      .poll(() => first.evaluate(() => window.__e2eSerial?.dc.readyState), {
+        message: "replaced session's serial channel should close",
+        timeout: 15_000,
+      })
+      .toBe("closed");
+
+    await expectEcho(second, "after_close");
+
+    await first.close();
+    await second.close();
+  });
+});

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -931,22 +931,22 @@ export default function KvmIdRoute() {
   // Serial console - still created via useEffect for now
   const [serialConsole, setSerialConsole] = useState<RTCDataChannel | null>(null);
 
+  // One channel per peer connection: a channel from a previous peer is dead
+  // after a reconnect, so it is closed and replaced rather than kept.
   useEffect(() => {
-    if (!peerConnection) return;
-    if (!serialConsole) {
-      setSerialConsole(peerConnection.createDataChannel("serial"));
-    }
-  }, [peerConnection, serialConsole]);
+    const channel = peerConnection ? peerConnection.createDataChannel("serial") : null;
+    setSerialConsole(channel);
+    return () => channel?.close();
+  }, [peerConnection]);
 
   // CDC-ACM console data channel
   const [cdcACMConsole, setCdcACMConsole] = useState<RTCDataChannel | null>(null);
 
   useEffect(() => {
-    if (!peerConnection) return;
-    if (!cdcACMConsole) {
-      setCdcACMConsole(peerConnection.createDataChannel("cdcacm"));
-    }
-  }, [peerConnection, cdcACMConsole]);
+    const channel = peerConnection ? peerConnection.createDataChannel("cdcacm") : null;
+    setCdcACMConsole(channel);
+    return () => channel?.close();
+  }, [peerConnection]);
 
   // Register E2E test hooks
   useEffect(() => {


### PR DESCRIPTION
The serial and CDC-ACM console channels were created once, guarded by `if (!serialConsole)`, and kept across reconnects. After any reconnect the consoles held a channel from the dead peer and stopped working until the page was reloaded.

Create one channel per peer connection and close it when the peer changes or the route unmounts.

To reproduce on `dev`: open the serial console, force a reconnect (unplug network briefly), type. Nothing arrives.

## Device side

On a takeover the device closes the replaced peer connection a second
after answering the new one. The old serial channel's close ran after
the new channel had become the console broker's sink, and cleared it, so
the new session's serial console was silent until the next reconnect.
The close now only clears the sink it still owns.

E2E: a second session keeps receiving serial echo after the first
session's channel closed. Fails on `dev` every time.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches WebRTC console wiring and shared broker sink lifecycle; incorrect sink handling could break serial output for active sessions, but changes are narrowly scoped with targeted e2e tests.
> 
> **Overview**
> Fixes serial and USB CDC-ACM consoles going silent after WebRTC reconnect or session takeover without a full page reload.
> 
> The device page now creates a fresh `serial` and `cdcacm` data channel whenever `peerConnection` changes, and closes the previous channel on cleanup instead of reusing channels tied to a dead peer.
> 
> On the device, `ConsoleBroker` uses a mutex and **identity-aware** `ClearSink` so a late `OnClose` from the replaced session cannot clear the sink already claimed by the new session. Serial channel teardown calls `ClearSink` for that channel only rather than `SetSink(nil)`.
> 
> E2E coverage adds a post–app-restart send/receive path in the USB serial console test and a dedicated takeover spec (two browsers, echo enabled) that asserts the winning session still receives console traffic after the old peer’s channel closes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2d01cf293ff15da7e0689d60a5c5a29e3b244a48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Test

The serial console e2e test now restarts the app mid-way, lets the UI
reconnect without a reload, and requires a typed string to reach the
host again. It fails on `dev` at that step and passes with this change.
Adds about 8 s to the test.

