### PR TITLE
Fix reliable mouse button state across reconnects

### DIFF
--- a/ui/e2e/remote-agent/ra-hid-reconnect.spec.ts
+++ b/ui/e2e/remote-agent/ra-hid-reconnect.spec.ts
@@ -1,0 +1,92 @@
+import { test, expect } from "@playwright/test";
+import { ensureNoPasswordViaAPI, ensureRpcReady, sendAbsMouseMove } from "../helpers";
+import { createRemoteAgent } from "./remote-agent";
+
+const agent = createRemoteAgent();
+
+test("mouse buttons reach the host after a session takeover and reconnect", async ({
+  page,
+  browser,
+}) => {
+  test.setTimeout(90_000);
+  test.skip(!agent, "JETKVM_REMOTE_HOST not set");
+  await agent!.ensureDeployed();
+  await ensureNoPasswordViaAPI();
+  await page.addInitScript(() => {
+    const original = RTCDataChannel.prototype.send;
+    (window as unknown as { __pointerChannels: string[] }).__pointerChannels = [];
+    RTCDataChannel.prototype.send = function (data: string | ArrayBuffer | ArrayBufferView | Blob) {
+      const bytes = ArrayBuffer.isView(data)
+        ? new Uint8Array(data.buffer, data.byteOffset, data.byteLength)
+        : data instanceof ArrayBuffer
+          ? new Uint8Array(data)
+          : null;
+      if (bytes?.[0] === 3)
+        (window as unknown as { __pointerChannels: string[] }).__pointerChannels.push(this.label);
+      return original.call(this, data as never);
+    };
+  });
+  await page.goto("/", { waitUntil: "networkidle" });
+  await ensureRpcReady(page);
+  await expect
+    .poll(
+      async () => (await agent!.getJetKVMInputDevices()).some(d => d.type === "absolute_mouse"),
+      { timeout: 30_000 },
+    )
+    .toBe(true);
+  await agent!.clearMouseEvents();
+  await sendAbsMouseMove(page, 16000, 16000, 1);
+  await expect
+    .poll(async () =>
+      (await agent!.getMouseEvents()).some(
+        e => e.type === "mouse_button" && e.code === 272 && e.value === 1,
+      ),
+    )
+    .toBe(true);
+
+  const replacement = await browser.newPage();
+  try {
+    await replacement.goto("/", { waitUntil: "networkidle" });
+    await ensureRpcReady(replacement);
+    // Release the first session's held button before observing a new press.
+    await sendAbsMouseMove(replacement, 16000, 16000, 0);
+    await expect
+      .poll(async () =>
+        (await agent!.getMouseEvents()).some(
+          e => e.type === "mouse_button" && e.code === 272 && e.value === 0,
+        ),
+      )
+      .toBe(true);
+    await expect(page.getByRole("button", { name: "Use Here" })).toBeVisible();
+    await page.getByRole("button", { name: "Use Here" }).click();
+    await ensureRpcReady(page);
+    await agent!.clearMouseEvents();
+    await page.evaluate(() => {
+      (window as unknown as { __pointerChannels: string[] }).__pointerChannels = [];
+    });
+    await sendAbsMouseMove(page, 17000, 17000, 1);
+    await expect
+      .poll(async () =>
+        (await agent!.getMouseEvents()).some(
+          e => e.type === "mouse_button" && e.code === 272 && e.value === 1,
+        ),
+      )
+      .toBe(true);
+    await sendAbsMouseMove(page, 17000, 17000, 0);
+    await expect
+      .poll(async () =>
+        (await agent!.getMouseEvents())
+          .filter(e => e.type === "mouse_button" && e.code === 272)
+          .map(e => e.value),
+      )
+      .toEqual([1, 0]);
+    expect(
+      await page.evaluate(
+        () => (window as unknown as { __pointerChannels: string[] }).__pointerChannels,
+      ),
+    ).toEqual(["hidrpc", "hidrpc"]);
+  } finally {
+    await sendAbsMouseMove(page, 17000, 17000, 0);
+    await replacement.close();
+  }
+});

--- a/ui/src/hooks/useHidRpc.ts
+++ b/ui/src/hooks/useHidRpc.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { useCallback, useEffect, useMemo } from "react";
 import { Logger } from "tslog";
 
 import { useRTCStore } from "@hooks/stores";
