### PR TITLE
Discover video codec capabilities through RPC

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -199,6 +199,10 @@ func rpcSetStreamQualityFactor(factor float64) error {
 	return nil
 }
 
+func rpcGetSupportedVideoCodecs() []string {
+	return []string{"h264", "h265"}
+}
+
 func rpcGetVideoCodecPreference() (string, error) {
 	return config.VideoCodecPreference, nil
 }
@@ -1354,6 +1358,7 @@ var rpcHandlers = map[string]RPCHandler{
 	"sendWOLMagicPacket":         {Func: rpcSendWOLMagicPacket, Params: []string{"macAddress"}, OptionalParams: []string{"broadcastIP"}},
 	"getStreamQualityFactor":     {Func: rpcGetStreamQualityFactor},
 	"setStreamQualityFactor":     {Func: rpcSetStreamQualityFactor, Params: []string{"factor"}},
+	"getSupportedVideoCodecs":    {Func: rpcGetSupportedVideoCodecs},
 	"getVideoCodecPreference":    {Func: rpcGetVideoCodecPreference},
 	"setVideoCodecPreference":    {Func: rpcSetVideoCodecPreference, Params: []string{"codec"}},
 	"getAutoUpdateState":         {Func: rpcGetAutoUpdateState},

--- a/ui/e2e/video-codec.spec.ts
+++ b/ui/e2e/video-codec.spec.ts
@@ -175,3 +175,45 @@ test.describe("Video codec negotiation", () => {
     }
   });
 });
