### PR TITLE
fix(ui): show 0% instead of NaN% when storage reports no capacity

### DIFF
--- a/ui/src/routes/devices.$id.mount.tsx
+++ b/ui/src/routes/devices.$id.mount.tsx
@@ -514,11 +514,9 @@ function DeviceFileView({
 
   const percentageUsed = useMemo(() => {
     if (!storageSpace) return 0;
-    return Number(
-      ((storageSpace.bytesUsed / (storageSpace.bytesUsed + storageSpace.bytesFree)) * 100).toFixed(
-        1,
-      ),
-    );
+    const total = storageSpace.bytesUsed + storageSpace.bytesFree;
+    if (total === 0) return 0;
+    return Number(((storageSpace.bytesUsed / total) * 100).toFixed(1));
   }, [storageSpace]);
 
   const bytesUsed = useMemo(() => {


### PR DESCRIPTION
`bytesUsed / (bytesUsed + bytesFree)` divides by zero when both are zero and the storage usage bar renders `NaN%`. Return 0 when the total is 0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single UI guard in a display-only useMemo with no auth, data, or API behavior changes.
> 
> **Overview**
> Fixes the **JetKVM storage** usage display on the device mount screen when `getStorageSpace` returns **0 used and 0 free**.
> 
> The `percentageUsed` calculation now treats **zero total capacity** as **0%** instead of dividing by zero, so the label and progress bar no longer show **`NaN%`** or an invalid width.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d485f59af26c9ee0423fe59a71d69468081e0461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->