@@ -197,10 +197,10 @@ export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
     (
       message: RpcMessage,
       { ignoreHandshakeState, useUnreliableChannel, requireOrdered = true }: sendMessageParams = {},
-    ) => {
-      if (hidRpcDisabled) return;
-      if (rpcHidChannel?.readyState !== "open") return;
-      if (!rpcHidReady && !ignoreHandshakeState) return;
+    ): boolean => {
+      if (hidRpcDisabled) return false;
+      if (rpcHidChannel?.readyState !== "open") return false;
+      if (!rpcHidReady && !ignoreHandshakeState) return false;
 
       let data: Uint8Array | undefined;
       try {
@@ -208,19 +208,20 @@ export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
       } catch (e) {
         logger.error("Failed to marshal message", e);
       }
-      if (!data) return;
+      if (!data) return false;
 
       if (useUnreliableChannel) {
         if (requireOrdered && rpcHidUnreliableReady) {
           rpcHidUnreliableChannel?.send(data as unknown as ArrayBuffer);
-          return;
+          return true;
         } else if (!requireOrdered && rpcHidUnreliableNonOrderedReady) {
           rpcHidUnreliableNonOrderedChannel?.send(data as unknown as ArrayBuffer);
-          return;
+          return true;
         }
       }
 
-      rpcHidChannel?.send(data as unknown as ArrayBuffer);
+      rpcHidChannel.send(data as unknown as ArrayBuffer);
+      return true;
     },
     [
       rpcHidChannel,
@@ -247,14 +248,18 @@ export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
     [sendMessage],
   );
 
