### PR TITLE
Allow brief HID write backpressure without dropping reports

### DIFF
--- a/internal/usbgadget/consts.go
+++ b/internal/usbgadget/consts.go
@@ -6,6 +6,8 @@ const dwc3Path = "/sys/bus/platform/drivers/dwc3"
 
 const udcClassPath = "/sys/class/udc"
 
-const hidWriteTimeout = 10 * time.Millisecond
+// Leave room for host polling and scheduler delays while the previous HID
+// report is pending. A 10 ms deadline drops reports during ordinary bursts.
+const hidWriteTimeout = 100 * time.Millisecond
 
 const hidProbeWriteTimeout = 500 * time.Millisecond

--- a/internal/usbgadget/hid_write_recovery_test.go
+++ b/internal/usbgadget/hid_write_recovery_test.go
@@ -1,12 +1,47 @@
 package usbgadget
 
 import (
+	"bytes"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/rs/zerolog"
 )
+
+func TestWriteTimeoutLoggingResumesAfterSuccessfulWrite(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+
+	var logs bytes.Buffer
+	logger := zerolog.New(&logs)
+	u := newTestGadgetWithKeyboard(w)
+	u.log = &logger
+	report := make([]byte, hidKeyBufferSize)
+
+	// Consecutive timeouts produce one error, but a new timeout after a
+	// successful write must be visible even if it is an isolated failure.
+	for episode := 1; episode <= 2; episode++ {
+		fillPipeBuffer(t, w)
+		for range 2 {
+			if err := u.keyboardWriteHidFileLocked(0, report); err != nil {
+				t.Fatalf("timed-out write: %v", err)
+			}
+		}
+		if got := strings.Count(logs.String(), "write timed out:"); got != episode {
+			t.Fatalf("after episode %d: got %d timeout logs, want %d", episode, got, episode)
+		}
+		drainPipe(t, r)
+		if err := u.keyboardWriteHidFileLocked(0, report); err != nil {
+			t.Fatalf("successful write: %v", err)
+		}
+	}
+}
 
 func fillPipeBuffer(t *testing.T, w *os.File) {
 	t.Helper()

--- a/internal/usbgadget/hid_write_recovery_test.go
+++ b/internal/usbgadget/hid_write_recovery_test.go
@@ -2,6 +2,7 @@ package usbgadget
 
 import (
 	"bytes"
+	"io"
 	"os"
 	"strings"
 	"testing"
@@ -9,6 +10,33 @@ import (
 
 	"github.com/rs/zerolog"
 )
+
+func TestHIDWriteSurvivesBriefBackpressure(t *testing.T) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer r.Close()
+	defer w.Close()
+	fillPipeBuffer(t, w)
+
+	// The previous report can remain pending while the host or the device
+	// is briefly descheduled. The next report must wait, not disappear.
+	drained := make(chan error, 1)
+	go func() {
+		time.Sleep(25 * time.Millisecond)
+		_, err := io.CopyN(io.Discard, r, 4096)
+		drained <- err
+	}()
+	report := []byte{2, 0, 6, 0, 0, 0, 0, 0}
+	n, err := newTestGadgetWithKeyboard(w).writeWithTimeout(w, report)
+	if drainErr := <-drained; drainErr != nil {
+		t.Fatal(drainErr)
+	}
+	if err != nil || n != len(report) {
+		t.Fatalf("report lost during brief backpressure: wrote %d/%d bytes, error %v", n, len(report), err)
+	}
+}
 
 func TestWriteTimeoutLoggingResumesAfterSuccessfulWrite(t *testing.T) {
 	r, w, err := os.Pipe()

--- a/internal/usbgadget/hid_write_recovery_test.go
+++ b/internal/usbgadget/hid_write_recovery_test.go
@@ -12,6 +12,17 @@ import (
 )
 
 func TestHIDWriteSurvivesBriefBackpressure(t *testing.T) {
+	const maxAttempts = 5
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		if tryHIDWriteWithBriefBackpressure(t, attempt) {
+			return
+		}
+	}
+	t.Fatalf("no valid backpressure timing window in %d attempts", maxAttempts)
+}
+
+func tryHIDWriteWithBriefBackpressure(t *testing.T, attempt int) bool {
+	t.Helper()
 	r, w, err := os.Pipe()
 	if err != nil {
 		t.Fatal(err)
@@ -19,23 +30,57 @@ func TestHIDWriteSurvivesBriefBackpressure(t *testing.T) {
 	defer r.Close()
 	defer w.Close()
 	fillPipeBuffer(t, w)
+	if err := r.SetReadDeadline(time.Now().Add(time.Second)); err != nil {
+		t.Fatal(err)
+	}
 
 	// The previous report can remain pending while the host or the device
 	// is briefly descheduled. The next report must wait, not disappear.
-	drained := make(chan error, 1)
+	type drainResult struct {
+		started, finished time.Time
+		err               error
+	}
+	start := make(chan struct{})
+	drained := make(chan drainResult, 1)
 	go func() {
+		<-start
 		time.Sleep(25 * time.Millisecond)
+		started := time.Now()
 		_, err := io.CopyN(io.Discard, r, 4096)
-		drained <- err
+		drained <- drainResult{started, time.Now(), err}
 	}()
 	report := []byte{2, 0, 6, 0, 0, 0, 0, 0}
-	n, err := newTestGadgetWithKeyboard(w).writeWithTimeout(w, report)
-	if drainErr := <-drained; drainErr != nil {
-		t.Fatal(drainErr)
+	u := newTestGadgetWithKeyboard(w)
+	started := time.Now()
+	close(start)
+	n, err := u.writeWithTimeout(w, report)
+	finished := time.Now()
+	drain := <-drained
+	if os.IsTimeout(drain.err) {
+		t.Logf("attempt %d: pipe setup/drain missed its deadline", attempt)
+		return false
+	}
+	if drain.err != nil {
+		t.Fatal(drain.err)
+	}
+	// The drain must occur after the old 10 ms deadline, with headroom before
+	// the new 100 ms deadline. Oversleeping the intended window is a fixture
+	// scheduling failure, not evidence that a report was dropped.
+	if drain.started.Sub(started) < 20*time.Millisecond || drain.finished.Sub(started) > 75*time.Millisecond {
+		t.Logf("attempt %d: invalid drain window [%v, %v]", attempt, drain.started.Sub(started), drain.finished.Sub(started))
+		return false
+	}
+	if n == len(report) && err == nil && (finished.Before(drain.started) || finished.Sub(started) > hidWriteTimeout) {
+		// An early success did not encounter backpressure. A success outside
+		// the write budget may have started late after the caller was paused;
+		// do not let that make the old 10 ms implementation appear to pass.
+		t.Logf("attempt %d: invalid successful write duration %v", attempt, finished.Sub(started))
+		return false
 	}
 	if err != nil || n != len(report) {
 		t.Fatalf("report lost during brief backpressure: wrote %d/%d bytes, error %v", n, len(report), err)
 	}
+	return true
 }
 
 func TestWriteTimeoutLoggingResumesAfterSuccessfulWrite(t *testing.T) {

--- a/internal/usbgadget/utils.go
+++ b/internal/usbgadget/utils.go
@@ -120,6 +120,7 @@ func (u *UsbGadget) writeWithTimeout(file *os.File, data []byte) (n int, err err
 	n, err = file.Write(data)
 	if err == nil {
 		u.resetHidWriteTimeoutStreak(file.Name())
+		u.resetLogSuppressionCounter(fmt.Sprintf("writeWithTimeout_%s", file.Name()))
 		return
 	}
 
@@ -198,9 +199,7 @@ func (u *UsbGadget) resetLogSuppressionCounter(counterName string) {
 	u.logSuppressionLock.Lock()
 	defer u.logSuppressionLock.Unlock()
 
-	if _, ok := u.logSuppressionCounter[counterName]; !ok {
-		u.logSuppressionCounter[counterName] = 0
-	}
+	delete(u.logSuppressionCounter, counterName)
 }
 
 func unlockWithLog(lock *sync.Mutex, logger *zerolog.Logger, msg string, args ...any) {


### PR DESCRIPTION
A brief host scheduling delay can keep the previous HID report pending beyond the 10 ms write deadline, dropping the next key transition. Allow up to 100 ms of backpressure while retaining bounded writes and the existing repeated-timeout recovery.

Reset timeout-log suppression after a successful write so a later isolated timeout is visible. Add real-pipe regressions for delayed draining and separate timeout episodes.

Validation:
- Host Go tests pass.
- Both new regressions pass 20 times with the race detector.
- Independent hardware stress passes with storage disabled and enabled: 163 rounds, 1,630 letters, zero missing key transitions.
- The backpressure regression fails against the original 10 ms deadline.

The full isolated race suite also reproduces an existing asynchronous logging-buffer race; it passes with the separate logging fix included.

Combined validation: 94/94 selected non-OTA E2E tests pass with no skips or flaky results, followed by an additional HID recovery check and 96 stress rounds / 960 letters with zero failed rounds. The full host Go race suite passes.
