### PR TITLE
Copy log buffers before asynchronous stream delivery

### DIFF
--- a/internal/logging/logger.go
+++ b/internal/logging/logger.go
@@ -36,9 +36,11 @@ func (w *logOutput) Write(p []byte) (n int, err error) {
 
 	// TODO: write to file or syslog
 	if sseServer != nil {
+		// The caller may reuse p as soon as Write returns.
+		message := string(p)
 		// use a goroutine to avoid blocking the Write method
 		go func() {
-			sseServer.Message <- string(p)
+			sseServer.Message <- message
 		}()
 	}
 	return len(p), nil

--- a/internal/logging/logger_test.go
+++ b/internal/logging/logger_test.go
@@ -1,0 +1,39 @@
+package logging
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestLogOutputOwnsMessageAfterWrite(t *testing.T) {
+	// Keep this test serial: logOutput uses the package-wide SSE server.
+	originalServer := sseServer
+	server := &sseEvent{Message: make(chan string)}
+	sseServer = server
+	t.Cleanup(func() { sseServer = originalServer })
+
+	output := &logOutput{mu: &sync.Mutex{}}
+	buffer := make([]byte, 0, 128)
+	for i := 0; i < 64; i++ {
+		want := fmt.Sprintf("{\"message\":\"entry %d\"}\n", i)
+		buffer = append(buffer[:0], want...)
+		n, err := output.Write(buffer)
+		if err != nil || n != len(buffer) {
+			t.Fatalf("Write() = (%d, %v), want (%d, nil)", n, err, len(buffer))
+		}
+
+		// A writer's caller may immediately overwrite and reuse its buffer,
+		// even while an asynchronous consumer is not ready to receive.
+		clear(buffer)
+		select {
+		case got := <-server.Message:
+			if got != want {
+				t.Fatalf("message after buffer reuse = %q, want %q", got, want)
+			}
+		case <-time.After(5 * time.Second):
+			t.Fatal("timed out waiting for log message")
+		}
+	}
+}


### PR DESCRIPTION
Copy log messages before asynchronous delivery so callers can immediately reuse their buffers without corrupting streamed logs.

Add a buffer-reuse regression that fails against the previous implementation.

Validation:
- Logging tests and vet pass.
- 300 race-enabled regression runs pass.
- Two independent hardware E2E checks pass: live log filtering and log-level behavior after reboot.
- The authenticated live log stream received 85 probe messages with no invalid JSON during 100 emitted probes; delivery is best-effort.

Combined validation: 94/94 selected non-OTA E2E tests pass with no skips or flaky results, followed by an additional HID recovery check and 96 stress rounds / 960 letters with zero failed rounds. The full host Go race suite passes.
