### PR TITLE
fix: expose mass storage before HID interfaces

### DIFF
--- a/internal/usbgadget/config_test.go
+++ b/internal/usbgadget/config_test.go
@@ -22,3 +22,10 @@ func TestBaseGadgetConfigItemsAlwaysEnabled(t *testing.T) {
 		}
 	}
 }
+
+func TestMassStoragePrecedesHIDInterfaces(t *testing.T) {
+	if massStorageBaseConfig.order >= keyboardConfig.order ||
+		massStorageBaseConfig.order >= wakeHIDConfig.order {
+		t.Fatal("mass storage must be the first USB interface for bootloader compatibility")
+	}
+}

--- a/internal/usbgadget/mass_storage.go
+++ b/internal/usbgadget/mass_storage.go
@@ -8,7 +8,7 @@ import (
 )
 
 var massStorageBaseConfig = gadgetConfigItem{
-	order:      3000,
+	order:      900,
 	device:     "mass_storage.usb0",
 	path:       []string{"functions", "mass_storage.usb0"},
 	configPath: []string{"mass_storage.usb0"},
@@ -95,7 +95,7 @@ func (u *UsbGadget) syncMassStorageImageFromKernel() {
 }
 
 var massStorageLun0Config = gadgetConfigItem{
-	order: 3001,
+	order: 901,
 	path:  []string{"functions", "mass_storage.usb0", "lun.0"},
 	attrs: gadgetAttributes{
 		"cdrom":     "1",


### PR DESCRIPTION
Closes #1583
Related to #561 and #239.

### Summary

Expose the mass-storage function before the HID functions in the composite USB gadget.

On a Raspberry Pi 5, the EEPROM boot firmware can locate mass storage at interface 4 and load U-Boot from it. U-Boot 2026.10-rc3, however, reports zero USB storage devices and falls back to NVMe. Exposing mass storage as interface 0 allows U-Boot to enumerate the same virtual disk and boot Talos from it.

A regression test preserves the required interface ordering.

### Testing

- `go test ./internal/usbgadget`
- `go test ./...`
- `go vet ./...`
- `golangci-lint v2.4.0`
- Verified current upstream `dev` exposes mass storage as interface 4; Raspberry Pi firmware loads U-Boot, but U-Boot reports `0 Storage Device(s)`
- Verified the patched application exposes mass storage as interface 0; U-Boot enumerates the virtual disk and boots Talos v1.12.11
- Verified keyboard input and Caps Lock LED state on a separate Linux host after reordering

### Checklist

- [ ] Ran `make test_e2e` locally and passed
- [x] Linked to issue(s) above by issue number
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
