### PR TITLE
refactor(ui): extract the cloud UI bundle version selection

### DIFF
--- a/ui/src/cloudVersion.ts
+++ b/ui/src/cloudVersion.ts
@@ -1,0 +1,17 @@
+import semver from "semver";
+
+/**
+ * Select the versioned cloud UI bundle for a device. Devices at or above the
+ * compatibility floor get the bundle built for their own version; anything
+ * older, unparseable or unknown gets the floor bundle.
+ */
+export function selectCloudUiVersion(
+  appVersion: string | undefined,
+  backwardsCompatibleVersion: string,
+): string {
+  return appVersion &&
+    semver.valid(appVersion) &&
+    semver.gte(appVersion, backwardsCompatibleVersion)
+    ? appVersion
+    : backwardsCompatibleVersion;
+}

--- a/ui/src/utils.ts
+++ b/ui/src/utils.ts
@@ -1,9 +1,8 @@
-import semver from "semver";
-
 import { KeySequence } from "@hooks/stores";
 import { getLocale, locales, type LocalizedString } from "@localizations/runtime.js";
 import { m } from "@localizations/messages.js";
 import { CLOUD_BACKWARDS_COMPATIBLE_VERSION, CLOUD_ENABLE_VERSIONED_UI } from "@/ui.config";
+import { selectCloudUiVersion } from "@/cloudVersion";
 
 const isInvalidDate = (date: Date) => date instanceof Date && isNaN(date.getTime());
 
@@ -257,9 +256,11 @@ export function isChromeOS() {
  * "Loading video stream..." screen. See jetkvm/kvm#1413.
  */
 export function isLinuxDesktop() {
-  const uaData = (navigator as Navigator & {
-    userAgentData?: { platform?: string };
-  }).userAgentData;
+  const uaData = (
+    navigator as Navigator & {
+      userAgentData?: { platform?: string };
+    }
+  ).userAgentData;
 
   if (uaData?.platform) return uaData.platform === "Linux";
 
@@ -335,12 +336,7 @@ export function sleep(ms: number): Promise<void> {
 export function buildCloudUrl(deviceId: string, appVersion: string | undefined, path = ""): string {
   let uri = `/devices/${deviceId}${path}`;
   if (CLOUD_ENABLE_VERSIONED_UI) {
-    const version =
-      appVersion &&
-      semver.valid(appVersion) &&
-      semver.gte(appVersion, CLOUD_BACKWARDS_COMPATIBLE_VERSION)
-        ? appVersion
-        : CLOUD_BACKWARDS_COMPATIBLE_VERSION;
+    const version = selectCloudUiVersion(appVersion, CLOUD_BACKWARDS_COMPATIBLE_VERSION);
     uri = `/v/${version}${uri}`;
   }
   return new URL(uri, window.location.origin).href;


### PR DESCRIPTION
`buildCloudUrl()` inlined the rule that picks which versioned UI bundle a device gets. Move it to `selectCloudUiVersion()` in `src/cloudVersion.ts`, a pure function that can be tested and reused. The `semver` import leaves `utils.ts`.

No change in behaviour.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure refactor of URL version selection with the same semver rules; only affects versioned cloud UI paths when that feature flag is enabled.
> 
> **Overview**
> Moves the semver rule that picks which versioned cloud UI bundle a device loads out of `buildCloudUrl()` into a new **`selectCloudUiVersion()`** in `cloudVersion.ts`. Valid app versions at or above the compatibility floor still map to `/v/{appVersion}/...`; older, missing, or invalid versions still use the floor version.
> 
> `utils.ts` now calls that helper when `CLOUD_ENABLE_VERSIONED_UI` is on and drops its direct `semver` dependency. **No intended runtime behavior change** for cloud links (e.g. `KvmCard`, `VideoOverlay`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79395105bf06d34a21b2f817d2a7ceca7f27841d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->