### PR TITLE
fix(usbgadget): do not panic on commit when no USB function is enabled

### DIFF
--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -99,7 +99,11 @@ func (tx *UsbGadgetTransaction) removeFile(component string, path string, descri
 }
 
 func (tx *UsbGadgetTransaction) Commit() error {
-	tx.addFileChange("gadget-finalize", *tx.reorderSymlinkChanges)
+	// With every USB device class disabled there is no function to link and
+	// no reorder change was staged.
+	if tx.reorderSymlinkChanges != nil {
+		tx.addFileChange("gadget-finalize", *tx.reorderSymlinkChanges)
+	}
 
 	err := tx.c.Apply()
 	if err != nil {

--- a/internal/usbgadget/config_tx.go
+++ b/internal/usbgadget/config_tx.go
@@ -24,6 +24,8 @@ type UsbGadgetTransaction struct {
 	isGadgetConfigItemEnabled func(key string) bool
 
 	reorderSymlinkChanges *RequestedFileChange
+	// disabledFunctionKeys are the symlink removals the UDC write waits on.
+	disabledFunctionKeys []string
 }
 
 func (u *UsbGadget) newUsbGadgetTransaction(lock bool) error {
@@ -193,7 +195,8 @@ func (tx *UsbGadgetTransaction) DisableGadgetItemConfig(item gadgetConfigItem) {
 	}
 
 	configPath := joinPath(tx.configC1Path, item.configPath)
-	_ = tx.removeFile("gadget", configPath, "remove symlink: disable gadget config")
+	key := tx.removeFile("gadget", configPath, "remove symlink: disable gadget config")
+	tx.disabledFunctionKeys = append(tx.disabledFunctionKeys, key)
 }
 
 func (tx *UsbGadgetTransaction) writeGadgetItemConfig(item gadgetConfigItem, deps []string) []string {
@@ -321,6 +324,15 @@ func (tx *UsbGadgetTransaction) addReorderSymlinkChange(path string, target stri
 }
 
 func (tx *UsbGadgetTransaction) WriteUDC() {
+	// Rebinding with a disabled function still linked enumerates it on the
+	// host, and unlinking it afterwards makes configfs unbind the gadget
+	// again, so the removals come first. With every function disabled
+	// nothing stages the reorder change, so only wait on it when it exists.
+	deps := append([]string(nil), tx.disabledFunctionKeys...)
+	if tx.reorderSymlinkChanges != nil {
+		deps = append(deps, "reorder-symlinks")
+	}
+
 	// bound the gadget to a UDC (USB Device Controller)
 	path := path.Join(tx.kvmGadgetPath, "UDC")
 	tx.addFileChange("udc", RequestedFileChange{
@@ -328,7 +340,7 @@ func (tx *UsbGadgetTransaction) WriteUDC() {
 		Path:            path,
 		ExpectedState:   FileStateFileContentMatch,
 		ExpectedContent: []byte(tx.udc),
-		DependsOn:       []string{"reorder-symlinks"},
+		DependsOn:       deps,
 		Description:     "write UDC",
 	})
 }

--- a/internal/usbgadget/config_tx_order_test.go
+++ b/internal/usbgadget/config_tx_order_test.go
@@ -1,0 +1,56 @@
+package usbgadget
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/sourcegraph/tf-dag/dag"
+)
+
+// Rebinding while a disabled function's symlink is still present enumerates
+// it on the host, and removing it afterwards makes configfs unbind the gadget
+// again, so the removals have to come before the UDC write. Nothing ordered
+// them: the UDC write only waited on the reorder change of the enabled
+// functions.
+func TestUDCWriteFollowsDisabledFunctionRemovals(t *testing.T) {
+	// Devices{} disables every class the config can disable. The wake HID
+	// function stays enabled, as on a device.
+	u := NewUsbGadget("test", &Devices{}, &Config{}, nil)
+	u.udc = "test.usb"
+	if err := u.newUsbGadgetTransaction(true); err != nil {
+		t.Fatal(err)
+	}
+	tx := u.tx
+	tx.WriteGadgetConfig()
+	// Complete the graph the way Commit does.
+	if tx.reorderSymlinkChanges != nil {
+		tx.addFileChange("gadget-finalize", *tx.reorderSymlinkChanges)
+	}
+
+	r := ChangeSetResolver{changeset: tx.c, g: &dag.AcyclicGraph{}, l: tx.log}
+	changes, err := r.GetChanges()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Only the unconditional removals staged for disabled functions count;
+	// enabled functions stage a conditional one that runs before their own
+	// changes.
+	udcIndex, lastRemoval, removals := -1, -1, 0
+	for i, c := range changes {
+		switch {
+		case c.Key == "udc":
+			udcIndex = i
+		case c.ExpectedState == FileStateAbsent && c.When == "" &&
+			strings.HasPrefix(c.Path, tx.configC1Path+"/"):
+			lastRemoval = i
+			removals++
+		}
+	}
+	if udcIndex < 0 || removals == 0 {
+		t.Fatalf("expected a UDC write and function removals, got udc=%d removals=%d", udcIndex, removals)
+	}
+	if lastRemoval > udcIndex {
+		t.Fatalf("UDC write at %d precedes a function removal at %d", udcIndex, lastRemoval)
+	}
+}

--- a/internal/usbgadget/config_tx_test.go
+++ b/internal/usbgadget/config_tx_test.go
@@ -1,0 +1,12 @@
+package usbgadget
+
+import "testing"
+
+// With every device class disabled WriteGadgetConfig stages no function and
+// leaves reorderSymlinkChanges nil. Commit used to dereference it (#1541).
+func TestCommitWithoutFunctions(t *testing.T) {
+	tx := &UsbGadgetTransaction{c: &ChangeSet{}, log: defaultLogger}
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit of an empty transaction failed: %v", err)
+	}
+}


### PR DESCRIPTION
Fixes #1541.

## Cause

`WriteGadgetConfig` stages a symlink reorder change for every enabled
function. With every USB device class disabled nothing is enabled, the
pointer stays nil, and `Commit` dereferenced it on the first line. The
app panicked on every start and the supervisor exited, so the device
had no web UI until someone edited the config over SSH.

## Fix

Skip the finalize step when no reorder change was staged. Init errors
are already non-fatal, so the app now starts without USB functions
instead of dying.

## Reach

On 0.5.8 this is hit by setting the four `usb_devices` flags to false,
as reported. On `dev` the wake HID function from #1471 is always
enabled, so the all-off state cannot be reached through the config any
more. The guard still belongs there: the transaction code must not
depend on at least one function being enabled.

## Testing

Unit test that commits an empty transaction. It panics on the old code
and passes with the guard.

## Ordering

With no reorder change the UDC write lost its only dependency, and the
removals of the disabled function symlinks were unordered against the
rebind. Rebinding with a function still linked enumerates it on the
host, and unlinking it afterwards makes configfs unbind the gadget
again. The UDC write now depends on every removal, and on the reorder
change when there is one. A unit test resolves an all-disabled
transaction; on the old code the UDC write came before a removal.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes USB gadget transaction ordering and startup commit behavior on the device; mistakes could affect enumeration or leave the gadget unbound, though scope is limited to `internal/usbgadget` with new unit tests.
> 
> **Overview**
> Fixes startup panic when every USB gadget class is disabled: **`Commit`** only stages the symlink reorder finalize step when `reorderSymlinkChanges` was actually built, instead of always dereferencing it (#1541).
> 
> Separately fixes configfs apply ordering when some functions are turned off. Disabled-function symlink removals are recorded in **`disabledFunctionKeys`**, and the **UDC** bind write now **`DependsOn`** those removals (and on **`reorder-symlinks`** only when that step exists), so rebinding does not enumerate stale functions or trigger an extra unbind after late unlinking.
> 
> Adds **`TestCommitWithoutFunctions`** for the nil finalize case and **`TestUDCWriteFollowsDisabledFunctionRemovals`** to assert removals run before the UDC write in the resolved change graph.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f5f8c6e3f83f6479992f67161823143cc4fb4214. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
