### PR TITLE
fix(ui): clear HID channels and protocol version when the device route unmounts

### DIFF
--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -139,13 +139,13 @@ export interface RTCState {
   setRpcHidProtocolVersion: (version: number | null) => void;
 
   rpcHidChannel: RTCDataChannel | null;
-  setRpcHidChannel: (channel: RTCDataChannel) => void;
+  setRpcHidChannel: (channel: RTCDataChannel | null) => void;
 
   rpcHidUnreliableChannel: RTCDataChannel | null;
-  setRpcHidUnreliableChannel: (channel: RTCDataChannel) => void;
+  setRpcHidUnreliableChannel: (channel: RTCDataChannel | null) => void;
 
   rpcHidUnreliableNonOrderedChannel: RTCDataChannel | null;
-  setRpcHidUnreliableNonOrderedChannel: (channel: RTCDataChannel) => void;
+  setRpcHidUnreliableNonOrderedChannel: (channel: RTCDataChannel | null) => void;
 
   peerConnectionState: RTCPeerConnectionState | null;
   setPeerConnectionState: (state: RTCPeerConnectionState) => void;

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -666,6 +666,10 @@ export default function KvmIdRoute() {
       setSidebarView(null);
       setPeerConnection(null);
       setRpcDataChannel(null);
+      setRpcHidChannel(null);
+      setRpcHidUnreliableChannel(null);
+      setRpcHidUnreliableNonOrderedChannel(null);
+      setRpcHidProtocolVersion(null);
       setTerminalChannel(null);
     };
   }, [
@@ -674,6 +678,10 @@ export default function KvmIdRoute() {
     setPeerConnection,
     setSidebarView,
     setRpcDataChannel,
+    setRpcHidChannel,
+    setRpcHidUnreliableChannel,
+    setRpcHidUnreliableNonOrderedChannel,
+    setRpcHidProtocolVersion,
     setTerminalChannel,
   ]);
 


### PR DESCRIPTION
The unmount cleanup in the device route reset the peer, rpc and terminal channels but left the three HID channels and the negotiated HID protocol version in the store. Navigating away and back showed the closed channels until the new peer opened its own.

Reset them with the rest. The three store setters now accept `null`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped lifecycle cleanup and type-only setter widening; no auth or server changes.
> 
> **Overview**
> Fixes stale WebRTC HID state when leaving the device KVM route: the unmount cleanup already cleared peer, RPC, and terminal channels but **left the three HID data channels and negotiated `rpcHidProtocolVersion` in `useRTCStore`**, so a quick navigate-away-and-back could still see closed channels until the new peer negotiated replacements.
> 
> The device route unmount effect now resets **`setRpcHidChannel`**, **`setRpcHidUnreliableChannel`**, **`setRpcHidUnreliableNonOrderedChannel`**, and **`setRpcHidProtocolVersion`** to `null` alongside the existing store resets. The RTC store typings for those three HID channel setters are updated to accept **`RTCDataChannel | null`**, matching `setRpcDataChannel` / `setTerminalChannel`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef1ec00552946f515ab3315b49dcb34d71bb6d9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->