### PR TITLE
Preserve replacement audio during stale session teardown

### DIFF
--- a/webrtc.go
+++ b/webrtc.go
@@ -697,7 +697,8 @@ func onSessionConnected(session *Session) {
 func onLastSessionDisconnected() {
 	// Safety net: ensure all keys are released when the last session disconnects
 	_ = rpcKeyboardReport(0, keyboardClearStateKeys)
-	stopAudio()
+	// The closing session already released its own audio capture. A replacement
+	// may have connected since the zero-session decision, so do not stop its audio.
 	_ = nativeInstance.VideoStop()
 	_ = applyHostDisplayAdvertisement("last_session_disconnected")
 	startVideoSleepModeTicker()

--- a/webrtc_test.go
+++ b/webrtc_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/jetkvm/kvm/internal/native"
+	"github.com/jetkvm/kvm/internal/usbgadget"
 	"github.com/pion/webrtc/v4"
 )
 
@@ -59,5 +60,90 @@ func TestStartNativeVideoForSessionSetsCodecBeforeStart(t *testing.T) {
 				t.Fatalf("native calls = %v, want %v", recorder.calls, tt.want)
 			}
 		})
+	}
+}
+
+func TestLastSessionDisconnectedPreservesReplacementAudio(t *testing.T) {
+	// Do not run in parallel: this exercises the package's global session state.
+	track, err := webrtc.NewTrackLocalStaticSample(
+		webrtc.RTPCodecCapability{MimeType: webrtc.MimeTypePCMU, ClockRate: 8000}, "audio", "replacement")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	originalNative, originalConfig := nativeInstance, config
+	nativeInstance = &recordingNative{} // EmptyNativeInterface disables sleep-mode support.
+	config = &Config{VideoSleepAfterSec: -1}
+	hostDisplayAdvertiseLock.Lock()
+	originalAdvertised := hostDisplayAdvertised
+	hostDisplayAdvertised = true // Avoid an EDID update during teardown.
+	hostDisplayAdvertiseLock.Unlock()
+	usbStateLock.Lock()
+	originalUSBState := usbState
+	usbState = usbgadget.USBStateNotAttached // Keyboard clear must not touch HID.
+	usbStateLock.Unlock()
+	activeSessionsMutex.Lock()
+	originalSessions := actionSessions
+	actionSessions = 1
+	activeSessionsMutex.Unlock()
+	audioMu.Lock()
+	originalTrack, originalCancel, originalStopped := audioTrack, audioCancel, audioStopped
+	audioMu.Unlock()
+	t.Cleanup(func() {
+		audioMu.Lock()
+		audioTrack, audioCancel, audioStopped = originalTrack, originalCancel, originalStopped
+		audioMu.Unlock()
+		activeSessionsMutex.Lock()
+		actionSessions = originalSessions
+		activeSessionsMutex.Unlock()
+		usbStateLock.Lock()
+		usbState = originalUSBState
+		usbStateLock.Unlock()
+		hostDisplayAdvertiseLock.Lock()
+		hostDisplayAdvertised = originalAdvertised
+		hostDisplayAdvertiseLock.Unlock()
+		nativeInstance, config = originalNative, originalConfig
+	})
+
+	// Reproduce the interleaving without scheduler timing: old teardown has
+	// already performed its owner-specific stop and decided it was last.
+	if remaining := decrActiveSessions(); remaining != 0 {
+		t.Fatalf("old session left %d sessions, want 0", remaining)
+	}
+	// Before that teardown resumes, a replacement connects and owns capture.
+	if active := incrActiveSessions(); active != 1 {
+		t.Fatalf("replacement has %d sessions, want 1", active)
+	}
+	canceled := false
+	stopped := make(chan struct{})
+	close(stopped) // No capture goroutine or ALSA device is needed.
+	audioMu.Lock()
+	audioTrack = track
+	audioCancel = func() { canceled = true }
+	audioStopped = stopped
+	audioMu.Unlock()
+
+	onLastSessionDisconnected()
+
+	audioMu.Lock()
+	if canceled {
+		t.Error("stale last-session teardown canceled replacement audio capture")
+	}
+	if audioTrack != track || audioCancel == nil || audioStopped != stopped {
+		t.Error("stale last-session teardown discarded replacement audio ownership")
+	}
+	canceled = false
+	audioMu.Unlock()
+
+	// The replacement's own teardown must still release its capture.
+	stopAudioIfOwner(track)
+
+	audioMu.Lock()
+	defer audioMu.Unlock()
+	if !canceled {
+		t.Error("owner teardown did not cancel replacement audio capture")
+	}
+	if audioTrack != nil || audioCancel != nil || audioStopped != nil {
+		t.Error("owner teardown did not clear replacement audio ownership")
 	}
 }


### PR DESCRIPTION
A disconnect can decide it was the last session before a replacement starts audio capture. Remove the redundant unconditional audio stop so stale teardown preserves the replacement; the earlier owner-specific stop handles legitimate cleanup.

Add a deterministic Linux ARM regression covering replacement preservation and subsequent owner cleanup.

Validation:
- Host Go tests and vet pass.
- The ARM regression fails against the original teardown and passes 20 times with the fix.
- Six independent hardware E2E checks pass: audio playback and USB audio attachment across streaming toggles, each repeated three times.

Combined validation: 94/94 selected non-OTA E2E tests pass with no skips or flaky results, followed by an additional HID recovery check and 96 stress rounds / 960 letters with zero failed rounds. The full host Go race suite passes.
