### PR TITLE
fix(terminal): reap the shell spawned for the terminal channel

### DIFF
--- a/terminal.go
+++ b/terminal.go
@@ -31,6 +31,9 @@ func handleTerminalChannel(d *webrtc.DataChannel) {
 			d.Close()
 			return
 		}
+		// Reap the shell when it exits, whether on its own or from the kill
+		// in OnClose. Without this every closed session leaves a zombie.
+		go func() { _ = cmd.Wait() }()
 
 		go func() {
 			buf := make([]byte, 1024)

--- a/ui/e2e/session-zombies.spec.ts
+++ b/ui/e2e/session-zombies.spec.ts
@@ -1,0 +1,32 @@
+import { test, expect } from "@playwright/test";
+import { ensureNoPasswordViaAPI, sshExec, waitForWebRTCReady } from "./helpers";
+
+// Every WebRTC session opens a terminal data channel, and the device spawns a
+// shell for it. A closed session has to reap that shell (#1578).
+
+async function zombieChildrenOfApp(): Promise<string[]> {
+  const out = await sshExec(
+    "for p in /proc/[0-9]*; do " +
+      'set -- $(awk "{print \\$2, \\$3, \\$4}" $p/stat 2>/dev/null); ' +
+      '[ "$2" = Z ] || continue; ' +
+      'grep -q jetkvm_app /proc/$3/comm 2>/dev/null && echo "$(basename $p) $1"; ' +
+      "done",
+    true,
+  );
+  return out.trim().split("\n").filter(Boolean);
+}
+
+test("closed sessions leave no zombie shells behind", async ({ browser }) => {
+  test.setTimeout(90_000);
+  await ensureNoPasswordViaAPI();
+
+  for (let i = 0; i < 3; i++) {
+    const page = await browser.newPage();
+    await page.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(page);
+    await page.close();
+  }
+
+  // Give the last session's channels a moment to close on the device.
+  await expect.poll(zombieChildrenOfApp, { timeout: 10_000, intervals: [1000] }).toEqual([]);
+});

--- a/ui/e2e/session-zombies.spec.ts
+++ b/ui/e2e/session-zombies.spec.ts
@@ -4,16 +4,20 @@ import { ensureNoPasswordViaAPI, sshExec, waitForWebRTCReady } from "./helpers";
 // Every WebRTC session opens a terminal data channel, and the device spawns a
 // shell for it. A closed session has to reap that shell (#1578).
 
+// The scan ends with a sentinel so a failed or truncated SSH call cannot
+// read as "no zombies". Errors propagate instead of being ignored.
 async function zombieChildrenOfApp(): Promise<string[]> {
   const out = await sshExec(
     "for p in /proc/[0-9]*; do " +
       'set -- $(awk "{print \\$2, \\$3, \\$4}" $p/stat 2>/dev/null); ' +
       '[ "$2" = Z ] || continue; ' +
       'grep -q jetkvm_app /proc/$3/comm 2>/dev/null && echo "$(basename $p) $1"; ' +
-      "done",
-    true,
+      "done; echo scan-done",
   );
-  return out.trim().split("\n").filter(Boolean);
+  const lines = out.trim().split("\n").filter(Boolean);
+  if (lines.pop() !== "scan-done")
+    throw new Error(`zombie scan did not complete: ${JSON.stringify(out)}`);
+  return lines;
 }
 
 test("closed sessions leave no zombie shells behind", async ({ browser }) => {

--- a/ui/e2e/session-zombies.spec.ts
+++ b/ui/e2e/session-zombies.spec.ts
@@ -28,6 +28,15 @@ test("closed sessions leave no zombie shells behind", async ({ browser }) => {
     const page = await browser.newPage();
     await page.goto("/", { waitUntil: "networkidle" });
     await waitForWebRTCReady(page);
+    // The terminal channel opens on its own after the HID channel, and the
+    // device spawns the shell only once it does. Closing earlier would leave
+    // nothing to reap and pass without the fix.
+    await expect
+      .poll(() => page.evaluate(() => window.__kvmTestHooks?.isTerminalReady() ?? false), {
+        message: "terminal channel should open",
+        timeout: 15_000,
+      })
+      .toBe(true);
     await page.close();
   }
 


### PR DESCRIPTION
Fixes #1578.

## Cause

The UI opens a `terminal` data channel on every WebRTC connection. The
device answers by starting `/bin/sh` on a pty as soon as the channel
opens. When the session ends, OnClose closes the pty and kills the
shell, but nothing calls Wait, so the shell stays a zombie parented to
the app. One per session. The reported 15 a day is the reconnect rate
of that install, and with `pid_max` at 4096 the PID space runs out in
months.

There is no periodic shell poll in the app. Every other spawn in the
code base waits for its child.

## Fix

Wait for the shell in a goroutine right after it starts, so it is
reaped whether it exits on its own or from the kill in OnClose.

## Testing

Reproduced on the rig: three sessions opened and closed left three
`(sh)` zombies with the app as parent. With the fix, none. New e2e test
does exactly that and fails on `dev`. About 5 s.

The test waits for the terminal channel to open before it closes each
session, so it cannot pass by closing before the shell was spawned.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized process-lifecycle fix on the terminal channel with an e2e guard; no auth or data-path changes.
> 
> **Overview**
> Fixes zombie `/bin/sh` processes that accumulated when each WebRTC terminal data channel closed without reaping the child shell (#1578).
> 
> After `pty.Start`, the handler now runs **`cmd.Wait()` in a background goroutine** so the shell is reaped whether it exits on its own or is killed from `OnClose`.
> 
> Adds a Playwright e2e test that opens three full sessions (waiting for the terminal channel), closes each page, then SSH-scans `/proc` for zombie children of `jetkvm_app` and expects none.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4229a942cb04f2dbf0659a93446426cf5c3321cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
