### PR TITLE
Stop leaking the DHCP lease label update timer

### DIFF
--- a/ui/e2e/network-lease-timer.spec.ts
+++ b/ui/e2e/network-lease-timer.spec.ts
@@ -1,0 +1,56 @@
+import { test, expect } from "@playwright/test";
+import { callJsonRpc, ensureNoPasswordViaAPI, ensureRpcReady, waitForWebRTCReady } from "./helpers";
+
+test("the DHCP lease view does not install zero-delay intervals", async ({ page }) => {
+  await ensureNoPasswordViaAPI();
+  await page.addInitScript(() => {
+    const original = window.setInterval;
+    (window as unknown as { __intervalDelays: number[] }).__intervalDelays = [];
+    (window as unknown as { __fastIntervals: number }).__fastIntervals = 0;
+    window.setInterval = ((callback: TimerHandler, delay?: number, ...args: unknown[]) => {
+      (window as unknown as { __intervalDelays: number[] }).__intervalDelays.push(delay ?? 0);
+      if (!delay) (window as unknown as { __fastIntervals: number }).__fastIntervals++;
+      return original(callback, delay, ...args);
+    }) as typeof window.setInterval;
+  });
+  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  await ensureRpcReady(page);
+  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  await waitForWebRTCReady(page);
+  const state = (await callJsonRpc(page, "getNetworkState")) as {
+    dhcp_lease?: { ip: string; lease_expiry?: string };
+  };
+  expect(state.dhcp_lease?.ip, "device should have an active DHCP lease").toBeTruthy();
+  await expect(page.getByText("DHCP Lease Information", { exact: true })).toBeVisible();
+  // Some DHCP clients omit expiry. Exercise the countdown using a network-state
+  // notification with the real lease and an explicit future expiry.
+  await page.evaluate(state => {
+    window.__kvmTestHooks!._getRpcDataChannel!()!.dispatchEvent(
+      new MessageEvent("message", {
+        data: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "networkState",
+          params: {
+            ...state,
+            dhcp_lease: {
+              ...state.dhcp_lease,
+              lease_expiry: new Date(Date.now() + 3_600_000).toISOString(),
+            },
+          },
+        }),
+      }),
+    );
+  }, state);
+  const leaseRow = page.getByText("Lease Expires", { exact: true }).locator("..");
+  await expect(leaseRow).toBeVisible();
+  await expect(leaseRow).not.toContainText("Invalid Date");
+  await expect
+    .poll(() =>
+      page.evaluate(() => (window as unknown as { __intervalDelays: number[] }).__intervalDelays),
+    )
+    .toContain(30_000);
+  await page.waitForTimeout(2_200);
+  expect(
+    await page.evaluate(() => (window as unknown as { __fastIntervals: number }).__fastIntervals),
+  ).toBe(0);
+});

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -57,8 +57,7 @@ export function LifeTimeLabel({ lifetime }: Readonly<{ lifetime: string }>) {
 
   // rrecalculate remaining time every 30 seconds
   useEffect(() => {
-    // schedule immediate initial update
-    setInterval(() => setRemaining(dayjs(lifetime).fromNow()), 0);
+    setRemaining(dayjs(lifetime).fromNow());
 
     const interval = setInterval(() => {
       setRemaining(dayjs(lifetime).fromNow());


### PR DESCRIPTION
### Summary

The lease lifetime label starts an untracked zero-delay interval for its initial update. That timer keeps running after the label changes or unmounts. Update immediately once, then retain only the existing 30-second interval with cleanup.

### Validation

UI lint passes with existing warnings; `npx vite build --mode=device` passes. `npx tsc -b` reports the same diagnostics as unchanged `dev` at d58e6e44 (compared after normalizing line numbers). Full device E2E has not been run for this draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small presentation-layer timer lifecycle change with a regression test; no auth, data, or API contract changes.
> 
> **Overview**
> Fixes a **timer leak** in `LifeTimeLabel` on the network settings DHCP lease view: the initial “time remaining” refresh no longer uses `setInterval(..., 0)`, which was untracked and kept firing after unmount or when the lease changed.
> 
> The label now **updates once immediately** on mount/effect run, then only the existing **30-second** interval runs, still cleared on cleanup. Shared `LifeTimeLabel` usage (e.g. IPv6 lifetimes) gets the same behavior.
> 
> Adds a **Playwright E2E** (`network-lease-timer.spec.ts`) that loads network settings, drives lease expiry via a test `networkState` RPC message, and asserts a 30s interval is registered with **no zero-delay intervals** after a short wait.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c27d27733baa832bce8aee53581c3ad42c03657b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->