### PR TITLE
fix(ui): abort storage uploads on cancel, reselect and unmount

### DIFF
--- a/ui/e2e/upload-cancel.spec.ts
+++ b/ui/e2e/upload-cancel.spec.ts
@@ -1,0 +1,87 @@
+import { createHash, randomBytes } from "crypto";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { test, expect, type Page } from "@playwright/test";
+import { ensureNoPasswordViaAPI, ensureRpcReady, sshExec } from "./helpers";
+
+// Cancelling an upload has to stop the request that is streaming the file,
+// not just reset the view. The device keeps the partial file for a resume,
+// so the retry has to produce a byte-identical image.
+
+const FILE_NAME = "e2e-upload-cancel.img";
+const FILE_SIZE = 16 * 1024 * 1024;
+const REMOTE = `/userdata/jetkvm/images/${FILE_NAME}`;
+const THROTTLED_UPLOAD_BYTES_PER_SEC = 2 * 1024 * 1024;
+
+async function remoteSize(): Promise<number> {
+  // The device has no stat binary.
+  const out = await sshExec(
+    `f=${REMOTE}.incomplete; [ -f "$f" ] || f=${REMOTE}; [ -f "$f" ] && wc -c < "$f" || echo 0`,
+    true,
+  );
+  return parseInt(out.trim(), 10) || 0;
+}
+
+async function openUploadView(page: Page): Promise<void> {
+  await page.goto("/mount", { waitUntil: "networkidle" });
+  await ensureRpcReady(page);
+  await page.getByText("JetKVM Storage Mount").click();
+  await page.getByRole("button", { name: /^(next|continue)$/i }).click();
+  // "Upload New Image" with an empty store, "Upload a new image" otherwise.
+  await page.getByRole("button", { name: /^upload (a )?new image$/i }).click();
+}
+
+test.describe("Upload cancel and resume", () => {
+  let localPath = "";
+  let sha256 = "";
+
+  test.beforeAll(async () => {
+    await ensureNoPasswordViaAPI();
+    const data = randomBytes(FILE_SIZE);
+    localPath = join(mkdtempSync(join(tmpdir(), "jetkvm-e2e-")), FILE_NAME);
+    writeFileSync(localPath, data);
+    sha256 = createHash("sha256").update(data).digest("hex");
+    await sshExec(`rm -f ${REMOTE} ${REMOTE}.incomplete`, true);
+  });
+
+  test.afterAll(async () => {
+    await sshExec(`rm -f ${REMOTE} ${REMOTE}.incomplete`, true);
+  });
+
+  test("cancelling an upload stops the transfer, and a retry resumes it", async ({ page }) => {
+    test.setTimeout(90_000);
+
+    // Throttle the upload so Cancel lands while the request is streaming.
+    const cdp = await page.context().newCDPSession(page);
+    const throttle = (uploadThroughput: number) =>
+      cdp.send("Network.emulateNetworkConditions", {
+        offline: false,
+        latency: 0,
+        downloadThroughput: -1,
+        uploadThroughput,
+      });
+    await throttle(THROTTLED_UPLOAD_BYTES_PER_SEC);
+
+    await openUploadView(page);
+    await page.locator('input[type="file"]').setInputFiles(localPath);
+    await expect.poll(remoteSize, { timeout: 20_000 }).toBeGreaterThan(FILE_SIZE / 8);
+
+    await page.getByRole("button", { name: "Cancel Upload" }).click();
+
+    // Before the fix the request kept streaming after Cancel.
+    await page.waitForTimeout(1_000);
+    const afterCancel = await remoteSize();
+    await page.waitForTimeout(1_500);
+    expect(await remoteSize(), "upload kept streaming after Cancel").toBe(afterCancel);
+    expect(afterCancel, "cancelled upload must not complete").toBeLessThan(FILE_SIZE);
+
+    await throttle(-1);
+    await openUploadView(page);
+    await page.locator('input[type="file"]').setInputFiles(localPath);
+    await expect(page.getByText("Upload successful")).toBeVisible({ timeout: 40_000 });
+
+    const remote = (await sshExec(`sha256sum ${REMOTE} | cut -d" " -f1`, true)).trim();
+    expect(remote, "resumed upload must be byte-identical").toBe(sha256);
+  });
+});

