### PR TITLE
fix(ui): let Button pass aria-label through to the element

### DIFF
--- a/ui/src/components/Button.tsx
+++ b/ui/src/components/Button.tsx
@@ -161,6 +161,7 @@ type ButtonPropsType = Pick<
   | "onMouseLeave"
   | "onMouseDown"
   | "onMouseUp"
+  | "aria-label"
   | "data-testid"
 > &
   React.ComponentProps<typeof ButtonContent> & {
@@ -190,6 +191,7 @@ export const Button = React.forwardRef<HTMLButtonElement, ButtonPropsType>(
         onMouseLeave={props?.onMouseLeave}
         name={props.name}
         value={props.value}
+        aria-label={props["aria-label"]}
         data-testid={props["data-testid"]}
       >
         <ButtonContent


### PR DESCRIPTION
Icon-only buttons had no accessible name because the `Button` wrapper did not forward `aria-label`. Add it to the accepted props and the rendered `<button>`, so screen readers and role-based test selectors can name them.

Two lines, no behaviour change for existing callers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow accessibility prop forwarding with no changes to click, submit, or styling behavior.
> 
> **Overview**
> **Icon-only and unlabeled `Button` instances can now expose an accessible name** by passing `aria-label`, which previously did not reach the DOM because the wrapper only whitelisted a subset of native button attributes.
> 
> The change adds `aria-label` to `ButtonPropsType` and sets `aria-label={props["aria-label"]}` on the rendered `<button>`, matching how `data-testid` and other passthrough props already work. Callers that do not pass `aria-label` are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 832a0759cd6282e4ef178acbac766ca77a1adeb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->