### PR TITLE
fix(usbgadget): stop the mass storage oops and avoid needless USB rebinds

### DIFF
--- a/internal/usbgadget/audio.go
+++ b/internal/usbgadget/audio.go
@@ -6,7 +6,7 @@ var audioConfig = gadgetConfigItem{
 	path:       []string{"functions", "uac1.usb0"},
 	configPath: []string{"uac1.usb0"},
 	attrs: gadgetAttributes{
-		"c_chmask": "0x3",
+		"c_chmask": "3",
 		"c_srate":  "48000",
 		"c_ssize":  "2",
 		"p_chmask": "0",

--- a/internal/usbgadget/changeset_symlink.go
+++ b/internal/usbgadget/changeset_symlink.go
@@ -6,6 +6,7 @@ import (
 	"path"
 	"path/filepath"
 	"reflect"
+	"slices"
 
 	"github.com/rs/zerolog"
 )
@@ -48,11 +49,23 @@ func checkIfSymlinksInOrder(fc *FileChange, logger *zerolog.Logger) (FileState, 
 		return FileStateUnknown, fmt.Errorf("file is not a directory")
 	}
 
-	files, err := os.ReadDir(fc.Path)
-	symlinks := make([]symlink, 0)
+	// The gadget binds functions in symlink creation order, which is what
+	// the host sees as the interface order. configfs returns directory
+	// entries newest first (fs/configfs/dir.c keeps s_children as a LIFO
+	// list), so read the raw directory order and reverse it. os.ReadDir
+	// sorts by name and would hide the creation order.
+	dir, err := os.Open(fc.Path)
+	if err != nil {
+		return FileStateUnknown, fmt.Errorf("failed to open directory")
+	}
+	files, err := dir.ReadDir(-1)
+	dir.Close()
 	if err != nil {
 		return FileStateUnknown, fmt.Errorf("failed to read directory")
 	}
+	slices.Reverse(files)
+
+	symlinks := make([]symlink, 0)
 
 	for _, file := range files {
 		if file.Type()&os.ModeSymlink != os.ModeSymlink {

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -212,21 +212,44 @@ func (u *UsbGadget) UpdateGadgetConfig() error {
 }
 
 func (u *UsbGadget) configureUsbGadget(resetUsb bool) error {
-	if resetUsb {
-		_ = softDisconnect(u.udc)
-	}
-
+	disconnected := false
 	err := u.WithTransaction(func() error {
 		u.tx.MountConfigFS()
 		u.tx.CreateConfigPath()
 		u.tx.WriteGadgetConfig()
-		if resetUsb {
-			u.tx.RebindUsb(true)
+		if !resetUsb {
+			return nil
 		}
+
+		pending, err := u.tx.HasPendingChanges()
+		if err != nil {
+			return err
+		}
+		if !pending && u.isGadgetLive() {
+			// The configfs tree already matches and the gadget is bound and
+			// attached. Leave the host session alone: every disconnect races
+			// the mass storage function's kernel thread (#1360), so only pay
+			// for it when the configuration actually changes.
+			u.log.Info().Msg("USB gadget already configured and attached, skipping rebind")
+			return nil
+		}
+
+		// Quiesce the host session before the controller teardown so function
+		// drivers shut their endpoints down against a live controller.
+		_ = softDisconnect(u.udc)
+		disconnected = true
+		u.tx.RebindUsb(true)
 		return nil
 	})
-	if err != nil && resetUsb {
+	if err != nil && disconnected {
 		_ = softConnect(u.udc)
 	}
 	return err
+}
+
+// isGadgetLive reports whether the UDC driver is bound and the gadget is
+// attached to it, i.e. the host can see the device as currently configured.
+func (u *UsbGadget) isGadgetLive() bool {
+	bound, err := u.IsUDCBound()
+	return err == nil && bound && u.IsGadgetAttachedToUDC()
 }

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -197,10 +197,6 @@ func (u *UsbGadget) Init() error {
 	}
 	if adopted {
 		u.adoptLiveGadget()
-	} else {
-		// The host re-enumerated, which released every input and will resend
-		// its LED state, so nothing from the previous instance applies.
-		updateHidHandover(func(h *hidHandover) { *h = hidHandover{} })
 	}
 
 	return nil
@@ -264,12 +260,18 @@ func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) (bool, e
 	if err != nil && disconnected {
 		_ = softConnect(u.udc)
 	}
+	if err == nil && disconnected {
+		u.resetHidHandover()
+	}
 	return adopted && err == nil, err
 }
 
-// isGadgetLive reports whether the UDC driver is bound and the gadget is
-// attached to it, i.e. the host can see the device as currently configured.
+// isGadgetLive reports whether the host can see the device as currently
+// configured: the UDC driver is bound, the gadget is attached to it and the
+// pull-up is on. The last check matters for a process that died between its
+// soft disconnect and the rebind: the first two still hold, but the host
+// sees nothing until something reconnects.
 func (u *UsbGadget) isGadgetLive() bool {
 	bound, err := u.IsUDCBound()
-	return err == nil && bound && u.IsGadgetAttachedToUDC()
+	return err == nil && bound && u.IsGadgetAttachedToUDC() && isPullupEnabled(u.udc)
 }

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -240,8 +240,11 @@ func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) error {
 			}
 		}
 
-		// Quiesce the host session before the controller teardown so function
-		// drivers shut their endpoints down against a live controller.
+		// Close HID descriptors before the unbind for the same reason as in
+		// rebindUsb, then quiesce the host session before the controller
+		// teardown so function drivers shut their endpoints down against a
+		// live controller.
+		u.ResetHIDFiles()
 		_ = softDisconnect(u.udc)
 		disconnected = true
 		u.tx.RebindUsb(true)

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -189,7 +189,9 @@ func (u *UsbGadget) Init() error {
 
 	u.syncMassStorageImageFromKernel()
 
-	err := u.configureUsbGadget(true)
+	// A restarted process inherits the previous instance's gadget. Leave it
+	// alone when it already matches, instead of dropping the host session.
+	err := u.configureUsbGadget(true, false)
 	if err != nil {
 		return u.logError("unable to initialize USB stack", err)
 	}
@@ -203,7 +205,9 @@ func (u *UsbGadget) UpdateGadgetConfig() error {
 
 	u.loadGadgetConfig()
 
-	err := u.configureUsbGadget(true)
+	// Callers ask for this on config changes and as the recovery fallback,
+	// so always rebind here even if the configfs tree looks untouched.
+	err := u.configureUsbGadget(true, true)
 	if err != nil {
 		return u.logError("unable to update gadget config", err)
 	}
@@ -211,7 +215,7 @@ func (u *UsbGadget) UpdateGadgetConfig() error {
 	return nil
 }
 
-func (u *UsbGadget) configureUsbGadget(resetUsb bool) error {
+func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) error {
 	disconnected := false
 	err := u.WithTransaction(func() error {
 		u.tx.MountConfigFS()
@@ -221,17 +225,19 @@ func (u *UsbGadget) configureUsbGadget(resetUsb bool) error {
 			return nil
 		}
 
-		pending, err := u.tx.HasPendingChanges()
-		if err != nil {
-			return err
-		}
-		if !pending && u.isGadgetLive() {
-			// The configfs tree already matches and the gadget is bound and
-			// attached. Leave the host session alone: every disconnect races
-			// the mass storage function's kernel thread (#1360), so only pay
-			// for it when the configuration actually changes.
-			u.log.Info().Msg("USB gadget already configured and attached, skipping rebind")
-			return nil
+		if !forceRebind {
+			pending, err := u.tx.HasPendingChanges()
+			if err != nil {
+				return err
+			}
+			if !pending && u.isGadgetLive() {
+				// The configfs tree already matches and the gadget is bound and
+				// attached. Leave the host session alone: every disconnect races
+				// the mass storage function's kernel thread (#1360), so only pay
+				// for it when the configuration actually changes.
+				u.log.Info().Msg("USB gadget already configured and attached, skipping rebind")
+				return nil
+			}
 		}
 
 		// Quiesce the host session before the controller teardown so function

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -191,9 +191,16 @@ func (u *UsbGadget) Init() error {
 
 	// A restarted process inherits the previous instance's gadget. Leave it
 	// alone when it already matches, instead of dropping the host session.
-	err := u.configureUsbGadget(true, false)
+	adopted, err := u.configureUsbGadget(true, false)
 	if err != nil {
 		return u.logError("unable to initialize USB stack", err)
+	}
+	if adopted {
+		u.adoptLiveGadget()
+	} else {
+		// The host re-enumerated, which released every input and will resend
+		// its LED state, so nothing from the previous instance applies.
+		updateHidHandover(func(h *hidHandover) { *h = hidHandover{} })
 	}
 
 	return nil
@@ -207,7 +214,7 @@ func (u *UsbGadget) UpdateGadgetConfig() error {
 
 	// Callers ask for this on config changes and as the recovery fallback,
 	// so always rebind here even if the configfs tree looks untouched.
-	err := u.configureUsbGadget(true, true)
+	_, err := u.configureUsbGadget(true, true)
 	if err != nil {
 		return u.logError("unable to update gadget config", err)
 	}
@@ -215,8 +222,11 @@ func (u *UsbGadget) UpdateGadgetConfig() error {
 	return nil
 }
 
-func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) error {
+// configureUsbGadget reports whether it left an already matching, attached
+// gadget bound instead of rebinding it.
+func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) (bool, error) {
 	disconnected := false
+	adopted := false
 	err := u.WithTransaction(func() error {
 		u.tx.MountConfigFS()
 		u.tx.CreateConfigPath()
@@ -236,6 +246,7 @@ func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) error {
 				// the mass storage function's kernel thread (#1360), so only pay
 				// for it when the configuration actually changes.
 				u.log.Info().Msg("USB gadget already configured and attached, skipping rebind")
+				adopted = true
 				return nil
 			}
 		}
@@ -253,7 +264,7 @@ func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) error {
 	if err != nil && disconnected {
 		_ = softConnect(u.udc)
 	}
-	return err
+	return adopted && err == nil, err
 }
 
 // isGadgetLive reports whether the UDC driver is bound and the gadget is

--- a/internal/usbgadget/config.go
+++ b/internal/usbgadget/config.go
@@ -260,7 +260,8 @@ func (u *UsbGadget) configureUsbGadget(resetUsb bool, forceRebind bool) (bool, e
 	if err != nil && disconnected {
 		_ = softConnect(u.udc)
 	}
-	if err == nil && disconnected {
+	// Either the rebind or the reconnect above re-enumerated the host.
+	if disconnected {
 		u.resetHidHandover()
 	}
 	return adopted && err == nil, err

--- a/internal/usbgadget/config_pending_test.go
+++ b/internal/usbgadget/config_pending_test.go
@@ -1,0 +1,43 @@
+package usbgadget
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// wakeup_on_write is optional in the kernel. Where it is missing the staged
+// write can never succeed and Commit ignores the failure, so it must not count
+// as a pending change or every start would rebind on such kernels.
+func TestHasPendingChangesIgnoresMissingOptionalAttribute(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "protocol"), []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	stage := func() *UsbGadgetTransaction {
+		tx := &UsbGadgetTransaction{c: &ChangeSet{}, log: defaultLogger}
+		tx.writeGadgetAttrs(dir, gadgetAttributes{"protocol": "1", "wakeup_on_write": "0"}, "keyboard", nil)
+		return tx
+	}
+
+	pending, err := stage().HasPendingChanges()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pending {
+		t.Fatal("a missing optional attribute was reported as a pending change")
+	}
+
+	// Present with another value it is a real change.
+	if err := os.WriteFile(filepath.Join(dir, "wakeup_on_write"), []byte("1"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	pending, err = stage().HasPendingChanges()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !pending {
+		t.Fatal("an optional attribute with the wrong value was not reported as pending")
+	}
+}

--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -119,9 +119,16 @@ func (tx *UsbGadgetTransaction) HasPendingChanges() (bool, error) {
 		return false, err
 	}
 	for _, change := range resolved {
-		if change.Action() != FileChangeResolvedActionDoNothing {
-			return true, nil
+		action := change.Action()
+		if action == FileChangeResolvedActionDoNothing {
+			continue
 		}
+		// An optional attribute the kernel does not expose cannot be
+		// created; Commit ignores that failure, so it is not a change.
+		if change.IgnoreErrors && action == FileChangeResolvedActionCreateFile {
+			continue
+		}
+		return true, nil
 	}
 	return false, nil
 }

--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -64,14 +64,15 @@ func (u *UsbGadget) WithTransaction(fn func() error) error {
 		u.log.Error().Err(err).Msg("failed to create transaction")
 		return err
 	}
+	// Clear the transaction on every exit, or a callback error would leave
+	// it behind and every later WithTransaction would fail to start one.
+	defer func() { u.tx = nil }()
+
 	if err := fn(); err != nil {
 		u.log.Error().Err(err).Msg("transaction failed")
 		return err
 	}
-	result := u.tx.Commit()
-	u.tx = nil
-
-	return result
+	return u.tx.Commit()
 }
 
 func (tx *UsbGadgetTransaction) addFileChange(component string, change RequestedFileChange) string {

--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"path"
 	"path/filepath"
+	"slices"
 	"sort"
 
 	"github.com/rs/zerolog"
+	"github.com/sourcegraph/tf-dag/dag"
 )
 
 // no os package should occur in this file
@@ -98,6 +100,29 @@ func (tx *UsbGadgetTransaction) removeFile(component string, path string, descri
 		ExpectedState: FileStateAbsent,
 		Description:   description,
 	})
+}
+
+// HasPendingChanges resolves the staged changes, including the symlink
+// reorder that Commit appends, without applying anything, and reports whether
+// any of them would touch the configfs tree.
+func (tx *UsbGadgetTransaction) HasPendingChanges() (bool, error) {
+	staged := slices.Clone(tx.c.Changes)
+	if tx.reorderSymlinkChanges != nil {
+		finalize := *tx.reorderSymlinkChanges
+		finalize.Component = "gadget-finalize"
+		staged = append(staged, FileChange{RequestedFileChange: finalize})
+	}
+	r := ChangeSetResolver{changeset: &ChangeSet{Changes: staged}, g: &dag.AcyclicGraph{}, l: tx.log}
+	resolved, err := r.GetChanges()
+	if err != nil {
+		return false, err
+	}
+	for _, change := range resolved {
+		if change.Action() != FileChangeResolvedActionDoNothing {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
 func (tx *UsbGadgetTransaction) Commit() error {

--- a/internal/usbgadget/config_tx_test.go
+++ b/internal/usbgadget/config_tx_test.go
@@ -1,6 +1,27 @@
 package usbgadget
 
-import "testing"
+import (
+	"errors"
+	"testing"
+)
+
+func TestWithTransactionClearsFailedTransaction(t *testing.T) {
+	u := NewUsbGadget("test", &Devices{}, &Config{}, nil)
+
+	want := errors.New("callback failed")
+	if err := u.WithTransaction(func() error { return want }); !errors.Is(err, want) {
+		t.Fatalf("first transaction: got %v, want %v", err, want)
+	}
+	if u.tx != nil {
+		t.Fatal("failed transaction was left behind")
+	}
+
+	// A second transaction must start; before the fix it failed with
+	// "transaction already exists".
+	if err := u.WithTransaction(func() error { return want }); !errors.Is(err, want) {
+		t.Fatalf("second transaction: got %v, want %v", err, want)
+	}
+}
 
 // With every device class disabled WriteGadgetConfig stages no function and
 // leaves reorderSymlinkChanges nil. Commit used to dereference it (#1541).

--- a/internal/usbgadget/hid_handover.go
+++ b/internal/usbgadget/hid_handover.go
@@ -1,0 +1,81 @@
+package usbgadget
+
+import (
+	"encoding/json"
+	"os"
+	"sync"
+)
+
+// hidHandoverPath lives on tmpfs. A reboot clears it, and a reboot
+// re-enumerates the gadget anyway, so nothing needs to survive one.
+const hidHandoverPath = "/tmp/jetkvm-hid-handover.json"
+
+// hidHandover is what a restarted process needs when it adopts the previous
+// instance's gadget instead of re-enumerating it: the host's last LED report,
+// which the host will not resend, and an absolute mouse press that never got
+// its release.
+type hidHandover struct {
+	KeyboardLeds byte `json:"keyboard_leds"`
+	AbsPressed   bool `json:"abs_pressed"`
+	AbsX         int  `json:"abs_x"`
+	AbsY         int  `json:"abs_y"`
+}
+
+var hidHandoverLock sync.Mutex
+
+func updateHidHandover(fn func(h *hidHandover)) {
+	hidHandoverLock.Lock()
+	defer hidHandoverLock.Unlock()
+
+	h, _ := readHidHandover()
+	fn(&h)
+	data, err := json.Marshal(h)
+	if err != nil {
+		return
+	}
+	tmp := hidHandoverPath + ".tmp"
+	if err := os.WriteFile(tmp, data, 0600); err != nil {
+		return
+	}
+	_ = os.Rename(tmp, hidHandoverPath)
+}
+
+func readHidHandover() (hidHandover, bool) {
+	var h hidHandover
+	data, err := os.ReadFile(hidHandoverPath)
+	if err != nil {
+		return h, false
+	}
+	if err := json.Unmarshal(data, &h); err != nil {
+		return hidHandover{}, false
+	}
+	return h, true
+}
+
+func loadHidHandover() (hidHandover, bool) {
+	hidHandoverLock.Lock()
+	defer hidHandoverLock.Unlock()
+	return readHidHandover()
+}
+
+// adoptLiveGadget runs when Init kept the previous instance's gadget bound.
+// The host saw no disconnect, so it still holds whatever inputs the previous
+// process left pressed, and it will not resend its LED state.
+func (u *UsbGadget) adoptLiveGadget() {
+	h, ok := loadHidHandover()
+	if ok {
+		u.updateKeyboardState(h.KeyboardLeds)
+	}
+
+	if err := u.KeyboardReport(0, make([]byte, hidKeyBufferSize)); err != nil {
+		u.log.Warn().Err(err).Msg("failed to release inherited keyboard state")
+	}
+	if err := u.RelMouseReport(0, 0, 0); err != nil {
+		u.log.Warn().Err(err).Msg("failed to release inherited relative mouse buttons")
+	}
+	if ok && h.AbsPressed {
+		if err := u.AbsMouseReport(h.AbsX, h.AbsY, 0); err != nil {
+			u.log.Warn().Err(err).Msg("failed to release inherited absolute mouse buttons")
+		}
+	}
+}

--- a/internal/usbgadget/hid_handover.go
+++ b/internal/usbgadget/hid_handover.go
@@ -58,6 +58,16 @@ func loadHidHandover() (hidHandover, bool) {
 	return readHidHandover()
 }
 
+// resetHidHandover runs after a rebind. The host re-enumerated, which
+// released every input and makes it resend its LED state, so nothing from
+// before the rebind applies to the next adoption.
+func (u *UsbGadget) resetHidHandover() {
+	u.absMouseLock.Lock()
+	u.absMousePressed = false
+	u.absMouseLock.Unlock()
+	updateHidHandover(func(h *hidHandover) { *h = hidHandover{} })
+}
+
 // adoptLiveGadget runs when Init kept the previous instance's gadget bound.
 // The host saw no disconnect, so it still holds whatever inputs the previous
 // process left pressed, and it will not resend its LED state.

--- a/internal/usbgadget/hid_handover.go
+++ b/internal/usbgadget/hid_handover.go
@@ -74,6 +74,14 @@ func (u *UsbGadget) adoptLiveGadget() {
 		u.log.Warn().Err(err).Msg("failed to release inherited relative mouse buttons")
 	}
 	if ok && h.AbsPressed {
+		// Seed the press state so the release below is a real edge and clears
+		// the handover entry; otherwise the next adoption would replay it.
+		// The position is where the button went down: a drag in progress at
+		// the restart snaps back there, which keeps the hot path free of a
+		// file write per mouse move.
+		u.absMouseLock.Lock()
+		u.absMousePressed = true
+		u.absMouseLock.Unlock()
 		if err := u.AbsMouseReport(h.AbsX, h.AbsY, 0); err != nil {
 			u.log.Warn().Err(err).Msg("failed to release inherited absolute mouse buttons")
 		}

--- a/internal/usbgadget/hid_handover.go
+++ b/internal/usbgadget/hid_handover.go
@@ -62,9 +62,11 @@ func loadHidHandover() (hidHandover, bool) {
 // released every input and makes it resend its LED state, so nothing from
 // before the rebind applies to the next adoption.
 func (u *UsbGadget) resetHidHandover() {
+	// Hold the mouse lock through the write, or a press reported in between
+	// would be persisted and then overwritten.
 	u.absMouseLock.Lock()
+	defer u.absMouseLock.Unlock()
 	u.absMousePressed = false
-	u.absMouseLock.Unlock()
 	updateHidHandover(func(h *hidHandover) { *h = hidHandover{} })
 }
 

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -157,6 +157,7 @@ func (u *UsbGadget) updateKeyboardState(state byte) {
 	}
 	u.log.Trace().Uint8("old", u.keyboardState).Uint8("new", state).Msg("keyboardState updated")
 	u.keyboardState = state
+	updateHidHandover(func(h *hidHandover) { h.KeyboardLeds = state })
 
 	if u.onKeyboardStateChange != nil {
 		(*u.onKeyboardStateChange)(getKeyboardState(state))

--- a/internal/usbgadget/hid_keyboard.go
+++ b/internal/usbgadget/hid_keyboard.go
@@ -152,12 +152,16 @@ func (u *UsbGadget) updateKeyboardState(state byte) {
 		return
 	}
 
+	// Persist every report, unchanged ones included: a rebind resets the
+	// handover, and the host's report after re-enumeration usually repeats
+	// the state the process already holds.
+	updateHidHandover(func(h *hidHandover) { h.KeyboardLeds = state })
+
 	if u.keyboardState == state {
 		return
 	}
 	u.log.Trace().Uint8("old", u.keyboardState).Uint8("new", state).Msg("keyboardState updated")
 	u.keyboardState = state
-	updateHidHandover(func(h *hidHandover) { h.KeyboardLeds = state })
 
 	if u.onKeyboardStateChange != nil {
 		(*u.onKeyboardStateChange)(getKeyboardState(state))

--- a/internal/usbgadget/hid_mouse_absolute.go
+++ b/internal/usbgadget/hid_mouse_absolute.go
@@ -117,6 +117,13 @@ func (u *UsbGadget) AbsMouseReport(x int, y int, buttons uint8) error {
 		return err
 	}
 
+	if pressed := buttons != 0; pressed != u.absMousePressed {
+		u.absMousePressed = pressed
+		updateHidHandover(func(h *hidHandover) {
+			h.AbsPressed, h.AbsX, h.AbsY = pressed, x, y
+		})
+	}
+
 	u.resetUserInputTime()
 	return nil
 }

--- a/internal/usbgadget/mass_storage.go
+++ b/internal/usbgadget/mass_storage.go
@@ -13,7 +13,11 @@ var massStorageBaseConfig = gadgetConfigItem{
 	path:       []string{"functions", "mass_storage.usb0"},
 	configPath: []string{"mass_storage.usb0"},
 	attrs: gadgetAttributes{
-		"stall": "1",
+		// Never halt the bulk endpoints. Every halt call in f_mass_storage is
+		// gated by this flag, and on this dwc3 the halt races the function's
+		// disable path on disconnect and oopses in the kernel (#1360). With
+		// stalls off the function pads with a zero-length packet instead.
+		"stall": "0",
 	},
 }
 

--- a/internal/usbgadget/mass_storage.go
+++ b/internal/usbgadget/mass_storage.go
@@ -63,6 +63,8 @@ func (u *UsbGadget) SetMassStorageImage(imagePath string) error {
 
 func (u *UsbGadget) forceEjectLocked() error {
 	if softDisconnect(u.udc) == nil {
+		// The host re-enumerates on reconnect, the same as after a rebind.
+		u.resetHidHandover()
 		defer func() {
 			_ = softConnect(u.udc)
 		}()

--- a/internal/usbgadget/udc.go
+++ b/internal/usbgadget/udc.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -61,6 +62,42 @@ func softConnectPath(udc string) string {
 	return path.Join(udcClassPath, udc, "soft_connect")
 }
 
+// dwc3RegdumpPath is the controller register dump debugfs exposes. JetKVM
+// mounts debugfs from fstab.
+func dwc3RegdumpPath(udc string) string {
+	return path.Join("/sys/kernel/debug/usb", udc, "regdump")
+}
+
+// dwc3RunStop reads DCTL.RUN_STOP from a register dump. The bit is the
+// pull-up: soft_connect clears it on "disconnect" and sets it on "connect",
+// while the sysfs state and speed files keep their last value across both.
+func dwc3RunStop(regdump []byte) (bool, error) {
+	for _, line := range strings.Split(string(regdump), "\n") {
+		name, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(name) != "DCTL" {
+			continue
+		}
+		v, err := strconv.ParseUint(strings.TrimPrefix(strings.TrimSpace(value), "0x"), 16, 32)
+		if err != nil {
+			return false, fmt.Errorf("parse DCTL %q: %w", value, err)
+		}
+		return v&(1<<31) != 0, nil
+	}
+	return false, fmt.Errorf("DCTL not found in register dump")
+}
+
+// isPullupEnabled reports whether the controller presents the gadget to the
+// host. Without a readable register dump it reports false, which makes the
+// caller rebind as it always did before adoption existed.
+func isPullupEnabled(udc string) bool {
+	regdump, err := os.ReadFile(dwc3RegdumpPath(udc))
+	if err != nil {
+		return false
+	}
+	on, err := dwc3RunStop(regdump)
+	return err == nil && on
+}
+
 func softDisconnect(udc string) error {
 	err := os.WriteFile(softConnectPath(udc), []byte("disconnect"), 0644)
 	if err == nil {
@@ -101,6 +138,7 @@ func (u *UsbGadget) rebindUsb(ignoreUnbindError bool) error {
 	if err := rebindUsb(u.udc, ignoreUnbindError); err != nil {
 		return err
 	}
+	u.resetHidHandover()
 	time.Sleep(100 * time.Millisecond)
 	if !u.IsGadgetAttachedToUDC() {
 		return os.WriteFile(path.Join(u.kvmGadgetPath, "UDC"), []byte(u.udc), 0644)

--- a/internal/usbgadget/udc.go
+++ b/internal/usbgadget/udc.go
@@ -94,6 +94,10 @@ func isHidgChardevHealthy() bool {
 
 func (u *UsbGadget) rebindUsb(ignoreUnbindError bool) error {
 	u.log.Info().Str("udc", u.udc).Msg("rebinding USB gadget to UDC")
+	// f_hid re-initialises the same cdev on every bind. Descriptors left open
+	// from the previous bind would drop the fresh refcount to zero when they
+	// are finally closed, and every open after that fails with ENXIO.
+	u.ResetHIDFiles()
 	if err := rebindUsb(u.udc, ignoreUnbindError); err != nil {
 		return err
 	}

--- a/internal/usbgadget/udc.go
+++ b/internal/usbgadget/udc.go
@@ -117,6 +117,8 @@ func (u *UsbGadget) SoftReconnect() error {
 	if err := softDisconnect(u.udc); err != nil {
 		return err
 	}
+	// The host re-enumerates on reconnect, the same as after a rebind.
+	u.resetHidHandover()
 	return softConnect(u.udc)
 }
 

--- a/internal/usbgadget/udc_test.go
+++ b/internal/usbgadget/udc_test.go
@@ -1,0 +1,31 @@
+package usbgadget
+
+import "testing"
+
+// Register dumps taken on an RV1106 (kernel 5.10) with the host attached.
+const (
+	regdumpConnected    = "DCFG = 0x00080804\nDCTL = 0x80f00a00\nDSTS = 0x00826600\n"
+	regdumpDisconnected = "DCFG = 0x00080804\nDCTL = 0x00f00a00\nDSTS = 0x00d35cd9\n"
+)
+
+func TestDwc3RunStop(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		regdump string
+		want    bool
+		wantErr bool
+	}{
+		{"connected", regdumpConnected, true, false},
+		{"soft disconnected", regdumpDisconnected, false, false},
+		{"no DCTL", "DCFG = 0x00080804\n", false, true},
+		{"garbage", "DCTL = zz\n", false, true},
+	} {
+		got, err := dwc3RunStop([]byte(tc.regdump))
+		if (err != nil) != tc.wantErr {
+			t.Errorf("%s: err = %v, wantErr %v", tc.name, err, tc.wantErr)
+		}
+		if got != tc.want {
+			t.Errorf("%s: got %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}

--- a/internal/usbgadget/usbgadget.go
+++ b/internal/usbgadget/usbgadget.go
@@ -69,6 +69,7 @@ type UsbGadget struct {
 	wakeHidLock     sync.Mutex
 	absMouseHidFile *os.File
 	absMouseLock    sync.Mutex
+	absMousePressed bool
 	relMouseHidFile *os.File
 	relMouseLock    sync.Mutex
 

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -12,6 +12,7 @@ import type { Page } from "@playwright/test";
 const execAsync = promisify(exec);
 
 export const HID_KEY = {
+  LEFT_SHIFT: 0xe1, // 225
   SPACE: 0x2c, // 44
   CAPS_LOCK: 0x39, // 57
   NUM_LOCK: 0x53, // 83

--- a/ui/e2e/helpers.ts
+++ b/ui/e2e/helpers.ts
@@ -637,7 +637,9 @@ export async function loginLocal(
   const errorLocator = page.locator(".text-red-500, .text-red-600").first();
   const outcome = await Promise.race([
     page
-      .waitForURL(url => !url.toString().includes("/login"), { timeout: 5000 })
+      .waitForURL(url => !url.toString().includes("/login"), {
+        timeout: 5000,
+      })
       .then(() => "navigated" as const),
     errorLocator.waitFor({ state: "visible", timeout: 5000 }).then(() => "error" as const),
   ]).catch(() => "timeout" as const);
@@ -701,7 +703,9 @@ export async function enablePasswordFromSettings(
   await passwordInput.fill(password);
   await confirmPasswordInput.fill(confirmPassword ?? password);
 
-  const secureButton = page.getByRole("button", { name: /Secure|Set Password/i });
+  const secureButton = page.getByRole("button", {
+    name: /Secure|Set Password/i,
+  });
   await secureButton.click();
 
   if (expectSuccess) {
@@ -761,7 +765,9 @@ export async function disablePasswordFromSettings(
   await expect(passwordInput).toBeVisible({ timeout: 5000 });
   await passwordInput.fill(currentPassword);
 
-  const confirmDisableButton = page.getByRole("button", { name: /Disable.*Protection/i });
+  const confirmDisableButton = page.getByRole("button", {
+    name: /Disable.*Protection/i,
+  });
   await confirmDisableButton.click();
 
   if (expectSuccess) {
@@ -805,7 +811,9 @@ export async function sshExec(cmd: string, ignoreErrors = false): Promise<string
 
   for (let attempt = 1; attempt <= SSH_MAX_RETRIES; attempt++) {
     try {
-      const { stdout } = await execAsync(sshCmd, { timeout: SSH_COMMAND_TIMEOUT_MS });
+      const { stdout } = await execAsync(sshCmd, {
+        timeout: SSH_COMMAND_TIMEOUT_MS,
+      });
       return stdout;
     } catch (error) {
       if (ignoreErrors) return "";
@@ -905,10 +913,13 @@ async function getRestartAppPathViaSSH(): Promise<string> {
   return runningDebug.trim() === "1" ? REMOTE_DEBUG_APP_PATH : REMOTE_APP_PATH;
 }
 
-export async function restartAppViaSSH(): Promise<void> {
+export async function restartAppViaSSH(opts: { beforeStart?: string } = {}): Promise<void> {
   const appPath = await getRestartAppPathViaSSH();
   await sshExec("killall jetkvm_app jetkvm_app_debug", true);
   await new Promise(r => setTimeout(r, 500));
+  // Runs on the device while no app is up, for tests that stage the state a
+  // crashed process would leave behind.
+  if (opts.beforeStart) await sshExec(opts.beforeStart);
   // Rotate last.log into last.log.prev before respawning so a later teardown
   // can still recover the previous session's output if a subsequent restart
   // truncates the live log. Combined into one SSH call to save a round-trip.

--- a/ui/e2e/remote-agent/ra-all.spec.ts
+++ b/ui/e2e/remote-agent/ra-all.spec.ts
@@ -28,6 +28,7 @@ import {
   getLedState,
   waitForLedState,
   restartAppViaSSH,
+  rebootDeviceViaSSH,
   semverGte,
 } from "../helpers";
 import {

--- a/ui/e2e/remote-agent/ra-usb-restart-adoption.spec.ts
+++ b/ui/e2e/remote-agent/ra-usb-restart-adoption.spec.ts
@@ -3,6 +3,7 @@ import { test, expect, type Page } from "@playwright/test";
 import {
   HID_KEY,
   SSH_OPTS,
+  callJsonRpc,
   ensureNoPasswordViaAPI,
   ensureRpcReady,
   getLedState,
@@ -40,7 +41,7 @@ function remoteHostExec(cmd: string, timeoutMs = 15_000): string {
 // The host assigns a new device number on every enumeration. An unchanged
 // number across the restart proves the gadget was adopted, so whatever the
 // host observed afterwards came from the new process, not from a re-plug.
-function gadgetDeviceNumber(): number {
+function findGadgetDeviceNumber(): number | null {
   const out = remoteHostExec(
     "for d in /sys/bus/usb/devices/*-*/; do " +
       '[ -f "$d/manufacturer" ] || continue; ' +
@@ -49,8 +50,30 @@ function gadgetDeviceNumber(): number {
       "done",
   ).trim();
   const devnum = parseInt(out, 10);
-  expect(devnum, "gadget not found on the remote host").toBeGreaterThan(0);
-  return devnum;
+  return devnum > 0 ? devnum : null;
+}
+
+function gadgetDeviceNumber(): number {
+  const devnum = findGadgetDeviceNumber();
+  expect(devnum, "gadget not found on the remote host").not.toBeNull();
+  return devnum!;
+}
+
+async function waitForReenumeration(previous: number, timeout: number): Promise<number> {
+  await expect
+    .poll(
+      () => {
+        const devnum = findGadgetDeviceNumber();
+        return devnum !== null && devnum !== previous;
+      },
+      {
+        message: "host should enumerate the gadget again",
+        timeout,
+        intervals: [1000],
+      },
+    )
+    .toBe(true);
+  return gadgetDeviceNumber();
 }
 
 async function reconnect(): Promise<void> {
@@ -111,7 +134,10 @@ test("app restart releases keys the previous process left held", async () => {
           events.some(ev => ev.code === KEY.SPACE && ev.type === "key_release")
         );
       },
-      { message: "new process should release both keys on the host", timeout: 15_000 },
+      {
+        message: "new process should release both keys on the host",
+        timeout: 15_000,
+      },
     )
     .toBe(true);
 
@@ -175,7 +201,10 @@ test("app restart releases an absolute mouse button once", async () => {
     .poll(
       async () =>
         (await agent!.getMouseEvents()).some(ev => ev.type === "mouse_button" && ev.value === 0),
-      { message: "new process should release the button on the host", timeout: 15_000 },
+      {
+        message: "new process should release the button on the host",
+        timeout: 15_000,
+      },
     )
     .toBe(true);
   expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(before);
@@ -190,6 +219,64 @@ test("app restart releases an absolute mouse button once", async () => {
   await new Promise(r => setTimeout(r, 3_000));
   expect(await agent!.getMouseEvents(), "second restart must not replay the release").toEqual([]);
   expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(before);
+
+  await reconnect();
+});
+
+test("a gadget the previous process left soft-disconnected is rebound", async () => {
+  test.setTimeout(90_000);
+
+  const before = gadgetDeviceNumber();
+
+  // The app soft-disconnects before it rebinds. A process that dies in
+  // between leaves the UDC bound and the gadget attached, which is all the
+  // adoption check used to look at, while the host sees nothing.
+  await restartAppViaSSH({
+    beforeStart: "echo disconnect > /sys/class/udc/$(ls /sys/class/udc | head -n1)/soft_connect",
+  });
+
+  await waitForReenumeration(before, 20_000);
+  await reconnect();
+  await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 30_000);
+  expect(
+    (await waitForKeyboardReady(agent!, page, 30_000)).length,
+    "keyboard must work after the rebind",
+  ).toBeGreaterThan(0);
+});
+
+test("a forced rebind drops the inherited absolute mouse press", async () => {
+  test.setTimeout(120_000);
+
+  const press = { x: 24576, y: 24576 };
+
+  await agent!.clearMouseEvents();
+  await sendAbsMouseMove(page, press.x, press.y, 1);
+  await expect
+    .poll(
+      async () =>
+        (await agent!.getMouseEvents()).some(ev => ev.type === "mouse_button" && ev.value === 1),
+      { message: "host should see the button pressed", timeout: 5_000 },
+    )
+    .toBe(true);
+
+  // A config write always rebinds: the host re-enumerates and releases the
+  // button itself, so the recorded press is stale from here on.
+  const before = gadgetDeviceNumber();
+  const devices = await callJsonRpc(page, "getUsbDevices");
+  await callJsonRpc(page, "setUsbDevices", { devices });
+  const after = await waitForReenumeration(before, 30_000);
+  await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 30_000);
+
+  // The restart adopts the gadget. The fresh host device sits at (0, 0), so
+  // a replayed release at the press position would show up as a move.
+  await agent!.clearMouseEvents();
+  await restartAppViaSSH();
+  await new Promise(r => setTimeout(r, 3_000));
+  expect(
+    await agent!.getMouseEvents(),
+    "restart must not replay a release from before the rebind",
+  ).toEqual([]);
+  expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(after);
 
   await reconnect();
 });

--- a/ui/e2e/remote-agent/ra-usb-restart-adoption.spec.ts
+++ b/ui/e2e/remote-agent/ra-usb-restart-adoption.spec.ts
@@ -7,6 +7,7 @@ import {
   ensureRpcReady,
   getLedState,
   restartAppViaSSH,
+  sendAbsMouseMove,
   sendKeypress,
   tapKey,
   waitForLedState,
@@ -149,4 +150,46 @@ test("app restart keeps the host's keyboard LED state", async () => {
     await tapKey(page, HID_KEY.CAPS_LOCK);
     await waitForLedState(page, "caps_lock", initial!.caps_lock).catch(() => {});
   }
+});
+
+test("app restart releases an absolute mouse button once", async () => {
+  test.setTimeout(120_000);
+
+  const press = { x: 16384, y: 16384 };
+  const away = { x: 8192, y: 8192 };
+
+  await agent!.clearMouseEvents();
+  await sendAbsMouseMove(page, press.x, press.y, 1);
+  await expect
+    .poll(
+      async () =>
+        (await agent!.getMouseEvents()).some(ev => ev.type === "mouse_button" && ev.value === 1),
+      { message: "host should see the button pressed", timeout: 5_000 },
+    )
+    .toBe(true);
+
+  const before = gadgetDeviceNumber();
+  await restartAppViaSSH();
+
+  await expect
+    .poll(
+      async () =>
+        (await agent!.getMouseEvents()).some(ev => ev.type === "mouse_button" && ev.value === 0),
+      { message: "new process should release the button on the host", timeout: 15_000 },
+    )
+    .toBe(true);
+  expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(before);
+
+  // Park the cursor elsewhere. A release replayed at the press position on
+  // the next restart would show up on the host as a move back to it.
+  await reconnect();
+  await agent!.expectMouseMove(() => sendAbsMouseMove(page, away.x, away.y));
+  await agent!.clearMouseEvents();
+
+  await restartAppViaSSH();
+  await new Promise(r => setTimeout(r, 3_000));
+  expect(await agent!.getMouseEvents(), "second restart must not replay the release").toEqual([]);
+  expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(before);
+
+  await reconnect();
 });

--- a/ui/e2e/remote-agent/ra-usb-restart-adoption.spec.ts
+++ b/ui/e2e/remote-agent/ra-usb-restart-adoption.spec.ts
@@ -1,0 +1,152 @@
+import { execSync } from "child_process";
+import { test, expect, type Page } from "@playwright/test";
+import {
+  HID_KEY,
+  SSH_OPTS,
+  ensureNoPasswordViaAPI,
+  ensureRpcReady,
+  getLedState,
+  restartAppViaSSH,
+  sendKeypress,
+  tapKey,
+  waitForLedState,
+  waitForWebRTCReady,
+} from "../helpers";
+import { KEY, createRemoteAgent, waitForKeyboardReady } from "./remote-agent";
+
+// An app restart keeps the previous instance's gadget bound when nothing in
+// the configuration changed, so the host never sees a disconnect. These tests
+// pin the two things the new process has to do on its own in that case:
+// release inputs the old process left pressed, and carry over the host's LED
+// state, which the host only sends again after an enumeration.
+
+const agent = createRemoteAgent();
+
+test.describe.configure({ mode: "serial" });
+
+let page: Page;
+
+function remoteHostExec(cmd: string, timeoutMs = 15_000): string {
+  const target = process.env.JETKVM_REMOTE_HOST;
+  if (!target) throw new Error("JETKVM_REMOTE_HOST not set");
+  const escaped = cmd.replace(/'/g, "'\\''");
+  return execSync(`ssh ${SSH_OPTS} ${target} '${escaped}'`, {
+    encoding: "utf8",
+    timeout: timeoutMs,
+  });
+}
+
+// The host assigns a new device number on every enumeration. An unchanged
+// number across the restart proves the gadget was adopted, so whatever the
+// host observed afterwards came from the new process, not from a re-plug.
+function gadgetDeviceNumber(): number {
+  const out = remoteHostExec(
+    "for d in /sys/bus/usb/devices/*-*/; do " +
+      '[ -f "$d/manufacturer" ] || continue; ' +
+      'grep -qi jetkvm "$d/manufacturer" 2>/dev/null || continue; ' +
+      'cat "$d/devnum"; break; ' +
+      "done",
+  ).trim();
+  const devnum = parseInt(out, 10);
+  expect(devnum, "gadget not found on the remote host").toBeGreaterThan(0);
+  return devnum;
+}
+
+async function reconnect(): Promise<void> {
+  await page.goto("/", { waitUntil: "networkidle" });
+  await waitForWebRTCReady(page);
+  await ensureRpcReady(page);
+}
+
+test.beforeAll(async ({ browser }) => {
+  test.skip(!agent, "JETKVM_REMOTE_HOST not set");
+  await Promise.all([agent!.ensureDeployed(), ensureNoPasswordViaAPI()]);
+
+  page = await browser.newPage();
+  await reconnect();
+  await agent!.waitForInputDevices(["keyboard", "absolute_mouse", "relative_mouse"], 30_000);
+});
+
+test.afterAll(async () => {
+  if (page) await page.close();
+});
+
+test("app restart releases keys the previous process left held", async () => {
+  test.setTimeout(90_000);
+
+  expect(
+    (await waitForKeyboardReady(agent!, page, 30_000)).length,
+    "keyboard must work before the test",
+  ).toBeGreaterThan(0);
+
+  await agent!.clearKeyboardEvents();
+  await sendKeypress(page, HID_KEY.LEFT_SHIFT, true);
+  await sendKeypress(page, HID_KEY.SPACE, true);
+
+  await expect
+    .poll(
+      async () => {
+        const events = await agent!.getKeyboardEvents();
+        return (
+          events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_press") &&
+          events.some(ev => ev.code === KEY.SPACE && ev.type === "key_press")
+        );
+      },
+      { message: "host should see both keys pressed", timeout: 5_000 },
+    )
+    .toBe(true);
+
+  const before = gadgetDeviceNumber();
+
+  // SIGTERM: the old process exits without releasing anything.
+  await restartAppViaSSH();
+
+  await expect
+    .poll(
+      async () => {
+        const events = await agent!.getKeyboardEvents();
+        return (
+          events.some(ev => ev.code === KEY.LEFT_SHIFT && ev.type === "key_release") &&
+          events.some(ev => ev.code === KEY.SPACE && ev.type === "key_release")
+        );
+      },
+      { message: "new process should release both keys on the host", timeout: 15_000 },
+    )
+    .toBe(true);
+
+  expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(before);
+
+  await reconnect();
+});
+
+test("app restart keeps the host's keyboard LED state", async () => {
+  test.setTimeout(90_000);
+
+  expect(
+    (await waitForKeyboardReady(agent!, page, 30_000)).length,
+    "keyboard must work before the test",
+  ).toBeGreaterThan(0);
+
+  const initial = await getLedState(page);
+  expect(initial, "LED state should be available").not.toBeNull();
+  const toggled = !initial!.caps_lock;
+
+  await tapKey(page, HID_KEY.CAPS_LOCK);
+  await waitForLedState(page, "caps_lock", toggled);
+
+  const before = gadgetDeviceNumber();
+
+  try {
+    await restartAppViaSSH();
+    await reconnect();
+
+    expect(gadgetDeviceNumber(), "gadget must not re-enumerate on app restart").toBe(before);
+
+    // Nothing toggled Caps Lock since the restart and the host sent no new
+    // LED report, so this is the state the new process carried over.
+    await waitForLedState(page, "caps_lock", toggled, 10_000);
+  } finally {
+    await tapKey(page, HID_KEY.CAPS_LOCK);
+    await waitForLedState(page, "caps_lock", initial!.caps_lock).catch(() => {});
+  }
+});

--- a/usb.go
+++ b/usb.go
@@ -269,6 +269,7 @@ func tryReopenKeyboard(reason string, requireWritable bool) bool {
 		setUSBRecoveryTimer(time.Now())
 		time.Sleep(delay)
 		if err := gadget.ReopenKeyboardHidFile(); err != nil {
+			usbLogger.Debug().Err(err).Str("reason", reason).Msg("keyboard HID file reopen failed")
 			continue
 		}
 		if gadget.GetUsbState() != usbgadget.USBStateConfigured {


### PR DESCRIPTION
Fixes #1360.

## Crash

On disconnect the kernel disables every function's endpoints. If the
mass storage thread is answering a host command at that moment, it
stalls its bulk-in endpoint, which is already gone, and dwc3 oopses in
`__dwc3_gadget_ep_set_halt`. Only a power cycle recovers.

The driver only stalls when the `stall` attribute is 1. Set it to 0: it
sends a zero-length packet instead and the host reads the short
transfer from the status packet. The kernel documents this setting for
controllers that mishandle stalls.

## Fewer disconnects

Each disconnect is a chance to hit the race. We disconnected far more
than needed:

1. Every app start rebound the gadget even when it already matched.
   Init now skips the rebind when the configfs tree matches and the
   gadget is bound and attached. UpdateGadgetConfig still always rebinds
   because recovery depends on it.

2. The match check has never passed since audio was added. The symlink
   order check used a sorted directory read (hid, mass_storage, uac1)
   against the requested order (hid, uac1, mass_storage), so every start
   removed and recreated all symlinks. configfs lists newest first, so
   read the raw order and reverse it. The audio channel mask was written
   as "0x3" and read back as "3", so it was rewritten on every start.

3. Every recovery rebound twice. f_hid reuses the same cdev object on
   rebind. The app closed its old /dev/hidg0 descriptors after the
   rebind, which dropped the new cdev's refcount to zero, and every open
   then failed with ENXIO. After 20 s of retries the app did a full
   reconfigure. Close the descriptors before the rebind. The reopen
   error is now logged at debug level.

4. The UDC unbind e2e test calls rebootDeviceViaSSH in its cleanup
   without importing it. Import it.

## Adopting a live gadget

When a restart keeps the gadget bound, the host sees no disconnect. It
still holds whatever the old process left pressed, and it does not
resend its LED report. A tmpfs handover file keeps the last LED byte and
any unreleased absolute mouse press. On adoption the new process sends
neutral keyboard and mouse reports, releases a pending absolute press
at its own position, and restores the LED state. A rebind resets the
file. Three e2e tests cover this: keys held across a restart are
released on the host while the gadget's device number stays the same,
Caps Lock survives a restart without a new toggle, and a held absolute
mouse button is released once and not replayed on the next restart.
All three fail on the previous build.

Adoption also requires the pull-up to be on. A process that dies
between its soft disconnect and the rebind leaves the UDC bound and the
gadget attached while the host sees nothing, and the sysfs state file
still reads `configured`. `DCTL.RUN_STOP` in the dwc3 register dump
under debugfs reflects the soft disconnect, so that is what Init checks.
Without a readable dump it rebinds as before.

Every rebind resets the handover file, so a press recorded before a
config change is not replayed at the next adoption. An optional
attribute the kernel does not expose (`wakeup_on_write`) no longer
counts as a pending change; it made every start rebind on kernels
without it.

Two more e2e tests: a gadget left soft-disconnected is enumerated again
after an app start, and a press followed by a forced rebind and a
restart produces no mouse event on the host. Both fail on the previous
build.

The host's LED report after re-enumeration is persisted even when it
repeats the current state, so it survives the reset a rebind just did.
This did not reproduce on the rig, a Linux host sends an all-off report
before the real state, so there is no e2e test for it.

A soft reconnect, from the recovery loop or from the forced eject that
unmount falls back to when the host holds the medium, re-enumerates the
host too and resets the handover as well. Verified on the rig: the
previous build replays the release after a forced eject, this one does
not. No committed test for it, see the review thread.

## Testing

Full e2e on ten branches with these commits, twelve runs, ~350 host
re-enumerations including the restart storm and UDC recovery tests.
No oops, no wedge. Idle leak test 3/3 with retries off. Two more full
passes with the adoption commits, 78/78 each, no retries, and two more
on the final branch, 79/79. Adoption spec 10/10 twice on the final build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core USB gadget init/rebind, kernel-facing configfs attributes, and HID state across process restarts—mistakes can wedge the host session or leave stuck inputs.
> 
> **Overview**
> **Prevents a dwc3 kernel oops on USB disconnect** by turning off mass-storage bulk endpoint stalls (`stall` → `0`), and **cuts down how often the gadget disconnects** so that race is hit less often.
> 
> **Init can adopt the previous process’s live gadget** instead of always rebinding: `configureUsbGadget` gains `forceRebind`, `HasPendingChanges()` (ignoring optional attrs like `wakeup_on_write`), and `isGadgetLive()` (UDC bound + attached + dwc3 pull-up via debugfs `DCTL.RUN_STOP`). Config updates and recovery still force rebind. Fixes that made every start look “dirty”: symlink order read from configfs LIFO (not sorted `ReadDir`), audio `c_chmask` written as `3` not `0x3`, and **HID chardevs closed before unbind** so recovery doesn’t double-rebind after ENXIO.
> 
> **When adoption happens**, a tmpfs HID handover file carries keyboard LEDs and any stuck absolute mouse press; the new process releases inherited keys/mouse and restores LEDs, and handover is cleared on any rebind/soft reconnect. New unit and remote e2e tests cover adoption, soft-disconnect recovery, and post-rebind behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 788cb4c7b97495518421d2314a17ca73eb965506. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