--- a/ui/e2e/upload-cancel.spec.ts
+++ b/ui/e2e/upload-cancel.spec.ts
@@ -14,13 +14,16 @@ const FILE_SIZE = 16 * 1024 * 1024;
 const REMOTE = `/userdata/jetkvm/images/${FILE_NAME}`;
 const THROTTLED_UPLOAD_BYTES_PER_SEC = 2 * 1024 * 1024;
 
+// A failed read throws instead of reading as an empty file, so an SSH
+// hiccup cannot pass as a stopped upload.
 async function remoteSize(): Promise<number> {
   // The device has no stat binary.
   const out = await sshExec(
     `f=${REMOTE}.incomplete; [ -f "$f" ] || f=${REMOTE}; [ -f "$f" ] && wc -c < "$f" || echo 0`,
-    true,
   );
-  return parseInt(out.trim(), 10) || 0;
+  const size = parseInt(out.trim(), 10);
+  if (Number.isNaN(size)) throw new Error(`unexpected size output: ${JSON.stringify(out)}`);
+  return size;
 }
 
 async function openUploadView(page: Page): Promise<void> {
@@ -73,6 +76,7 @@ test.describe("Upload cancel and resume", () => {
     await page.waitForTimeout(1_000);
     const afterCancel = await remoteSize();
     await page.waitForTimeout(1_500);
+    expect(afterCancel, "partial file must exist after Cancel").toBeGreaterThan(0);
     expect(await remoteSize(), "upload kept streaming after Cancel").toBe(afterCancel);
     expect(afterCancel, "cancelled upload must not complete").toBeLessThan(FILE_SIZE);
 

--- a/ui/e2e/upload-cancel.spec.ts
+++ b/ui/e2e/upload-cancel.spec.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { test, expect, type Page } from "@playwright/test";
-import { ensureNoPasswordViaAPI, ensureRpcReady, sshExec } from "./helpers";
+import { callJsonRpc, ensureNoPasswordViaAPI, ensureRpcReady, sshExec } from "./helpers";
 
 // Cancelling an upload has to stop the request that is streaming the file,
 // not just reset the view. The device keeps the partial file for a resume,
@@ -88,4 +88,52 @@ test.describe("Upload cancel and resume", () => {
     const remote = (await sshExec(`sha256sum ${REMOTE} | cut -d" " -f1`, true)).trim();
     expect(remote, "resumed upload must be byte-identical").toBe(sha256);
   });
+});
+
+// A cancelled data channel closes gracefully and can still deliver buffered
+// chunks after the user has retried. The device ends the old transfer when a
+// new one starts for the same file, so only one writer is ever appending.
+test("a second start for the same file supersedes the first", async ({ page }) => {
+  test.setTimeout(60_000);
+
+  const name = "e2e-upload-supersede.img";
+  const remote = `/userdata/jetkvm/images/${name}`;
+  const data = randomBytes(1024 * 1024);
+  const cleanup = () => sshExec(`rm -f ${remote} ${remote}.incomplete`, true);
+
+  await ensureNoPasswordViaAPI();
+  await cleanup();
+  try {
+    await page.goto("/", { waitUntil: "networkidle" });
+    await ensureRpcReady(page);
+
+    const start = async () =>
+      (await callJsonRpc(page, "startStorageFileUpload", {
+        filename: name,
+        size: data.length,
+      })) as { dataChannel: string };
+    const first = await start();
+    const second = await start();
+
+    // Data for the first upload is rejected rather than appended beside the
+    // second transfer's bytes.
+    const stale = await page.request.post(
+      `/storage/upload?uploadId=${encodeURIComponent(first.dataChannel)}`,
+      { data: data.subarray(0, 4096) },
+    );
+    expect(stale.status(), "superseded upload must be rejected").toBe(404);
+
+    const ok = await page.request.post(
+      `/storage/upload?uploadId=${encodeURIComponent(second.dataChannel)}`,
+      { data },
+    );
+    expect(ok.ok(), "second upload must complete").toBe(true);
+
+    const remoteHash = (await sshExec(`sha256sum ${remote} | cut -d" " -f1`)).trim();
+    expect(remoteHash, "image must be byte-identical").toBe(
+      createHash("sha256").update(data).digest("hex"),
+    );
+  } finally {
+    await cleanup();
+  }
 });

--- a/ui/src/routes/devices.$id.mount.tsx
+++ b/ui/src/routes/devices.$id.mount.tsx
@@ -788,6 +788,8 @@ function DeviceFileView({
   );
 }
 
+const START_STORAGE_UPLOAD_TIMEOUT_MS = 30_000;
+
 function UploadFileView({
   onBack,
   onCancelUpload,
@@ -806,35 +808,52 @@ function UploadFileView({
   const [uploadError, setUploadError] = useState<string | null>(null);
 
   const { send } = useJsonRpc();
-  const rtcDataChannelRef = useRef<RTCDataChannel | null>(null);
 
-  useEffect(() => {
-    const ref = rtcDataChannelRef.current;
-    return () => {
-      console.log("unmounting");
-      if (ref) {
-        ref.onopen = null;
-        ref.onerror = null;
-        ref.onmessage = null;
-        ref.onclose = null;
-        ref.close();
-      }
-    };
+  // One controller per upload attempt. Aborting it stops the transport the
+  // attempt is using and makes its late callbacks return early, so
+  // cancelling, picking another file or leaving the view cannot leave a
+  // transfer running or write into stale state.
+  const attemptRef = useRef<AbortController | null>(null);
+
+  const abortUpload = useCallback(() => {
+    attemptRef.current?.abort();
+    attemptRef.current = null;
   }, []);
 
-  function handleWebRTCUpload(file: File, alreadyUploadedBytes: number, dataChannel: string) {
+  useEffect(() => abortUpload, [abortUpload]);
+
+  function failUpload(error: string) {
+    abortUpload();
+    setUploadError(error);
+    setUploadState("idle");
+    setUploadSpeed(null);
+  }
+
+  function handleWebRTCUpload(
+    file: File,
+    alreadyUploadedBytes: number,
+    dataChannel: string,
+    signal: AbortSignal,
+  ) {
     const rtcDataChannel = useRTCStore.getState().peerConnection?.createDataChannel(dataChannel);
 
     if (!rtcDataChannel) {
       console.error("Failed to create data channel for file upload");
       notifications.error(m.mount_upload_failed_datachannel());
-      setUploadState("idle");
+      failUpload(m.mount_upload_failed_datachannel());
       console.log("Upload state set to 'idle'");
 
       return;
     }
 
-    rtcDataChannelRef.current = rtcDataChannel;
+    signal.addEventListener("abort", () => {
+      rtcDataChannel.onopen = null;
+      rtcDataChannel.onerror = null;
+      rtcDataChannel.onmessage = null;
+      rtcDataChannel.onclose = null;
+      rtcDataChannel.onbufferedamountlow = null;
+      rtcDataChannel.close();
+    });
 
     const lowWaterMark = 256 * 1024;
     const highWaterMark = 1 * 1024 * 1024;
@@ -884,6 +903,7 @@ function UploadFileView({
 
       let offset = alreadyUploadedBytes;
       const sendNextChunk = () => {
+        if (signal.aborted) return;
         if (offset >= file.size) {
           rtcDataChannel.close();
           setUploadState("success");
@@ -894,7 +914,14 @@ function UploadFileView({
 
         const chunk = file.slice(offset, offset + chunkSize);
         chunk.arrayBuffer().then(buffer => {
-          rtcDataChannel.send(buffer);
+          if (signal.aborted) return;
+          try {
+            rtcDataChannel.send(buffer);
+          } catch (error) {
+            console.error("RTC Data channel send failed:", error);
+            failUpload(m.mount_upload_failed_rtc({ error: String(error) }));
+            return;
+          }
 
           if (rtcDataChannel.bufferedAmount >= highWaterMark) {
             pauseSending = true;
@@ -917,16 +944,22 @@ function UploadFileView({
     rtcDataChannel.onerror = error => {
       console.error("RTC Data channel error:", error);
       notifications.error(m.mount_upload_failed_rtc({ error: error }));
-      setUploadState("idle");
+      failUpload(m.mount_upload_failed_rtc({ error: error }));
       console.log("Upload state set to 'idle'");
     };
   }
 
-  async function handleHttpUpload(file: File, alreadyUploadedBytes: number, dataChannel: string) {
-    const uploadUrl = `${DEVICE_API}/storage/upload?uploadId=${dataChannel}`;
+  function handleHttpUpload(
+    file: File,
+    alreadyUploadedBytes: number,
+    uploadId: string,
+    signal: AbortSignal,
+  ) {
+    const uploadUrl = `${DEVICE_API}/storage/upload?uploadId=${encodeURIComponent(uploadId)}`;
 
     const xhr = new XMLHttpRequest();
     xhr.open("POST", uploadUrl, true);
+    signal.addEventListener("abort", () => xhr.abort());
 
     let lastUploadedBytes = alreadyUploadedBytes;
     let lastUpdateTime = Date.now();
@@ -967,15 +1000,13 @@ function UploadFileView({
         setUploadState("success");
       } else {
         console.error("Upload error:", xhr.statusText);
-        setUploadError(xhr.statusText);
-        setUploadState("idle");
+        failUpload(xhr.statusText);
       }
     };
 
     xhr.onerror = () => {
       console.error("XHR error:", xhr.statusText);
-      setUploadError(xhr.statusText);
-      setUploadState("idle");
+      failUpload(xhr.statusText);
     };
 
     // Prepare the data to send
@@ -998,6 +1029,12 @@ function UploadFileView({
         return;
       }
 
+      // A previous attempt, if any, is abandoned here.
+      abortUpload();
+      const attempt = new AbortController();
+      attemptRef.current = attempt;
+      const { signal } = attempt;
+
       setFileError(null);
       console.log(`File selected: ${file.name}, size: ${file.size} bytes`);
       setUploadedFileName(file.name);
@@ -1005,32 +1042,50 @@ function UploadFileView({
       setUploadState("uploading");
       console.log("Upload state set to 'uploading'");
 
+      const startTimeout = window.setTimeout(() => {
+        if (signal.aborted) return;
+        failUpload("Timed out waiting to start the storage upload");
+      }, START_STORAGE_UPLOAD_TIMEOUT_MS);
+
       send(
         "startStorageFileUpload",
         { filename: file.name, size: file.size },
         (resp: JsonRpcResponse) => {
+          if (signal.aborted) return;
+          window.clearTimeout(startTimeout);
           console.log("startStorageFileUpload response:", resp);
           if ("error" in resp) {
             console.error("Upload error:", resp.error.message);
-            setUploadError(resp.error.data || resp.error.message);
-            setUploadState("idle");
+            failUpload(resp.error.data || resp.error.message);
             console.log("Upload state set to 'idle'");
             return;
           }
 
-          const { alreadyUploadedBytes, dataChannel } = resp.result as {
-            alreadyUploadedBytes: number;
-            dataChannel: string;
+          const { alreadyUploadedBytes, dataChannel } = (resp.result ?? {}) as {
+            alreadyUploadedBytes?: unknown;
+            dataChannel?: unknown;
           };
+          if (
+            typeof alreadyUploadedBytes !== "number" ||
+            !Number.isSafeInteger(alreadyUploadedBytes) ||
+            alreadyUploadedBytes < 0 ||
+            alreadyUploadedBytes > file.size ||
+            typeof dataChannel !== "string" ||
+            dataChannel.length === 0
+          ) {
+            console.error("Invalid startStorageFileUpload response:", resp.result);
+            failUpload("Invalid response from device");
+            return;
+          }
 
           console.log(
             `Already uploaded bytes: ${alreadyUploadedBytes}, Data channel: ${dataChannel}`,
           );
 
           if (isOnDevice) {
-            handleHttpUpload(file, alreadyUploadedBytes, dataChannel);
+            handleHttpUpload(file, alreadyUploadedBytes, dataChannel, signal);
           } else {
-            handleWebRTCUpload(file, alreadyUploadedBytes, dataChannel);
+            handleWebRTCUpload(file, alreadyUploadedBytes, dataChannel, signal);
           }
         },
       );
@@ -1188,6 +1243,7 @@ function UploadFileView({
               theme="light"
               text={m.mount_button_cancel_upload()}
               onClick={() => {
+                abortUpload();
                 onCancelUpload();
                 setUploadState("idle");
                 setUploadProgress(0);

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -679,12 +679,17 @@ func handleUploadChannel(d *webrtc.DataChannel) {
 		pendingUploadsMutex.Unlock()
 	}()
 	uploadComplete := make(chan struct{})
+	var finishOnce sync.Once
+	finish := func() { finishOnce.Do(func() { close(uploadComplete) }) }
+	// A client that cancels closes the channel. Without this the handler
+	// blocked forever, keeping the file open and the pending entry alive.
+	d.OnClose(finish)
 	lastProgressTime := time.Now()
 	d.OnMessage(func(msg webrtc.DataChannelMessage) {
 		bytesWritten, err := pendingUpload.File.Write(msg.Data)
 		if err != nil {
 			logger.Warn().Err(err).Str("uploadId", uploadId).Msg("failed to write to file")
-			close(uploadComplete)
+			finish()
 			return
 		}
 		totalBytesWritten += int64(bytesWritten)
@@ -692,7 +697,7 @@ func handleUploadChannel(d *webrtc.DataChannel) {
 		sendProgress := time.Since(lastProgressTime) >= 200*time.Millisecond
 		if totalBytesWritten >= pendingUpload.Size {
 			sendProgress = true
-			close(uploadComplete)
+			finish()
 		}
 
 		if sendProgress {

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -613,6 +613,24 @@ func rpcStartStorageFileUpload(filename string, size int64) (*StorageFileUpload,
 		return nil, fmt.Errorf("file already exists: %s", sanitizedFilename)
 	}
 
+	pendingUploadsMutex.Lock()
+	defer pendingUploadsMutex.Unlock()
+
+	// A retry after a cancel must not race the transfer it replaces. A data
+	// channel closes gracefully and still delivers what it had buffered, so
+	// the old handler could keep appending while the new one measures the
+	// partial file and appends too. Closing the old file ends that transfer.
+	for id, p := range pendingUploads {
+		if p.File.Name() != uploadPath {
+			continue
+		}
+		p.writeLock.Lock()
+		p.File.Close()
+		p.writeLock.Unlock()
+		delete(pendingUploads, id)
+		logger.Info().Str("uploadId", id).Msg("upload superseded by a new start for the same file")
+	}
+
 	var alreadyUploadedBytes int64 = 0
 	if stat, err := os.Stat(uploadPath); err == nil {
 		alreadyUploadedBytes = stat.Size()
@@ -623,13 +641,13 @@ func rpcStartStorageFileUpload(filename string, size int64) (*StorageFileUpload,
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file for upload: %v", err)
 	}
-	pendingUploadsMutex.Lock()
 	pendingUploads[uploadId] = pendingUpload{
 		File:                 file,
 		Size:                 size,
 		AlreadyUploadedBytes: alreadyUploadedBytes,
+		writeLock:            &sync.Mutex{},
 	}
-	pendingUploadsMutex.Unlock()
+	time.AfterFunc(uploadClaimTimeout, func() { expireUnclaimedUpload(uploadId) })
 	return &StorageFileUpload{
 		AlreadyUploadedBytes: alreadyUploadedBytes,
 		DataChannel:          uploadId,
@@ -640,10 +658,52 @@ type pendingUpload struct {
 	File                 *os.File
 	Size                 int64
 	AlreadyUploadedBytes int64
+	// writeLock serialises the transport's writes with a supersede from
+	// rpcStartStorageFileUpload, so nothing lands after the replacement
+	// measured the partial file.
+	writeLock *sync.Mutex
+	claimed   bool
 }
+
+// uploadClaimTimeout bounds how long a started upload waits for its
+// transport. The UI gives up on the start call after 30 s; an abort in that
+// window used to leave the file open and the entry in the map until reboot.
+const uploadClaimTimeout = 60 * time.Second
 
 var pendingUploads = make(map[string]pendingUpload)
 var pendingUploadsMutex sync.Mutex
+
+// claimPendingUpload hands the upload to its transport.
+func claimPendingUpload(uploadId string) (pendingUpload, bool) {
+	pendingUploadsMutex.Lock()
+	defer pendingUploadsMutex.Unlock()
+	p, ok := pendingUploads[uploadId]
+	if !ok {
+		return pendingUpload{}, false
+	}
+	p.claimed = true
+	pendingUploads[uploadId] = p
+	return p, true
+}
+
+// expireUnclaimedUpload releases an upload whose transport never arrived.
+func expireUnclaimedUpload(uploadId string) {
+	pendingUploadsMutex.Lock()
+	defer pendingUploadsMutex.Unlock()
+	p, ok := pendingUploads[uploadId]
+	if !ok || p.claimed {
+		return
+	}
+	p.File.Close()
+	delete(pendingUploads, uploadId)
+	logger.Warn().Str("uploadId", uploadId).Msg("upload transport never arrived, releasing the upload")
+}
+
+func (p pendingUpload) write(data []byte) (int, error) {
+	p.writeLock.Lock()
+	defer p.writeLock.Unlock()
+	return p.File.Write(data)
+}
 
 type UploadProgress struct {
 	Size                 int64
@@ -653,9 +713,7 @@ type UploadProgress struct {
 func handleUploadChannel(d *webrtc.DataChannel) {
 	defer d.Close()
 	uploadId := d.Label()
-	pendingUploadsMutex.Lock()
-	pendingUpload, ok := pendingUploads[uploadId]
-	pendingUploadsMutex.Unlock()
+	pendingUpload, ok := claimPendingUpload(uploadId)
 	if !ok {
 		logger.Warn().Str("uploadId", uploadId).Msg("upload channel opened for unknown upload")
 		return
@@ -686,7 +744,7 @@ func handleUploadChannel(d *webrtc.DataChannel) {
 	d.OnClose(finish)
 	lastProgressTime := time.Now()
 	d.OnMessage(func(msg webrtc.DataChannelMessage) {
-		bytesWritten, err := pendingUpload.File.Write(msg.Data)
+		bytesWritten, err := pendingUpload.write(msg.Data)
 		if err != nil {
 			logger.Warn().Err(err).Str("uploadId", uploadId).Msg("failed to write to file")
 			finish()
@@ -724,9 +782,7 @@ func handleUploadChannel(d *webrtc.DataChannel) {
 
 func handleUploadHttp(c *gin.Context) {
 	uploadId := c.Query("uploadId")
-	pendingUploadsMutex.Lock()
-	pendingUpload, ok := pendingUploads[uploadId]
-	pendingUploadsMutex.Unlock()
+	pendingUpload, ok := claimPendingUpload(uploadId)
 	if !ok {
 		c.JSON(http.StatusNotFound, gin.H{"error": "Upload not found"})
 		return
@@ -762,7 +818,7 @@ func handleUploadHttp(c *gin.Context) {
 		}
 
 		if n > 0 {
-			bytesWritten, err := pendingUpload.File.Write(buffer[:n])
+			bytesWritten, err := pendingUpload.write(buffer[:n])
 			if err != nil {
 				logger.Warn().Err(err).Str("uploadId", uploadId).Msg("failed to write to file")
 				c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to write upload data"})

--- a/usb_mass_storage.go
+++ b/usb_mass_storage.go
@@ -609,12 +609,14 @@ func rpcStartStorageFileUpload(filename string, size int64) (*StorageFileUpload,
 	filePath := path.Join(imagesFolder, sanitizedFilename)
 	uploadPath := filePath + ".incomplete"
 
+	// Held from the exists check through the open: finishUpload renames
+	// under the same lock, so the partial file cannot change in between.
+	pendingUploadsMutex.Lock()
+	defer pendingUploadsMutex.Unlock()
+
 	if _, err := os.Stat(filePath); err == nil {
 		return nil, fmt.Errorf("file already exists: %s", sanitizedFilename)
 	}
-
-	pendingUploadsMutex.Lock()
-	defer pendingUploadsMutex.Unlock()
 
 	// A retry after a cancel must not race the transfer it replaces. A data
 	// channel closes gracefully and still delivers what it had buffered, so
@@ -699,6 +701,33 @@ func expireUnclaimedUpload(uploadId string) {
 	logger.Warn().Str("uploadId", uploadId).Msg("upload transport never arrived, releasing the upload")
 }
 
+// finishUpload closes the upload and, when every byte arrived, renames the
+// file into place. It runs under the map lock so that a start for the same
+// file cannot measure the partial file while the rename is in flight, and
+// a superseded upload never renames over its replacement.
+func finishUpload(uploadId string, p pendingUpload, written int64) {
+	pendingUploadsMutex.Lock()
+	defer pendingUploadsMutex.Unlock()
+
+	p.File.Close()
+	if _, live := pendingUploads[uploadId]; !live {
+		logger.Info().Str("uploadId", uploadId).Msg("upload was superseded, leaving the file to its replacement")
+		return
+	}
+	delete(pendingUploads, uploadId)
+
+	if written != p.Size {
+		logger.Warn().Str("uploadId", uploadId).Msg("uploaded ended before the complete file received")
+		return
+	}
+	newName := strings.TrimSuffix(p.File.Name(), ".incomplete")
+	if err := os.Rename(p.File.Name(), newName); err != nil {
+		logger.Warn().Err(err).Str("uploadId", uploadId).Msg("failed to rename uploaded file")
+	} else {
+		logger.Debug().Str("uploadId", uploadId).Str("newName", newName).Msg("successfully renamed uploaded file")
+	}
+}
+
 func (p pendingUpload) write(data []byte) (int, error) {
 	p.writeLock.Lock()
 	defer p.writeLock.Unlock()
@@ -719,23 +748,7 @@ func handleUploadChannel(d *webrtc.DataChannel) {
 		return
 	}
 	totalBytesWritten := pendingUpload.AlreadyUploadedBytes
-	defer func() {
-		pendingUpload.File.Close()
-		if totalBytesWritten == pendingUpload.Size {
-			newName := strings.TrimSuffix(pendingUpload.File.Name(), ".incomplete")
-			err := os.Rename(pendingUpload.File.Name(), newName)
-			if err != nil {
-				logger.Warn().Err(err).Str("uploadId", uploadId).Msg("failed to rename uploaded file")
-			} else {
-				logger.Debug().Str("uploadId", uploadId).Str("newName", newName).Msg("successfully renamed uploaded file")
-			}
-		} else {
-			logger.Warn().Str("uploadId", uploadId).Msg("uploaded ended before the complete file received")
-		}
-		pendingUploadsMutex.Lock()
-		delete(pendingUploads, uploadId)
-		pendingUploadsMutex.Unlock()
-	}()
+	defer func() { finishUpload(uploadId, pendingUpload, totalBytesWritten) }()
 	uploadComplete := make(chan struct{})
 	var finishOnce sync.Once
 	finish := func() { finishOnce.Do(func() { close(uploadComplete) }) }
@@ -789,23 +802,7 @@ func handleUploadHttp(c *gin.Context) {
 	}
 
 	totalBytesWritten := pendingUpload.AlreadyUploadedBytes
-	defer func() {
-		pendingUpload.File.Close()
-		if totalBytesWritten == pendingUpload.Size {
-			newName := strings.TrimSuffix(pendingUpload.File.Name(), ".incomplete")
-			err := os.Rename(pendingUpload.File.Name(), newName)
-			if err != nil {
-				logger.Warn().Err(err).Str("uploadId", uploadId).Msg("failed to rename uploaded file")
-			} else {
-				logger.Debug().Str("uploadId", uploadId).Str("newName", newName).Msg("successfully renamed uploaded file")
-			}
-		} else {
-			logger.Warn().Str("uploadId", uploadId).Msg("uploaded ended before the complete file received")
-		}
-		pendingUploadsMutex.Lock()
-		delete(pendingUploads, uploadId)
-		pendingUploadsMutex.Unlock()
-	}()
+	defer func() { finishUpload(uploadId, pendingUpload, totalBytesWritten) }()
 
 	reader := c.Request.Body
 	buffer := make([]byte, 32*1024)


### PR DESCRIPTION
An upload in progress kept running after Cancel, after picking another file, or after leaving the mount view, and its handlers kept writing progress into the next attempt's state. Only the WebRTC channel was closed, and only on unmount. The on-device XHR was never aborted.

Each attempt now gets an `AbortController`:

- Cancel, reselect and unmount abort it.
- The transport registers its own teardown on the signal: `xhr.abort()` on device, detach handlers and close the data channel in the cloud.
- Late callbacks return when the signal is aborted.

Also:

- `uploadId` is URL-encoded.
- `startStorageFileUpload` times out after 30 s.
- `alreadyUploadedBytes` and `dataChannel` are validated before use.

Transfer logic, chunk size, water marks and speed calculation are unchanged. +87 −31, one file.

## Device side

A data channel closes gracefully and still delivers what it had
buffered, so a retry right after Cancel could leave two handlers
appending to the same file. `startStorageFileUpload` now ends any
pending upload for the same file before it measures the partial file.
An upload whose transport never arrives, for example after the 30 s
start timeout, is released after 60 s instead of holding the file open
until reboot.

E2E: two starts for the same file, then data for the first id is
rejected and the second completes byte-identical. Fails on the previous
build. The cancel-and-resume test still passes.

An upload finishes under the same lock, and only if it is still
registered, so a start for the same file can neither measure the
partial file while the rename is in flight nor be renamed over by the
upload it replaced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches concurrent file writes and upload session lifecycle on device storage; incorrect supersede/finish logic could corrupt partial images or leak handles, though changes are narrowly scoped to upload paths.
> 
> **Overview**
> Fixes storage image uploads that **kept streaming after Cancel**, file reselect, or leaving the mount view, and could corrupt resume by writing into the next attempt’s UI state.
> 
> The mount **upload UI** now tracks one **`AbortController` per attempt**: Cancel, a new file, and unmount all abort the active transport (**`xhr.abort()`** on-device, WebRTC channel teardown in the cloud), with late callbacks bailing on **`signal.aborted`**. Adds a **30s** start timeout, **`uploadId` URL encoding**, and validation of **`startStorageFileUpload`** fields before starting HTTP/WebRTC.
> 
> On the **device**, **`startStorageFileUpload`** **supersedes** any pending upload for the same `.incomplete` file (close + drop from map), serializes writes with a **per-upload mutex**, and centralizes teardown in **`claimPendingUpload` / `finishUpload`**. WebRTC handlers **exit on channel close** (cancel no longer blocks forever); unclaimed uploads **expire after 60s**. Superseded or incomplete transfers no longer rename into the final image.
> 
> **E2E** adds throttled cancel-and-resume (partial size must stop growing, retry is byte-identical) and a supersede test (stale **`uploadId`** → **404**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc00f74e22c88dbc01edc00d838e474556027dcc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Device side

The WebRTC upload handler blocked until completion or a write error,
so a client that cancelled by closing the channel left it stuck with
the file open until reboot. It now finishes on channel close too.

## Test

New e2e: throttle an upload, cancel it mid-way, and require the partial
file on the device to stop growing, then upload the same file again and
require a byte-identical result. On `dev` the partial keeps growing
after Cancel. Runs in about 14 s.


