### PR TITLE
Align static IPv4 validation and live network state

### DIFF
--- a/internal/network/types/config.go
+++ b/internal/network/types/config.go
@@ -11,8 +11,8 @@ import (
 type IPv4StaticConfig struct {
 	Address null.String `json:"address,omitempty" validate_type:"ipv4" required:"true"`
 	Netmask null.String `json:"netmask,omitempty" validate_type:"ipv4" required:"true"`
-	Gateway null.String `json:"gateway,omitempty" validate_type:"ipv4" required:"true"`
-	DNS     []string    `json:"dns,omitempty" validate_type:"ipv4" required:"true"`
+	Gateway null.String `json:"gateway,omitempty" validate_type:"ipv4"`
+	DNS     []string    `json:"dns,omitempty" validate_type:"ipv4"`
 }
 
 // IPv6StaticConfig represents static IPv6 configuration

--- a/pkg/nmlite/static.go
+++ b/pkg/nmlite/static.go
@@ -44,10 +44,13 @@ func (scm *StaticConfigManager) ToIPv4Static(config *types.IPv4StaticConfig) (*t
 	}
 	scm.logger.Info().Str("ipNet", ipNet.String()).Interface("ipc", config).Msg("parsed IPv4 address and netmask")
 
-	// Parse gateway
-	gateway := net.ParseIP(config.Gateway.String)
-	if gateway == nil {
-		return nil, fmt.Errorf("invalid gateway: %s", config.Gateway.String)
+	// A local subnet does not require a default gateway.
+	var gateway net.IP
+	if config.Gateway.String != "" {
+		gateway = net.ParseIP(config.Gateway.String)
+		if gateway == nil || gateway.To4() == nil {
+			return nil, fmt.Errorf("invalid gateway: %s", config.Gateway.String)
+		}
 	}
 
 	// Parse DNS servers

--- a/pkg/nmlite/static_test.go
+++ b/pkg/nmlite/static_test.go
@@ -1,0 +1,67 @@
+package nmlite
+
+import (
+	"io"
+	"testing"
+
+	"github.com/guregu/null/v6"
+	"github.com/jetkvm/kvm/internal/confparser"
+	"github.com/jetkvm/kvm/internal/network/types"
+	"github.com/rs/zerolog"
+)
+
+func TestIPv4StaticOptionalGatewayAndDNS(t *testing.T) {
+	logger := zerolog.New(io.Discard)
+	manager, err := NewStaticConfigManager("eth0", &logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		name    string
+		gateway string
+		dns     []string
+		invalid bool
+	}{
+		{name: "local subnet"},
+		{name: "gateway without DNS", gateway: "192.0.2.1"},
+		{name: "DNS without gateway", dns: []string{"192.0.2.53"}},
+		{name: "gateway and DNS", gateway: "192.0.2.1", dns: []string{"192.0.2.53"}},
+		{name: "invalid gateway", gateway: "invalid", invalid: true},
+		{name: "IPv6 gateway", gateway: "2001:db8::1", invalid: true},
+		{name: "invalid DNS", dns: []string{"invalid"}, invalid: true},
+		{name: "IPv6 DNS", dns: []string{"2001:db8::53"}, invalid: true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			config := &types.IPv4StaticConfig{
+				Address: null.StringFrom("192.0.2.2"),
+				Netmask: null.StringFrom("255.255.255.0"),
+				Gateway: null.StringFrom(test.gateway),
+				DNS:     test.dns,
+			}
+			validation := confparser.SetDefaultsAndValidate(config)
+			parsed, err := manager.ToIPv4Static(config)
+			if test.invalid {
+				if validation == nil || err == nil {
+					t.Fatalf("invalid input accepted: validation=%v, parse=%v", validation, err)
+				}
+				return
+			}
+			if validation != nil || err != nil {
+				t.Fatalf("valid input rejected: validation=%v, parse=%v", validation, err)
+			}
+			if len(parsed.Addresses) != 1 || parsed.Addresses[0].Address.String() != "192.0.2.2/24" {
+				t.Fatalf("unexpected address: %+v", parsed.Addresses)
+			}
+			gateway := parsed.Addresses[0].Gateway
+			if test.gateway == "" && gateway != nil {
+				t.Fatalf("unexpected default gateway: %v", gateway)
+			}
+			if test.gateway != "" && gateway.String() != test.gateway {
+				t.Fatalf("gateway = %v, want %s", gateway, test.gateway)
+			}
+			if len(parsed.Nameservers) != len(test.dns) {
+				t.Fatalf("unexpected DNS servers: %v", parsed.Nameservers)
+			}
+		})
+	}
+}

--- a/ui/e2e/network-settings.spec.ts
+++ b/ui/e2e/network-settings.spec.ts
@@ -1,9 +1,26 @@
 import { isIPv4 } from "node:net";
-import { test, expect } from "@playwright/test";
+import { test, expect, type Page } from "@playwright/test";
 import { callJsonRpc, ensureNoPasswordViaAPI, ensureRpcReady } from "./helpers";
 import type { NetworkSettings, NetworkState } from "../src/hooks/stores";
 
 let original: NetworkSettings | undefined;
+
+async function openNetworkSettings(page: Page, settings: NetworkSettings) {
+  await ensureRpcReady(page);
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByRole("link", { name: "Network", exact: true }).click();
+  // Both cards replace the skeleton only after async form defaults finish loading.
+  if (settings.ipv4_mode === "static") {
+    await expect(page.locator('[name="ipv4_static.address"]')).toHaveValue(
+      settings.ipv4_static!.address,
+      { timeout: 20_000 },
+    );
+  } else {
+    await expect(
+      page.getByRole("heading", { name: "DHCP Lease Information", exact: true }),
+    ).toBeVisible({ timeout: 20_000 });
+  }
+}
 
 test.afterAll(async ({ browser }) => {
   test.setTimeout(180_000);
@@ -27,12 +44,11 @@ test("static IPv4 accepts empty gateway and DNS and preserves a saved hostname",
   const address = new URL(process.env.JETKVM_URL!).hostname;
   test.skip(!isIPv4(address), "Network reconfiguration requires an IPv4 JETKVM_URL");
   await ensureNoPasswordViaAPI();
-  await page.goto("/settings/network", { waitUntil: "networkidle" });
-  await ensureRpcReady(page);
-  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  await ensureRpcReady(page, { navigateFirst: true });
+  original = (await callJsonRpc(page, "getNetworkSettings")) as NetworkSettings;
+  await openNetworkSettings(page, original);
   // Let terminal channel initialization finish before focusing form controls.
   await page.waitForTimeout(1_000);
-  original = (await callJsonRpc(page, "getNetworkSettings")) as NetworkSettings;
   const state = (await callJsonRpc(page, "getNetworkState")) as NetworkState;
   const netmask = state.dhcp_lease?.netmask || original.ipv4_static?.netmask;
   expect(netmask, "need the connected subnet mask to preserve device access").toBeTruthy();
@@ -57,7 +73,7 @@ test("static IPv4 accepts empty gateway and DNS and preserves a saved hostname",
   });
   expect(saved.ipv4_static?.gateway ?? "").toBe("");
   expect(saved.ipv4_static?.dns ?? []).toEqual([]);
-  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  await openNetworkSettings(page, saved);
   await expect(page.locator('[name="hostname"]')).toHaveValue("jetkvm-e2e-network");
   await expect(page.locator('[name="ipv4_static.gateway"]')).toHaveValue("");
   await expect

--- a/ui/e2e/network-settings.spec.ts
+++ b/ui/e2e/network-settings.spec.ts
@@ -1,0 +1,66 @@
+import { isIPv4 } from "node:net";
+import { test, expect } from "@playwright/test";
+import { callJsonRpc, ensureNoPasswordViaAPI, ensureRpcReady } from "./helpers";
+import type { NetworkSettings, NetworkState } from "../src/hooks/stores";
+
+let original: NetworkSettings | undefined;
+
+test.afterAll(async ({ browser }) => {
+  test.setTimeout(180_000);
+  if (!original) return;
+  const page = await browser.newPage();
+  try {
+    await ensureRpcReady(page, { navigateFirst: true, timeoutMs: 90_000 });
+    await callJsonRpc(page, "setNetworkSettings", { settings: original });
+    await page.waitForTimeout(5_000);
+    await ensureRpcReady(page, { navigateFirst: true, timeoutMs: 90_000 });
+    expect(await callJsonRpc(page, "getNetworkSettings")).toEqual(original);
+  } finally {
+    await page.close();
+  }
+});
+
+test("static IPv4 accepts empty gateway and DNS and preserves a saved hostname", async ({
+  page,
+}) => {
+  test.setTimeout(180_000);
+  const address = new URL(process.env.JETKVM_URL!).hostname;
+  test.skip(!isIPv4(address), "Network reconfiguration requires an IPv4 JETKVM_URL");
+  await ensureNoPasswordViaAPI();
+  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  await ensureRpcReady(page);
+  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  // Let terminal channel initialization finish before focusing form controls.
+  await page.waitForTimeout(1_000);
+  original = (await callJsonRpc(page, "getNetworkSettings")) as NetworkSettings;
+  const state = (await callJsonRpc(page, "getNetworkState")) as NetworkState;
+  const netmask = state.dhcp_lease?.netmask || original.ipv4_static?.netmask;
+  expect(netmask, "need the connected subnet mask to preserve device access").toBeTruthy();
+  await page.locator('[name="hostname"]').fill("jetkvm-e2e-network");
+  await page.locator('[name="ipv4_mode"]').selectOption("static");
+  await page.locator('[name="ipv4_static.address"]').fill(address);
+  await page.locator('[name="ipv4_static.netmask"]').fill(netmask!);
+  await page.locator('[name="ipv4_static.gateway"]').fill("");
+  const dnsFields = page.locator('input[name^="ipv4_static.dns."]');
+  if (!(await dnsFields.count()))
+    await page.getByRole("button", { name: "Add DNS Server" }).click();
+  for (const input of await dnsFields.all()) await input.fill("");
+  await page.getByRole("button", { name: "Save Settings", exact: true }).first().click();
+  await page.getByRole("button", { name: "Apply changes", exact: true }).click();
+  await page.waitForTimeout(5_000);
+  await ensureRpcReady(page, { navigateFirst: true, timeoutMs: 90_000 });
+  const saved = (await callJsonRpc(page, "getNetworkSettings")) as NetworkSettings;
+  expect(saved).toMatchObject({
+    hostname: "jetkvm-e2e-network",
+    ipv4_mode: "static",
+    ipv4_static: { address, netmask },
+  });
+  expect(saved.ipv4_static?.gateway ?? "").toBe("");
+  expect(saved.ipv4_static?.dns ?? []).toEqual([]);
+  await page.goto("/settings/network", { waitUntil: "networkidle" });
+  await expect(page.locator('[name="hostname"]')).toHaveValue("jetkvm-e2e-network");
+  await expect(page.locator('[name="ipv4_static.gateway"]')).toHaveValue("");
+  await expect
+    .poll(async () => ((await callJsonRpc(page, "getNetworkState")) as NetworkState).hostname)
+    .toBe("jetkvm-e2e-network");
+});

--- a/ui/src/components/StaticIpv4Card.tsx
+++ b/ui/src/components/StaticIpv4Card.tsx
@@ -43,7 +43,7 @@ export default function StaticIpv4Card() {
   };
 
   const validateIsIPOrCIDR4 = (value: string) => {
-    if (!validator.isIP(value) && !validator.isIPRange(value, 4))
+    if (!validator.isIP(value, 4) && !validator.isIPRange(value, 4))
       return m.network_ipv4_invalid_cidr();
     return true;
   };
@@ -93,7 +93,7 @@ export default function StaticIpv4Card() {
             size="SM"
             placeholder="192.168.1.1"
             {...register("ipv4_static.gateway", {
-              validate: (value: string | undefined) => ipv4Validation(value ?? ""),
+              validate: (value: string | undefined) => !value || ipv4Validation(value),
             })}
             error={formState.errors.ipv4_static?.gateway?.message}
           />
@@ -111,7 +111,7 @@ export default function StaticIpv4Card() {
                         size="SM"
                         placeholder="1.1.1.1"
                         {...register(`ipv4_static.dns.${index}`, {
-                          validate: (value: string | undefined) => ipv4Validation(value ?? ""),
+                          validate: (value: string | undefined) => !value || ipv4Validation(value),
                         })}
                         error={formState.errors.ipv4_static?.dns?.[index]?.message}
                       />

--- a/ui/src/hooks/stores.ts
+++ b/ui/src/hooks/stores.ts
@@ -775,7 +775,7 @@ export interface DhcpLease {
   _swap_server?: string;
   boot_size?: string;
   root_path?: string;
-  lease?: string;
+  lease?: number; // Go time.Duration, in nanoseconds
   lease_expiry?: Date;
   dhcp_type?: string;
   server_id?: string;

--- a/ui/src/routes/devices.$id.settings.network.tsx
+++ b/ui/src/routes/devices.$id.settings.network.tsx
@@ -197,6 +197,10 @@ export default function SettingsNetworkRoute() {
         settings.ipv4_static.address = parts[0];
       }
 
+      if (settings.ipv4_static) {
+        settings.ipv4_static.dns = settings.ipv4_static.dns.filter(Boolean);
+      }
+
       send("setNetworkSettings", { settings }, async resp => {
         if ("error" in resp) {
           notifications.error(

--- a/ui/src/routes/devices.$id.tsx
+++ b/ui/src/routes/devices.$id.tsx
@@ -401,7 +401,9 @@ export default function KvmIdRoute() {
 
     if (resp.method === "networkState") {
       console.debug("Setting network state", resp.params);
-      setNetworkState(resp.params as NetworkState);
+      const state = resp.params as NetworkState;
+      setNetworkState(state);
+      if (state.hostname) setDisplayHostname(state.hostname);
     }
 
     if (resp.method === "keyboardLedState") {


### PR DESCRIPTION
### Summary

Align static IPv4 form validation with the network configuration: reject IPv6 addresses in the IPv4 field, accept an omitted gateway or DNS list, and remove empty DNS form entries before submission. The backend accepts local-subnet configurations without creating a default gateway, while still rejecting invalid supplied addresses.

Also update the displayed hostname from network-state notifications and type DHCP lease duration as the numeric nanoseconds returned by Go.

### Validation

`go test ./pkg/nmlite/... ./internal/confparser/... ./internal/network/types/...` passes. Added cases cover configurations with and without gateway/DNS, invalid addresses, and IPv6 values in IPv4 settings.

UI lint passes with existing warnings; `npx vite build --mode=device` passes. `npx tsc -b` reports the same diagnostics as unchanged `dev` at d58e6e44 (compared after normalizing line numbers). Full device E2E has not been run for this draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how static IPv4 is validated and applied to the device; misconfiguration could affect connectivity, though scope is limited to optional gateway/DNS and stricter IPv4 checks.
> 
> **Overview**
> **Static IPv4** can now be saved with only address and netmask: backend schema and `nmlite` parsing treat **gateway** and **DNS** as optional (no default route when gateway is omitted), while still rejecting invalid or IPv6 values when they are provided.
> 
> The settings UI matches that behavior—empty gateway/DNS pass validation, CIDR checks are **IPv4-only**, and empty DNS rows are stripped before `setNetworkSettings`. **Live hostname** in the device shell updates from `networkState` pushes, and the DHCP lease **`lease`** field is typed as numeric nanoseconds from Go.
> 
> Coverage adds Go unit tests for optional/invalid combinations and a Playwright flow that applies static IPv4 with blank gateway/DNS and verifies persisted settings plus hostname in network state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8274c7ccfd4dc7f5220801997682e190576195. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->