### PR TITLE
Prevent delayed macro cancellation from stopping its replacement

### DIFF
--- a/hid_macro_cancel_test.go
+++ b/hid_macro_cancel_test.go
@@ -1,0 +1,56 @@
+//go:build linux && arm
+
+package kvm
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jetkvm/kvm/internal/hidrpc"
+	"github.com/pion/webrtc/v4"
+	"github.com/rs/zerolog"
+)
+
+func TestHidMacroCancelCannotReachReplacement(t *testing.T) {
+	defer setKeyboardMacroCancel(nil)
+	session := &Session{done: make(chan struct{})}
+	session.initQueues()
+	log := zerolog.Nop()
+	handle := getOnHidMessageHandler(session, &log, "hidrpc")
+	old, cancelOld := context.WithCancel(context.Background())
+	defer cancelOld()
+	setKeyboardMacroCancel(cancelOld)
+
+	// Hold the control queue idle while the ordered channel delivers cancel.
+	// The old macro can finish naturally before that queue gets CPU time.
+	handle(webrtc.DataChannelMessage{Data: []byte{byte(hidrpc.TypeCancelKeyboardMacroReport)}})
+	replacement, cancelReplacement := context.WithCancel(context.Background())
+	defer cancelReplacement()
+	setKeyboardMacroCancel(cancelReplacement)
+	for len(session.hidQueue[3]) > 0 {
+		onHidMessage(<-session.hidQueue[3], session)
+	}
+	if replacement.Err() != nil {
+		t.Fatal("the previous macro's queued cancellation stopped its replacement")
+	}
+	if old.Err() != context.Canceled {
+		t.Fatal("the running macro was not canceled before admitting its replacement")
+	}
+}
+
+func TestClosedHidSessionCannotCancelMacro(t *testing.T) {
+	defer setKeyboardMacroCancel(nil)
+	session := &Session{done: make(chan struct{})}
+	session.initQueues()
+	session.close()
+	log := zerolog.Nop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	setKeyboardMacroCancel(cancel)
+	getOnHidMessageHandler(session, &log, "hidrpc")(
+		webrtc.DataChannelMessage{Data: []byte{byte(hidrpc.TypeCancelKeyboardMacroReport)}},
+	)
+	if ctx.Err() != nil {
+		t.Fatal("a closed session canceled the active macro")
+	}
+}

--- a/webrtc.go
+++ b/webrtc.go
@@ -402,6 +402,16 @@ func getOnHidMessageHandler(session *Session, scopedLogger *zerolog.Logger, chan
 
 		l.Trace().Msg("received data in HID RPC message handler")
 
+		// Cancel before admitting the next message on this ordered channel.
+		// A separate worker can process a late cancel after the old macro has
+		// finished and its replacement has started, canceling the replacement.
+		if hidrpc.MessageType(msg.Data[0]) == hidrpc.TypeCancelKeyboardMacroReport {
+			if !session.isClosed() {
+				rpcCancelKeyboardMacro()
+			}
+			return
+		}
+
 		// Enqueue to ensure ordered processing
 		queueIndex := hidrpc.GetQueueIndex(hidrpc.MessageType(msg.Data[0]))
 		if queueIndex >= len(session.hidQueue) || queueIndex < 0 {


### PR DESCRIPTION
Rapidly replacing a keyboard macro can stop its replacement after the first key. Macro execution and cancellation use separate workers: if the old macro finishes naturally before its queued cancel runs, the cancel can reach the new macro instead. The final hardware E2E run reproduced this when replacing Ctrl+A with A → B → C: the complete sequence was sent, but only A reached the host.

Apply cancellation in the HID receive callback before accepting the next message, while continuing to ignore input from closed sessions. This preserves the existing wire protocol and UI behavior.

Adds ARM regressions for delayed cancellation reaching a replacement and cancellation arriving from a closed session. The first regression fails against the original code; both pass 100 repetitions with the fix. The host Go race suite passes. All 20 hardware E2E repetitions covering the original failure and paste-to-toolbar handoff pass with no retries or skips.

The full hardware E2E suite passes 95/95 with no retries or skips. An additional forced HID-write recovery check passes, followed by a 90-second typing stress test delivering 860 letters with every expected key and modifier press/release received exactly once.