-  const lastAbsButtons = useRef(0);
+  // Button authority belongs to one channel/handshake. The first report must
+  // establish it reliably, including when a held button survives reconnect.
+  const lastAbsButtons = useMemo(
+    () => ({ current: null as number | null }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- Reset button authority for each channel and handshake.
+    [rpcHidChannel, rpcHidReady],
+  );
 
   const reportAbsMouseEvent = useCallback(
     (x: number, y: number, buttons: number) => {
       const buttonsChanged = buttons !== lastAbsButtons.current;
-      lastAbsButtons.current = buttons;
-
-      sendMessage(new PointerReportMessage(x, y, buttons), {
+      const sent = sendMessage(new PointerReportMessage(x, y, buttons), {
         // Use the reliable channel for button state changes to guarantee delivery.
         // Movement-only events use the unreliable channel for lower latency;
         // lost movement packets self-correct via subsequent mousemove events,
@@ -262,8 +267,9 @@ export function useHidRpc(onHidRpcMessage?: (payload: RpcMessage) => void) {
         // no such redundancy and must not be dropped.
         useUnreliableChannel: !buttonsChanged,
       });
+      if (sent) lastAbsButtons.current = buttons;
     },
-    [sendMessage],
+    [sendMessage, lastAbsButtons],
   );
 
   const reportRelMouseEvent = useCallback(

--- a/ui/tests/hid-button-generation.mjs
+++ b/ui/tests/hid-button-generation.mjs
@@ -1,0 +1,75 @@
+// Regression for held-button reconnects and reports sent before the handshake.
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { rolldown } from "rolldown";
+import { chromium } from "playwright";
+const entry = fileURLToPath(new URL("./hid-button-entry.ts", import.meta.url));
+const bundle = await rolldown({
+  input: entry, transform: { define: { "process.env.NODE_ENV": '"production"' } },
+  plugins: [{
+    name: "test-hid-store",
+    resolveId(source) {
+      if (source === entry) return entry;
+      if (source === "@hooks/stores" || source === "./stores") return "\0hid-store";
+    },
+    load(id) {
+      if (id === "\0hid-store") return "export const useRTCStore = () => window.testStore; export const hidKeyBufferSize = 6;";
+      if (id === entry) return `
+        import { createElement } from 'react';
+        import { createRoot } from 'react-dom/client';
+        import { flushSync } from 'react-dom';
+        import { useHidRpc } from '../src/hooks/useHidRpc';
+        const root = createRoot(document.getElementById('root'));
+        function Harness() { window.hid = useHidRpc(); return null; }
+        window.renderHid = () => flushSync(() => root.render(createElement(Harness)));
+      `;
+    },
+  }],
+});
+const { output } = await bundle.generate({ format: "iife" });
+await bundle.close();
+const browser = await chromium.launch({
+  executablePath: process.env.CHROME_BIN,
+  headless: true, args: ["--no-sandbox"],
+});
+try {
+  const page = await browser.newPage();
+  await page.setContent('<div id="root"></div>');
+  await page.addScriptTag({ content: output[0].code });
+  const sent = await page.evaluate(() => {
+    const reports = [];
+    const channel = label => ({
+      label, readyState: "open", addEventListener() {}, removeEventListener() {},
+      send(data) { reports.push({ channel: label, bytes: Array.from(new Uint8Array(data)) }); },
+    });
+    window.testStore = {
+      rpcHidChannel: channel("reliable-1"), rpcHidUnreliableChannel: channel("movement-1"),
+      rpcHidProtocolVersion: 1, hidRpcDisabled: false, setRpcHidProtocolVersion() {},
+    };
+    window.renderHid();
+    window.hid.reportAbsMouseEvent(100, 100, 1);
+    window.hid.reportAbsMouseEvent(101, 101, 1);
+    window.testStore.rpcHidChannel = channel("reliable-2");
+    window.testStore.rpcHidUnreliableChannel = channel("movement-2");
+    window.testStore.rpcHidProtocolVersion = null;
+    window.renderHid();
+    window.hid.reportAbsMouseEvent(102, 102, 1);
+    window.testStore.rpcHidProtocolVersion = 1;
+    window.renderHid();
+    window.hid.reportAbsMouseEvent(103, 103, 1);
+    window.hid.reportAbsMouseEvent(104, 104, 1);
+    window.hid.reportAbsMouseEvent(105, 105, 0);
+    window.testStore.rpcHidProtocolVersion = null;
+    window.renderHid();
+    window.hid.reportAbsMouseEvent(106, 106, 0);
+    window.testStore.rpcHidProtocolVersion = 1;
+    window.renderHid();
+    window.hid.reportAbsMouseEvent(107, 107, 0);
+    return reports;
+  });
+  assert.deepEqual(sent.map(report => report.channel), [
+    "reliable-1", "movement-1", "reliable-2", "movement-2", "reliable-2", "reliable-2",
+  ]);
+  assert.deepEqual(sent.map(report => report.bytes[9]), [1, 1, 1, 1, 0, 0]);
+  console.log("HID button authority across reconnect and handshake: OK");
+} finally { await browser.close(); }


### PR DESCRIPTION
### Summary

A mouse report suppressed before the HID handshake can still update the cached button state, and that cache survives channel replacement. Subsequent reports can therefore omit the reliable button transition. Reset the cache for each channel/handshake and update it only after sending a report.

### Validation

The browser regression covers held-button reconnects, reports before the handshake, and reliable release delivery: `CHROME_BIN=/usr/bin/google-chrome node tests/hid-button-generation.mjs` passes. The test also supports Playwright's default browser when `CHROME_BIN` is unset.

UI lint passes with existing warnings; `npx vite build --mode=device` passes. `npx tsc -b` reports the same diagnostics as unchanged `dev` at d58e6e44 (compared after normalizing line numbers). Full device E2E has not been run for this draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches live HID pointer reporting and channel selection; a regression could leave mouse buttons stuck or missing on the host after reconnect.
> 
> **Overview**
> Fixes a bug where **absolute mouse button state** could be wrong after WebRTC/HID channel replacement or when reports were dropped before the HID handshake completed.
> 
> In `useHidRpc`, **`sendMessage` now returns a boolean** so callers know whether a report was actually sent. **`lastAbsButtons` resets** whenever `rpcHidChannel` or handshake readiness changes (not a single long-lived ref), and the cached button mask is **updated only after a successful send**. That forces the next report after reconnect or a failed pre-handshake send to treat a button change as new and route it on the **reliable** channel instead of silently skipping the transition.
> 
> Adds a **Playwright remote-agent E2E** (`ra-hid-reconnect.spec.ts`) for session takeover: press, second tab release, “Use Here”, then press/release on the host. Adds a **bundled browser regression** (`hid-button-generation.mjs`) for held buttons across channel swap, pre-handshake suppression, and release delivery.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 153d4168f61b528880f7a63bc19b6887486ef258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->