+
+test("codec settings use device capabilities and retain an unavailable saved preference", async ({
+  page,
+}) => {
+  test.setTimeout(90_000);
+  await page.goto("/");
+  await ensureLocalAuthMode(page, { mode: "noPassword" });
+  await waitForWebRTCReady(page);
+  const supported = await callJsonRpc(page, "getSupportedVideoCodecs");
+  expect(supported).toEqual(["h264", "h265"]);
+  const original = await callJsonRpc(page, "getVideoCodecPreference");
+  try {
+    await callJsonRpc(page, "setVideoCodecPreference", { codec: "h265" });
+    await page.goto("/settings/video", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(page);
+    const select = page.locator("select").filter({ has: page.locator('option[value="auto"]') });
+    await expect(select).toHaveValue("h265");
+    await expect(select.locator('option[value="h265"]')).toHaveJSProperty("disabled", true);
+    await expect(select.locator('option[value="h264"]')).toHaveJSProperty("disabled", false);
+    await expect(select).toBeEnabled();
+    await Promise.all([page.waitForEvent("load"), select.selectOption("h264")]);
+    await page.waitForLoadState("networkidle");
+    await waitForWebRTCReady(page);
+    expect(await callJsonRpc(page, "getVideoCodecPreference")).toBe("h264");
+    await page.goto("/", { waitUntil: "networkidle" });
+    await waitForWebRTCReady(page);
+    await wakeDisplay(page);
+    await waitForVideoStream(page);
+    expect((await getActiveCodec(page)).toLowerCase()).toContain("h264");
+    await assertBytesFlowing(page);
+    const frames = (await page.evaluate(() => window.__kvmTestHooks?.getInboundVideoStats()))!
+      .framesDecoded;
+    await expect
+      .poll(
+        async () =>
+          (await page.evaluate(() => window.__kvmTestHooks?.getInboundVideoStats()))?.framesDecoded,
+      )
+      .toBeGreaterThan(frames);
+  } finally {
+    await callJsonRpc(page, "setVideoCodecPreference", { codec: original });
+  }
+});

--- a/ui/e2e/video-codec.spec.ts
+++ b/ui/e2e/video-codec.spec.ts
@@ -2,6 +2,7 @@ import { test, expect, type Page } from "@playwright/test";
 
 import {
   ensureLocalAuthMode,
+  dismissSessionTakeoverDialog,
   waitForWebRTCReady,
   waitForVideoStream,
   wakeDisplay,
@@ -182,6 +183,7 @@ test("codec settings use device capabilities and retain an unavailable saved pre
   test.setTimeout(90_000);
   await page.goto("/");
   await ensureLocalAuthMode(page, { mode: "noPassword" });
+  await dismissSessionTakeoverDialog(page);
   await waitForWebRTCReady(page);
   const supported = await callJsonRpc(page, "getSupportedVideoCodecs");
   expect(supported).toEqual(["h264", "h265"]);
@@ -189,6 +191,7 @@ test("codec settings use device capabilities and retain an unavailable saved pre
   try {
     await callJsonRpc(page, "setVideoCodecPreference", { codec: "h265" });
     await page.goto("/settings/video", { waitUntil: "networkidle" });
+    await dismissSessionTakeoverDialog(page);
     await waitForWebRTCReady(page);
     const select = page.locator("select").filter({ has: page.locator('option[value="auto"]') });
     await expect(select).toHaveValue("h265");
@@ -197,9 +200,11 @@ test("codec settings use device capabilities and retain an unavailable saved pre
     await expect(select).toBeEnabled();
     await Promise.all([page.waitForEvent("load"), select.selectOption("h264")]);
     await page.waitForLoadState("networkidle");
+    await dismissSessionTakeoverDialog(page);
     await waitForWebRTCReady(page);
     expect(await callJsonRpc(page, "getVideoCodecPreference")).toBe("h264");
     await page.goto("/", { waitUntil: "networkidle" });
+    await dismissSessionTakeoverDialog(page);
     await waitForWebRTCReady(page);
     await wakeDisplay(page);
     await waitForVideoStream(page);

--- a/ui/e2e/video-codec.spec.ts
+++ b/ui/e2e/video-codec.spec.ts
@@ -2,7 +2,7 @@ import { test, expect, type Page } from "@playwright/test";
 
 import {
   ensureLocalAuthMode,
-  dismissSessionTakeoverDialog,
+  ensureRpcReady,
   waitForWebRTCReady,
   waitForVideoStream,
   wakeDisplay,
@@ -183,16 +183,14 @@ test("codec settings use device capabilities and retain an unavailable saved pre
   test.setTimeout(90_000);
   await page.goto("/");
   await ensureLocalAuthMode(page, { mode: "noPassword" });
-  await dismissSessionTakeoverDialog(page);
-  await waitForWebRTCReady(page);
+  await ensureRpcReady(page);
   const supported = await callJsonRpc(page, "getSupportedVideoCodecs");
   expect(supported).toEqual(["h264", "h265"]);
   const original = await callJsonRpc(page, "getVideoCodecPreference");
   try {
     await callJsonRpc(page, "setVideoCodecPreference", { codec: "h265" });
-    await page.goto("/settings/video", { waitUntil: "networkidle" });
-    await dismissSessionTakeoverDialog(page);
-    await waitForWebRTCReady(page);
+    await page.getByRole("button", { name: "Settings", exact: true }).click();
+    await page.getByRole("link", { name: "Video", exact: true }).click();
     const select = page.locator("select").filter({ has: page.locator('option[value="auto"]') });
     await expect(select).toHaveValue("h265");
     await expect(select.locator('option[value="h265"]')).toHaveJSProperty("disabled", true);
@@ -200,12 +198,10 @@ test("codec settings use device capabilities and retain an unavailable saved pre
     await expect(select).toBeEnabled();
     await Promise.all([page.waitForEvent("load"), select.selectOption("h264")]);
     await page.waitForLoadState("networkidle");
-    await dismissSessionTakeoverDialog(page);
-    await waitForWebRTCReady(page);
+    await ensureRpcReady(page);
     expect(await callJsonRpc(page, "getVideoCodecPreference")).toBe("h264");
     await page.goto("/", { waitUntil: "networkidle" });
-    await dismissSessionTakeoverDialog(page);
-    await waitForWebRTCReady(page);
+    await ensureRpcReady(page);
     await wakeDisplay(page);
     await waitForVideoStream(page);
     expect((await getActiveCodec(page)).toLowerCase()).toContain("h264");

--- a/ui/src/routes/devices.$id.settings.video.tsx
+++ b/ui/src/routes/devices.$id.settings.video.tsx
@@ -67,7 +67,7 @@ const h265Supported = (() => {
   return caps?.codecs.some(c => c.mimeType === "video/H265") ?? false;
 })();
 
-const codecOptions = h265Supported
+const browserCodecOptions = h265Supported
   ? allCodecOptions
   : allCodecOptions.filter(o => o.value !== "h265");
 
@@ -76,6 +76,21 @@ export default function SettingsVideoRoute() {
   const [streamQuality, setStreamQuality] = useState("1");
   const [streamQualityLoading, setStreamQualityLoading] = useState(true);
   const [codecPreference, setCodecPreference] = useState("auto");
+  const [supportedCodecs, setSupportedCodecs] = useState<string[] | null>(null);
+  const codecOptions = allCodecOptions
+    .filter(
+      option =>
+        option.value === codecPreference ||
+        (browserCodecOptions.includes(option) &&
+          (option.value === "auto" || supportedCodecs?.includes(option.value))),
+    )
+    .map(option => ({
+      ...option,
+      disabled:
+        option.value !== "auto" &&
+        (!browserCodecOptions.includes(option) || !supportedCodecs?.includes(option.value)),
+    }));
+
   const [disableHostDisplayWhenIdle, setDisableHostDisplayWhenIdle] = useState(false);
   const [disableHostDisplayWhenIdleLoading, setDisableHostDisplayWhenIdleLoading] = useState(true);
   const [customEdidValue, setCustomEdidValue] = useState<string | null>(null);
@@ -93,6 +108,13 @@ export default function SettingsVideoRoute() {
   } = useSettingsStore();
 
   useEffect(() => {
+    void send("getSupportedVideoCodecs", {}, (resp: JsonRpcResponse) => {
+      if ("error" in resp) return;
+      if (Array.isArray(resp.result) && resp.result.every(codec => typeof codec === "string")) {
+        setSupportedCodecs(resp.result as string[]);
+      }
+    });
+
     void send("getStreamQualityFactor", {}, (resp: JsonRpcResponse) => {
       setStreamQualityLoading(false);
       if ("error" in resp) return;
@@ -102,7 +124,7 @@ export default function SettingsVideoRoute() {
     void send("getVideoCodecPreference", {}, (resp: JsonRpcResponse) => {
       if ("error" in resp) return;
       const codec = resp.result as string;
-      const isAvailable = codecOptions.some(o => o.value === codec);
+      const isAvailable = allCodecOptions.some(o => o.value === codec);
       setCodecPreference(isAvailable ? codec : "auto");
     });
 
@@ -260,6 +282,7 @@ export default function SettingsVideoRoute() {
                 label=""
                 value={codecPreference}
                 options={codecOptions}
+                disabled={supportedCodecs === null}
                 onChange={e => handleCodecChange(e.target.value)}
               />
             </SettingsItem>

--- a/ui/src/routes/devices.$id.settings.video.tsx
+++ b/ui/src/routes/devices.$id.settings.video.tsx
@@ -77,6 +77,8 @@ export default function SettingsVideoRoute() {
   const [streamQualityLoading, setStreamQualityLoading] = useState(true);
   const [codecPreference, setCodecPreference] = useState("auto");
   const [supportedCodecs, setSupportedCodecs] = useState<string[] | null>(null);
+  const [codecLoadFailed, setCodecLoadFailed] = useState(false);
+  const [codecLoadAttempt, setCodecLoadAttempt] = useState(0);
   const codecOptions = allCodecOptions
     .filter(
       option =>
@@ -108,13 +110,31 @@ export default function SettingsVideoRoute() {
   } = useSettingsStore();
 
   useEffect(() => {
+    let active = true;
+    setSupportedCodecs(null);
+    setCodecLoadFailed(false);
+    const timeout = window.setTimeout(() => setCodecLoadFailed(true), 10000);
     void send("getSupportedVideoCodecs", {}, (resp: JsonRpcResponse) => {
-      if ("error" in resp) return;
-      if (Array.isArray(resp.result) && resp.result.every(codec => typeof codec === "string")) {
-        setSupportedCodecs(resp.result as string[]);
+      if (!active) return;
+      window.clearTimeout(timeout);
+      if (
+        "error" in resp ||
+        !Array.isArray(resp.result) ||
+        !resp.result.every(codec => typeof codec === "string")
+      ) {
+        setCodecLoadFailed(true);
+        return;
       }
+      setCodecLoadFailed(false);
+      setSupportedCodecs(resp.result as string[]);
     });
+    return () => {
+      active = false;
+      window.clearTimeout(timeout);
+    };
+  }, [send, codecLoadAttempt]);
 
+  useEffect(() => {
     void send("getStreamQualityFactor", {}, (resp: JsonRpcResponse) => {
       setStreamQualityLoading(false);
       if ("error" in resp) return;
@@ -276,7 +296,11 @@ export default function SettingsVideoRoute() {
               />
             </SettingsItem>
 
-            <SettingsItem title={m.video_codec_title()} description={m.video_codec_description()}>
+            <SettingsItem
+              title={m.video_codec_title()}
+              description={m.video_codec_description()}
+              loading={supportedCodecs === null && !codecLoadFailed}
+            >
               <SelectMenuBasic
                 size="SM"
                 label=""
@@ -285,6 +309,15 @@ export default function SettingsVideoRoute() {
                 disabled={supportedCodecs === null}
                 onChange={e => handleCodecChange(e.target.value)}
               />
+              {codecLoadFailed && (
+                <Button
+                  data-testid="video-codec-retry"
+                  size="SM"
+                  theme="light"
+                  text={m.retry()}
+                  onClick={() => setCodecLoadAttempt(attempt => attempt + 1)}
+                />
+              )}
             </SettingsItem>
 
             <SettingsItem

--- a/ui/tests/video-codec-retry.mjs
+++ b/ui/tests/video-codec-retry.mjs
@@ -1,0 +1,115 @@
+import assert from "node:assert/strict";
+import { fileURLToPath } from "node:url";
+import { rolldown } from "rolldown";
+import { chromium } from "playwright";
+
+const entry = fileURLToPath(new URL("./video-codec-entry.tsx", import.meta.url));
+const route = fileURLToPath(
+  new URL("../src/routes/devices.$id.settings.video.tsx", import.meta.url),
+);
+const bundle = await rolldown({
+  input: entry,
+  transform: { define: { "process.env.NODE_ENV": '"production"' } },
+  plugins: [
+    {
+      name: "video-settings-harness",
+      resolveId(source) {
+        if (source === entry || source === route) return source;
+        if (source.startsWith("@")) return "\0" + source;
+      },
+      load(id) {
+        if (id === entry)
+          return `
+        import { createElement } from 'react';
+        import { createRoot } from 'react-dom/client';
+        import Route from ${JSON.stringify(route)};
+        window.requests = [];
+        window.send = (method, params, callback) => {
+          if (method === 'getSupportedVideoCodecs') window.requests.push(callback);
+        };
+        createRoot(document.getElementById('root')).render(createElement(Route));
+      `;
+        if (id === "\0@/hooks/useJsonRpc")
+          return "export const useJsonRpc = () => ({send: window.send});";
+        if (id === "\0@hooks/stores")
+          return "export const useSettingsStore = () => ({videoSaturation: 50, videoBrightness: 50, videoContrast: 50});";
+        if (id === "\0@/utils") return "export const isLinuxDesktop = () => false;";
+        if (id === "\0@/notifications") return "export default {error() {}, success() {}};";
+        if (id === "\0@localizations/messages.js")
+          return "export const m = new Proxy({}, {get: (_, key) => () => key});";
+        if (id === "\0@components/SelectMenuBasic")
+          return `
+        import {createElement as h} from 'react';
+        export const SelectMenuBasic = ({options, disabled, value, onChange}) =>
+          h('select', {disabled, value, onChange}, options.map(o => h('option', {key:o.value, value:o.value, disabled:o.disabled}, o.label)));
+      `;
+        if (id === "\0@components/Button")
+          return `
+        import {createElement as h} from 'react';
+        export const Button = ({text, onClick, disabled}) => h('button', {onClick, disabled}, text);
+      `;
+        if (id.startsWith("\0@components/")) {
+          const name = id.split("/").pop();
+          const exported =
+            { SettingsPageheader: "SettingsPageHeader", TextArea: "TextAreaWithLabel" }[name] ||
+            name;
+          return `import {createElement as h} from 'react';
+          const Component = ({children,title,loading}) => h('div', {'data-title':title,'data-loading':String(!!loading)}, children);
+          export {Component as ${exported}}; export default Component;`;
+        }
+      },
+    },
+  ],
+});
+const { output } = await bundle.generate({ format: "iife" });
+await bundle.close();
+const browser = await chromium.launch({
+  executablePath: process.env.CHROME_BIN,
+  headless: true,
+  args: ["--no-sandbox"],
+});
+try {
+  const page = await browser.newPage();
+  page.on("pageerror", error => console.error(error));
+  await page.clock.install();
+  await page.setContent('<div id="root"></div>');
+  await page.evaluate(() => {
+    RTCRtpReceiver.getCapabilities = () => ({ codecs: [{ mimeType: "video/H265" }] });
+  });
+  await page.addScriptTag({ content: output[0].code });
+  const section = page.locator('[data-title="video_codec_title"]');
+  const select = section.locator("select");
+  const retry = section.getByRole("button", { name: "retry", exact: true });
+  await page.waitForFunction(() => window.requests.length === 1);
+  assert(await select.isDisabled());
+  await page.evaluate(() =>
+    window.requests[0]({ error: { code: -32000, message: "temporary failure" } }),
+  );
+  await retry.waitFor();
+  assert.equal(await section.getAttribute("data-loading"), "false");
+  await retry.click();
+  await page.waitForFunction(() => window.requests.length === 2);
+  await page.evaluate(() => window.requests[1]({ result: { invalid: true } }));
+  await retry.waitFor();
+  await retry.click();
+  await page.waitForFunction(() => window.requests.length === 3);
+  await page.clock.fastForward(10000);
+  await retry.waitFor();
+  await retry.click();
+  await page.waitForFunction(() => window.requests.length === 4);
+  // An older attempt must not enable the selector while its replacement is pending.
+  await page.evaluate(() => window.requests[2]({ result: ["h264", "h265"] }));
+  assert(await select.isDisabled());
+  await page.evaluate(() => window.requests[3]({ result: ["h264"] }));
+  await page.waitForFunction(
+    () => !document.querySelector('[data-title="video_codec_title"] select').disabled,
+  );
+  assert.equal(await retry.count(), 0);
+  assert.deepEqual(
+    await select.locator("option").evaluateAll(options => options.map(o => o.value)),
+    ["auto", "h264"],
+  );
+  console.log("Codec RPC error, invalid response, timeout, stale reply and retry recovery: OK");
+} finally {
+  await browser.close();
+}


### PR DESCRIPTION
### Summary

The codec selector currently considers browser support but assumes the device can encode every listed codec. Add `getSupportedVideoCodecs` and filter choices by both device and browser capabilities. Keep a saved unsupported preference visible but disabled, and disable the selector while capabilities are loading. Failed, malformed, or timed-out requests expose a Retry action; abandoned requests cannot replace a newer result.

The firmware returns its supported H.264/H.265 codecs. This UI and RPC are intended to ship together in the matching version.

### Validation

`CHROME_BIN=/usr/bin/google-chrome node tests/video-codec-retry.mjs` passes: RPC errors, malformed responses, timeout, stale replies and successful retry are covered against the actual video settings route.

`go test . -run '^TestNonexistent$'` passes, compiling the application and RPC registration.

UI lint passes with existing warnings; `npx vite build --mode=device` passes. `npx tsc -b` reports the same diagnostics as unchanged `dev` at d58e6e44 (compared after normalizing line numbers). Full device E2E has not been run for this draft.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes video codec selection and a new RPC surface that UI and firmware must ship together; mis-sync could hide valid codecs or leave users on unsupported choices, though existing preference validation on the backend is unchanged.
> 
> **Overview**
> Adds a **`getSupportedVideoCodecs`** JSON-RPC method on the device (currently **`h264`** and **`h265`**) so the Video settings page no longer assumes the host can encode every browser-advertised codec.
> 
> The codec dropdown now loads device capabilities over RPC, stays disabled until they arrive, and builds options from **both** browser decode support and device encode support. A stored preference that the device or browser cannot use stays selected but appears as a **disabled** option instead of being silently reset. Failed, invalid, or timed-out capability fetches show a **Retry** control; in-flight requests are cancelled so stale responses cannot enable the selector after a newer attempt.
> 
> Coverage includes a Playwright E2E path for RPC + settings + live **H.264** streaming, and a bundled **`video-codec-retry.mjs`** harness for error, timeout, stale-reply, and recovery behavior on the real settings route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e687bdcd47e7c9e893fa8e259d9b0ee652e0953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->