### PR TITLE
fix(ui): send keyboard macros to the device in chunks

### DIFF
--- a/ui/e2e/remote-agent/ra-paste-chunks.spec.ts
+++ b/ui/e2e/remote-agent/ra-paste-chunks.spec.ts
@@ -52,7 +52,7 @@ async function typedText(): Promise<string> {
 
 async function openPasteModal(): Promise<void> {
   await page.getByRole("button", { name: "Paste text" }).click();
-  await expect(page.locator("textarea")).toBeVisible();
+  await expect(page.locator('textarea[rows="4"]')).toBeVisible();
 }
 
 test.beforeAll(async ({ browser }) => {
@@ -76,7 +76,13 @@ test.beforeAll(async ({ browser }) => {
   await page.goto("/", { waitUntil: "networkidle" });
   await waitForWebRTCReady(page);
   await ensureRpcReady(page);
-  await agent!.waitForInputDevices(["keyboard"], 30_000);
+  // Terminal channels settle focus shortly after the initial connection.
+  await page.waitForTimeout(1_000);
+  await expect
+    .poll(async () => (await agent!.getJetKVMInputDevices()).some(d => d.type === "keyboard"), {
+      timeout: 30_000,
+    })
+    .toBe(true);
 });
 
 test.afterAll(async () => {
@@ -88,7 +94,7 @@ test("a paste longer than one chunk lands on the host in full and in order", asy
   await agent!.clearKeyboardEvents();
 
   await openPasteModal();
-  await page.locator("textarea").fill(TEXT);
+  await page.locator('textarea[rows="4"]').fill(TEXT, { timeout: 5_000 });
   const confirm = page.getByRole("button", { name: "Confirm Paste" });
   await confirm.click();
 
@@ -112,20 +118,25 @@ test("a paste longer than one chunk lands on the host in full and in order", asy
     MAX_MACRO_MESSAGE_BYTES,
   );
 
-  await page.keyboard.press("Escape");
+  await page.getByRole("button", { name: "Paste text" }).click();
+  await expect(page.locator('textarea[rows="4"]')).toHaveCount(0);
 });
 
-test("cancelling a paste stops within one chunk and releases the keyboard", async () => {
+test("cancelling after reopening the paste popover stops and releases the keyboard", async () => {
   test.setTimeout(60_000);
   await agent!.clearKeyboardEvents();
 
   await openPasteModal();
-  await page.locator("textarea").fill(TEXT);
+  await page.locator('textarea[rows="4"]').fill(TEXT, { timeout: 5_000 });
   await page.getByRole("button", { name: "Confirm Paste" }).click();
 
   await expect
     .poll(async () => (await typedText()).length, { timeout: 15_000, intervals: [200] })
     .toBeGreaterThanOrEqual(20);
+
+  await page.getByRole("button", { name: "Paste text" }).click();
+  await expect(page.locator('textarea[rows="4"]')).toHaveCount(0);
+  await openPasteModal();
 
   await page
     .getByRole("button", { name: /^cancel$/i })
@@ -143,4 +154,42 @@ test("cancelling a paste stops within one chunk and releases the keyboard", asyn
 
   const keysDown = (await callJsonRpc(page, "getKeyDownState")) as { keys: number[] };
   expect(keysDown.keys.filter(k => k !== 0)).toEqual([]);
+  await expect(page.locator('textarea[rows="4"]')).toHaveCount(0);
+});
+
+test("a toolbar macro cannot be interrupted by chunks from a previous paste", async () => {
+  test.setTimeout(60_000);
+  const saved = (await callJsonRpc(page, "getKeyboardMacros")) as object[];
+  const replacement = {
+    id: "e2e_test_replacement",
+    name: "E2E Replacement B",
+    sortOrder: 0,
+    steps: Array.from({ length: 10 }, () => ({ keys: ["KeyB"], modifiers: [], delay: 50 })),
+  };
+  try {
+    await callJsonRpc(page, "setKeyboardMacros", { params: { macros: [...saved, replacement] } });
+    await page.reload({ waitUntil: "networkidle" });
+    await waitForWebRTCReady(page);
+    await ensureRpcReady(page);
+    await page.waitForTimeout(1_000);
+    await agent!.clearKeyboardEvents();
+    await openPasteModal();
+    await page.locator('textarea[rows="4"]').fill("a".repeat(200));
+    await page.getByRole("button", { name: "Confirm Paste" }).click();
+    await expect.poll(typedText, { timeout: 10_000 }).toMatch(/^a{10,199}$/);
+
+    // Closing the popover leaves the paste running. A different hook instance
+    // in the toolbar must cancel it before starting the replacement macro.
+    await page.getByRole("button", { name: "Paste text" }).click();
+    await expect(page.locator('textarea[rows="4"]')).toHaveCount(0);
+    await page.getByRole("button", { name: replacement.name, exact: true }).click();
+    await expect.poll(typedText, { timeout: 15_000 }).toMatch(/^a{10,199}b{10}$/);
+    const completed = await typedText();
+    await page.waitForTimeout(5_000);
+    expect(await typedText()).toBe(completed);
+    const keysDown = (await callJsonRpc(page, "getKeyDownState")) as { keys: number[] };
+    expect(keysDown.keys.filter(k => k !== 0)).toEqual([]);
+  } finally {
+    await callJsonRpc(page, "setKeyboardMacros", { params: { macros: saved } });
+  }
 });

--- a/ui/e2e/remote-agent/ra-paste-chunks.spec.ts
+++ b/ui/e2e/remote-agent/ra-paste-chunks.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  callJsonRpc,
+  ensureNoPasswordViaAPI,
+  ensureRpcReady,
+  waitForWebRTCReady,
+} from "../helpers";
+import { KEY, createRemoteAgent } from "./remote-agent";
+
+// A paste is sent to the device as keyboard macro reports of at most 128 wire
+// steps each, and the next report only goes out once the device reports the
+// previous one finished. These tests pin what that buys: every character lands
+// on the host in order across chunk boundaries, no single data channel message
+// grows with the text, and a cancel stops within one chunk.
+
+const agent = createRemoteAgent();
+
+test.describe.configure({ mode: "serial" });
+
+let page: Page;
+
+// 128 wire steps at 9 bytes each plus the 6 byte header.
+const MAX_MACRO_MESSAGE_BYTES = 128 * 9 + 6;
+
+const LETTERS = "abcdefghij";
+const LETTER_CODES: Record<string, number> = {
+  a: KEY.A,
+  b: KEY.B,
+  c: KEY.C,
+  d: KEY.D,
+  e: KEY.E,
+  f: KEY.F,
+  g: KEY.G,
+  h: KEY.H,
+  i: KEY.I,
+  j: KEY.J,
+};
+const CODE_LETTERS = Object.fromEntries(
+  Object.entries(LETTER_CODES).map(([letter, code]) => [code, letter]),
+);
+
+// 200 characters is three full chunks and a partial one.
+const TEXT = LETTERS.repeat(20);
+
+async function typedText(): Promise<string> {
+  const events = await agent!.getKeyboardEvents();
+  return events
+    .filter(e => e.type === "key_press")
+    .map(e => CODE_LETTERS[e.code] ?? "?")
+    .join("");
+}
+
+async function openPasteModal(): Promise<void> {
+  await page.getByRole("button", { name: "Paste text" }).click();
+  await expect(page.locator("textarea")).toBeVisible();
+}
+
+test.beforeAll(async ({ browser }) => {
+  test.skip(!agent, "JETKVM_REMOTE_HOST not set");
+  await Promise.all([agent!.ensureDeployed(), ensureNoPasswordViaAPI()]);
+
+  page = await browser.newPage();
+  // Record the largest hidrpc message the page sends.
+  await page.addInitScript(() => {
+    const send = RTCDataChannel.prototype.send;
+    (window as unknown as { __maxHidRpcMessage: number }).__maxHidRpcMessage = 0;
+    RTCDataChannel.prototype.send = function (this: RTCDataChannel, data: never) {
+      if (this.label === "hidrpc") {
+        const size = (data as ArrayBuffer).byteLength ?? 0;
+        const w = window as unknown as { __maxHidRpcMessage: number };
+        w.__maxHidRpcMessage = Math.max(w.__maxHidRpcMessage, size);
+      }
+      return send.call(this, data);
+    };
+  });
+  await page.goto("/", { waitUntil: "networkidle" });
+  await waitForWebRTCReady(page);
+  await ensureRpcReady(page);
+  await agent!.waitForInputDevices(["keyboard"], 30_000);
+});
+
+test.afterAll(async () => {
+  if (page) await page.close();
+});
+
+test("a paste longer than one chunk lands on the host in full and in order", async () => {
+  test.setTimeout(90_000);
+  await agent!.clearKeyboardEvents();
+
+  await openPasteModal();
+  await page.locator("textarea").fill(TEXT);
+  const confirm = page.getByRole("button", { name: "Confirm Paste" });
+  await confirm.click();
+
+  await expect
+    .poll(async () => (await typedText()).length, {
+      message: "host should receive every character",
+      timeout: 60_000,
+      intervals: [500],
+    })
+    .toBeGreaterThanOrEqual(TEXT.length);
+
+  expect(await typedText()).toBe(TEXT);
+
+  // The paste is reported finished once the last chunk is done.
+  await expect(confirm).toBeEnabled({ timeout: 5_000 });
+
+  const maxMessage = await page.evaluate(
+    () => (window as unknown as { __maxHidRpcMessage: number }).__maxHidRpcMessage,
+  );
+  expect(maxMessage, "no hidrpc message should carry more than one chunk").toBeLessThanOrEqual(
+    MAX_MACRO_MESSAGE_BYTES,
+  );
+
+  await page.keyboard.press("Escape");
+});
+
+test("cancelling a paste stops within one chunk and releases the keyboard", async () => {
+  test.setTimeout(60_000);
+  await agent!.clearKeyboardEvents();
+
+  await openPasteModal();
+  await page.locator("textarea").fill(TEXT);
+  await page.getByRole("button", { name: "Confirm Paste" }).click();
+
+  await expect
+    .poll(async () => (await typedText()).length, { timeout: 15_000, intervals: [200] })
+    .toBeGreaterThanOrEqual(20);
+
+  await page
+    .getByRole("button", { name: /^cancel$/i })
+    .last()
+    .click();
+
+  // Whatever the device had queued in the current chunk may still land, but
+  // nothing beyond it, and nothing keeps arriving afterwards.
+  await page.waitForTimeout(1_000);
+  const afterCancel = await typedText();
+  await page.waitForTimeout(3_000);
+  expect(await typedText()).toBe(afterCancel);
+  expect(afterCancel.length).toBeLessThan(TEXT.length);
+  expect(TEXT.startsWith(afterCancel)).toBe(true);
+
+  const keysDown = (await callJsonRpc(page, "getKeyDownState")) as { keys: number[] };
+  expect(keysDown.keys.filter(k => k !== 0)).toEqual([]);
+});

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -24,6 +24,25 @@ const MACRO_RESET_KEYBOARD_STATE = {
   delay: 0,
 };
 
+// A keyboard macro is sent to the device in chunks of this many wire steps.
+// One report per paste would grow past the data channel's message size limit
+// (64 KiB, about 3600 characters at 9 bytes per step and two steps per
+// character), and a cancel could only take effect once the whole macro had
+// been queued. Even, so a chunk never splits a press from its release.
+const MACRO_CHUNK_STEPS = 128;
+
+// Extra time a chunk may take beyond the sum of its step delays before the
+// next chunk is sent anyway. Covers devices that do not report macro state.
+const MACRO_CHUNK_GRACE_MS = 2000;
+
+// The device runs one macro at a time and every mounted useKeyboard receives
+// its state messages, so the chunk handshake is module state, not per hook.
+// macroChunkDone is called by the device's "macro finished" message while a
+// chunk is awaited. macroChunksRemaining is set while later chunks are still to
+// be sent, so no hook instance clears "paste in progress" in between.
+let macroChunkDone: (() => void) | null = null;
+let macroChunksRemaining = false;
+
 export interface MacroStep {
   keys: string[] | null;
   modifiers: string[] | null;
@@ -74,10 +93,14 @@ export default function useKeyboard() {
       case KeyboardLedStateMessage:
         setKeyboardLedState((message as KeyboardLedStateMessage).keyboardLedState);
         break;
-      case KeyboardMacroStateMessage:
-        if (!(message as KeyboardMacroStateMessage).isPaste) break;
-        setPasteModeEnabled((message as KeyboardMacroStateMessage).state);
+      case KeyboardMacroStateMessage: {
+        const { state, isPaste } = message as KeyboardMacroStateMessage;
+        if (!state) macroChunkDone?.();
+        if (!isPaste) break;
+        if (!state && macroChunksRemaining) break;
+        setPasteModeEnabled(state);
         break;
+      }
       default:
         break;
     }
@@ -328,9 +351,48 @@ export default function useKeyboard() {
         }
       }
 
-      sendKeyboardMacroEventHidRpc(macro);
+      const ac = new AbortController();
+      setAbortController(ac);
+
+      try {
+        for (let i = 0; i < macro.length; i += MACRO_CHUNK_STEPS) {
+          // A cancel already reset the keyboard on the device; just stop.
+          if (ac.signal.aborted) return;
+
+          const chunk = macro.slice(i, i + MACRO_CHUNK_STEPS);
+          macroChunksRemaining = i + MACRO_CHUNK_STEPS < macro.length;
+
+          // The device cancels a running macro when the next one arrives, so
+          // wait for it to report this chunk finished before sending the next.
+          const chunkMs = chunk.reduce((sum, step) => sum + step.delay, 0);
+          const finished = new Promise<void>(resolve => {
+            const cleanup = () => {
+              clearTimeout(timer);
+              ac.signal.removeEventListener("abort", onAbort);
+              macroChunkDone = null;
+            };
+            const done = () => {
+              cleanup();
+              resolve();
+            };
+            const onAbort = () => {
+              cleanup();
+              resolve();
+            };
+            const timer = setTimeout(done, chunkMs + MACRO_CHUNK_GRACE_MS);
+            ac.signal.addEventListener("abort", onAbort);
+            macroChunkDone = done;
+          });
+
+          sendKeyboardMacroEventHidRpc(chunk);
+          await finished;
+        }
+      } finally {
+        macroChunksRemaining = false;
+        if (abortController.current === ac) setAbortController(null);
+      }
     },
-    [sendKeyboardMacroEventHidRpc],
+    [sendKeyboardMacroEventHidRpc, setAbortController],
   );
 
   const executeMacroClientSide = useCallback(

--- a/ui/src/hooks/useKeyboard.ts
+++ b/ui/src/hooks/useKeyboard.ts
@@ -32,16 +32,13 @@ const MACRO_RESET_KEYBOARD_STATE = {
 const MACRO_CHUNK_STEPS = 128;
 
 // Extra time a chunk may take beyond the sum of its step delays before the
-// next chunk is sent anyway. Covers devices that do not report macro state.
+// operation is stopped. A missing acknowledgement must not truncate a chunk.
 const MACRO_CHUNK_GRACE_MS = 2000;
 
-// The device runs one macro at a time and every mounted useKeyboard receives
-// its state messages, so the chunk handshake is module state, not per hook.
-// macroChunkDone is called by the device's "macro finished" message while a
-// chunk is awaited. macroChunksRemaining is set while later chunks are still to
-// be sent, so no hook instance clears "paste in progress" in between.
-let macroChunkDone: (() => void) | null = null;
-let macroChunksRemaining = false;
+// All hook instances share the device's single macro runner, including after
+// a paste popover unmounts. Replacements wait for the previous chunk to stop.
+let remoteMacro: { controller: AbortController; done: Promise<void> } | null = null;
+let macroChunk: { channel: RTCDataChannel; onState: (running: boolean) => void } | null = null;
 
 export interface MacroStep {
   keys: string[] | null;
@@ -53,7 +50,7 @@ export type MacroSteps = MacroStep[];
 
 export default function useKeyboard() {
   const { send } = useJsonRpc();
-  const { rpcDataChannel } = useRTCStore();
+  const { rpcDataChannel, rpcHidChannel } = useRTCStore();
   const { keysDownState, setKeysDownState, setKeyboardLedState, setPasteModeEnabled } =
     useHidStore();
 
@@ -95,9 +92,9 @@ export default function useKeyboard() {
         break;
       case KeyboardMacroStateMessage: {
         const { state, isPaste } = message as KeyboardMacroStateMessage;
-        if (!state) macroChunkDone?.();
+        if (macroChunk?.channel === rpcHidChannel) macroChunk.onState(state);
         if (!isPaste) break;
-        if (!state && macroChunksRemaining) break;
+        if (!state && remoteMacro) break;
         setPasteModeEnabled(state);
         break;
       }
@@ -351,48 +348,88 @@ export default function useKeyboard() {
         }
       }
 
+      if (!rpcHidChannel || rpcHidChannel.readyState !== "open" || !macro.length) return;
+      const channel = rpcHidChannel;
+      const previous = remoteMacro;
       const ac = new AbortController();
-      setAbortController(ac);
+      let release!: () => void;
+      const run = {
+        controller: ac,
+        done: new Promise<void>(resolve => {
+          release = resolve;
+        }),
+      };
+      remoteMacro = run;
+      previous?.controller.abort();
 
+      const onClose = () => ac.abort();
+      channel.addEventListener("close", onClose);
       try {
+        await previous?.done;
         for (let i = 0; i < macro.length; i += MACRO_CHUNK_STEPS) {
-          // A cancel already reset the keyboard on the device; just stop.
-          if (ac.signal.aborted) return;
+          if (ac.signal.aborted || channel.readyState !== "open") return;
 
           const chunk = macro.slice(i, i + MACRO_CHUNK_STEPS);
-          macroChunksRemaining = i + MACRO_CHUNK_STEPS < macro.length;
-
-          // The device cancels a running macro when the next one arrives, so
-          // wait for it to report this chunk finished before sending the next.
           const chunkMs = chunk.reduce((sum, step) => sum + step.delay, 0);
-          const finished = new Promise<void>(resolve => {
-            const cleanup = () => {
+          await new Promise<void>((resolve, reject) => {
+            let started = false;
+            const waiter = {
+              channel,
+              onState: (running: boolean) => {
+                if (running && !started) {
+                  started = true;
+                  if (ac.signal.aborted) cancelOngoingKeyboardMacroHidRpc();
+                } else if (!running && started) {
+                  finish();
+                }
+              },
+            };
+            const finish = (error?: Error) => {
               clearTimeout(timer);
               ac.signal.removeEventListener("abort", onAbort);
-              macroChunkDone = null;
+              channel.removeEventListener("close", onChannelClose);
+              if (macroChunk === waiter) macroChunk = null;
+              if (error) reject(error);
+              else resolve();
             };
-            const done = () => {
-              cleanup();
-              resolve();
-            };
+            const onChannelClose = () => finish();
+            // Wait for the finish acknowledgement even after cancellation,
+            // so it cannot acknowledge a replacement's first chunk.
             const onAbort = () => {
-              cleanup();
-              resolve();
+              if (channel.readyState !== "open") finish();
+              else if (started) cancelOngoingKeyboardMacroHidRpc();
             };
-            const timer = setTimeout(done, chunkMs + MACRO_CHUNK_GRACE_MS);
+            const timer = setTimeout(() => {
+              // A missing finish cannot safely hand ownership to another
+              // macro on this channel. Reconnection provides a fresh one.
+              finish(new Error("Timed out waiting for keyboard macro completion"));
+              channel.close();
+            }, chunkMs + MACRO_CHUNK_GRACE_MS);
             ac.signal.addEventListener("abort", onAbort);
-            macroChunkDone = done;
+            channel.addEventListener("close", onChannelClose);
+            macroChunk = waiter;
+            try {
+              sendKeyboardMacroEventHidRpc(chunk);
+            } catch (error) {
+              finish(error instanceof Error ? error : new Error(String(error)));
+            }
           });
-
-          sendKeyboardMacroEventHidRpc(chunk);
-          await finished;
         }
       } finally {
-        macroChunksRemaining = false;
-        if (abortController.current === ac) setAbortController(null);
+        channel.removeEventListener("close", onClose);
+        release();
+        if (remoteMacro === run) {
+          remoteMacro = null;
+          setPasteModeEnabled(false);
+        }
       }
     },
-    [sendKeyboardMacroEventHidRpc, setAbortController],
+    [
+      rpcHidChannel,
+      sendKeyboardMacroEventHidRpc,
+      cancelOngoingKeyboardMacroHidRpc,
+      setPasteModeEnabled,
+    ],
   );
 
   const executeMacroClientSide = useCallback(
@@ -459,6 +496,10 @@ export default function useKeyboard() {
   );
 
   const cancelExecuteMacro = useCallback(async () => {
+    if (remoteMacro) {
+      remoteMacro.controller.abort();
+      return;
+    }
     if (abortController.current) {
       abortController.current.abort();
     }

--- a/ui/tests/keyboard-macro-ownership.mjs
+++ b/ui/tests/keyboard-macro-ownership.mjs
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { rolldown } from "rolldown";
+import { chromium } from "playwright";
+
+const entry = fileURLToPath(new URL("./keyboard-macro-entry.ts", import.meta.url));
+const bundle = await rolldown({
+  input: entry,
+  transform: { define: { "process.env.NODE_ENV": '"production"' } },
+  plugins: [
+    {
+      name: "keyboard-test-transport",
+      resolveId(source) {
+        if (source === entry) return entry;
+        if (source === "@/hooks/useHidRpc") return "\0hid-transport";
+        if (source === "@/hooks/stores" || source === "./stores") return "\0stores";
+        if (source === "@/hooks/useJsonRpc") return "\0jsonrpc";
+        if (source === "@/keyboardMappings") return "\0mappings";
+        if (source === "@/utils") return "\0utils";
+        if (source === "@/hooks/hidRpc")
+          return fileURLToPath(new URL("../src/hooks/hidRpc.ts", import.meta.url));
+      },
+      load(id) {
+        if (id === "\0stores")
+          return `
+        export const useRTCStore = () => window.store;
+        export const useHidStore = () => ({ setPasteModeEnabled() {} });
+        export const hidKeyBufferSize = 6;
+        export const hidErrorRollOver = 1;
+      `;
+        if (id === "\0jsonrpc") return "export const useJsonRpc = () => ({send() {}});";
+        if (id === "\0mappings")
+          return "export const keys = {KeyA:4,KeyB:5}, modifiers = {}, hidKeyToModifierMask = {};";
+        if (id === "\0utils")
+          return "export const sleep = ms => new Promise(r => setTimeout(r, ms));";
+        if (id === "\0hid-transport")
+          return `
+        import {useEffect} from 'react';
+        export function useHidRpc(listener) {
+          useEffect(() => { window.listeners.add(listener); return () => window.listeners.delete(listener); }, [listener]);
+          return { rpcHidReady: true,
+            reportKeyboardMacroEvent: steps => window.sent.push(steps),
+            cancelOngoingKeyboardMacro: () => window.cancels++,
+          };
+        }
+      `;
+        if (id === entry)
+          return `
+        import {createElement} from 'react';
+        import {createRoot} from 'react-dom/client';
+        import {flushSync} from 'react-dom';
+        import useKeyboard from '../src/hooks/useKeyboard';
+        import {KeyboardMacroStateMessage} from '../src/hooks/hidRpc';
+        const root = createRoot(document.getElementById('root'));
+        function Hook({id}) { window.apis[id] = useKeyboard(); return null; }
+        window.renderHooks = generation => flushSync(() => root.render([
+          createElement(Hook, {id:0, key:'popover'+generation}),
+          createElement(Hook, {id:1, key:'toolbar'}),
+        ]));
+        window.emitState = async state => {
+          for (const listener of [...window.listeners]) {
+            listener(new KeyboardMacroStateMessage(state, true));
+            await Promise.resolve();
+          }
+        };
+      `;
+      },
+    },
+  ],
+});
+const { output } = await bundle.generate({ format: "iife" });
+await bundle.close();
+const browser = await chromium.launch({ executablePath: process.env.CHROME_BIN, headless: true });
+try {
+  const page = await browser.newPage();
+  await page.setContent('<div id="root"></div>');
+  await page.addScriptTag({ content: output[0].code });
+  const result = await page.evaluate(async () => {
+    class Channel extends EventTarget {
+      readyState = "open";
+      close() {
+        this.readyState = "closed";
+        this.dispatchEvent(new Event("close"));
+      }
+    }
+    window.listeners = new Set();
+    window.apis = [];
+    window.sent = [];
+    window.cancels = 0;
+    window.store = { rpcHidChannel: new Channel() };
+    window.renderHooks(0);
+    const steps = (key, count) =>
+      Array.from({ length: count }, () => ({ keys: [key], modifiers: [], delay: 1 }));
+    const tick = () => new Promise(r => setTimeout(r, 0));
+    const first = window.apis[0].executeMacro(steps("KeyA", 130));
+    await tick();
+    window.renderHooks(1);
+    await window.apis[0].cancelExecuteMacro();
+    const beforeStart = window.cancels;
+    await window.emitState(true);
+    const afterStart = window.cancels;
+    await window.emitState(false);
+    await first;
+    const afterRemount = window.sent.length;
+
+    const old = window.apis[0].executeMacro(steps("KeyA", 130));
+    await tick();
+    await window.emitState(true);
+    const replacement = window.apis[1].executeMacro(steps("KeyB", 2));
+    await tick();
+    const beforeStop = window.sent.length;
+    await window.emitState(false);
+    await tick();
+    const afterStop = window.sent.length;
+    await window.emitState(true);
+    await window.emitState(false);
+    await Promise.all([old, replacement]);
+    return {
+      beforeStart,
+      afterStart,
+      afterRemount,
+      beforeStop,
+      afterStop,
+      chunks: window.sent.map(chunk => chunk.length),
+      keys: window.sent.map(chunk => chunk[0].keys[0]),
+      cancels: window.cancels,
+    };
+  });
+  assert.deepEqual(result, {
+    beforeStart: 0,
+    afterStart: 1,
+    afterRemount: 1,
+    beforeStop: 2,
+    afterStop: 3,
+    chunks: [128, 128, 4],
+    keys: [4, 4, 5],
+    cancels: 2,
+  });
+  await page.clock.install();
+  await page.evaluate(async () => {
+    window.timeoutRun = window.apis[0]
+      .executeMacro([{ keys: ["KeyA"], modifiers: [], delay: 1 }])
+      .catch(error => error.message);
+    await Promise.resolve();
+    await window.emitState(true);
+    window.queuedRun = window.apis[1].executeMacro([{ keys: ["KeyB"], modifiers: [], delay: 1 }]);
+  });
+  await page.clock.runFor(2500);
+  const timedOut = await page.evaluate(async () => ({
+    error: await window.timeoutRun,
+    queued: await window.queuedRun,
+    channel: window.store.rpcHidChannel.readyState,
+    chunks: window.sent.length,
+  }));
+  assert.equal(timedOut.channel, "closed");
+  assert.equal(timedOut.chunks, 4);
+  assert.match(timedOut.error, /Timed out/);
+  console.log("Macro ownership across remount, replacement, early cancel, and timeout: OK");
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
Large pastes can exceed the data-channel message limit when sent as a single keyboard macro. This change splits macros into reports of at most 128 wire steps (1,158 bytes), preserving press/release pairs and waiting for each device acknowledgement before sending the next chunk.

The device has one macro runner, so all keyboard hook instances share ownership. Cancel continues to work after reopening the paste popover. A replacement macro cancels the active operation and waits for its completion before sending, preventing an older paste from interrupting it. A missing acknowledgement stops the operation and closes the input channel instead of advancing without confirmation.

Validation:

- RV1106 with a Debian Wayland host: ordered 200-character paste, bounded report size, cancellation after popover remount, and replacement from the macro toolbar with no old chunks resuming or keys left held.
- Controlled browser regression: cancellation before the start acknowledgement, remounts, concurrent hook instances, duplicate state callbacks, and missing completion acknowledgements.
- Device UI build, ARM firmware build, and UI lint pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core remote input/paste sequencing over WebRTC HID RPC; bugs could cause stuck keys, truncated pastes, or channel teardown, but scope is localized to macro execution with dedicated E2E and regression tests.
> 
> **Overview**
> **Remote keyboard macros (including paste)** are no longer sent as one HID RPC payload. `useKeyboard` splits them into **128 wire-step chunks**, sends each chunk only after the device reports the previous one finished, and keeps **module-level ownership** so cancel/replace still works when the paste popover unmounts or another hook starts a toolbar macro.
> 
> Cancellation aborts the shared runner (with device cancel once a chunk has started), replacements wait for the prior run to finish so stale acknowledgements cannot interleave, and a **missing completion** times out and **closes the HID data channel** instead of advancing blindly. Paste-mode UI updates are gated so a late “macro stopped” signal does not clear paste state while a replacement is still running.
> 
> **Tests:** new Playwright remote-agent coverage for long ordered paste, bounded `hidrpc` message size, cancel after reopening the popover, and toolbar macro preempting a background paste; plus a Rolldown/Playwright harness (`keyboard-macro-ownership.mjs`) for remount, replacement, early cancel, and timeout behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 732fe5cdd6ed267727e927b1e5460ab34b86b38f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->