### PR TITLE
Show loading states when submitting password settings

### DIFF
--- a/ui/src/routes/devices.$id.settings.access.local-auth.tsx
+++ b/ui/src/routes/devices.$id.settings.access.local-auth.tsx
@@ -31,9 +31,12 @@ export default function SecurityAccessLocalAuthRoute() {
 export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
   const { modalView, setModalView } = useLocalAuthModalStore();
   const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
   const revalidator = useRevalidator();
 
   const handleCreatePassword = async (password: string, confirmPassword: string) => {
+    if (isSubmitting) return;
+
     if (password === "") {
       setError(m.local_auth_error_enter_password());
       return;
@@ -54,6 +57,8 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
       return;
     }
 
+    setError(null);
+    setIsSubmitting(true);
     try {
       const res = await api.POST("/auth/password-local", { password });
       if (res.ok) {
@@ -67,6 +72,8 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
     } catch (error) {
       console.error(error);
       setError(m.local_auth_error_setting_password());
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -75,6 +82,8 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
     newPassword: string,
     confirmNewPassword: string,
   ) => {
+    if (isSubmitting) return;
+
     if (oldPassword === "") {
       setError(m.local_auth_error_enter_old_password());
       return;
@@ -101,6 +110,8 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
       return;
     }
 
+    setError(null);
+    setIsSubmitting(true);
     try {
       const res = await api.PUT("/auth/password-local", {
         oldPassword,
@@ -118,15 +129,21 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
     } catch (error) {
       console.error(error);
       setError(m.local_auth_error_changing_password());
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   const handleDeletePassword = async (password: string) => {
+    if (isSubmitting) return;
+
     if (password === "") {
       setError(m.local_auth_error_enter_current_password());
       return;
     }
 
+    setError(null);
+    setIsSubmitting(true);
     try {
       const res = await api.DELETE("/auth/local-password", { password });
       if (res.ok) {
@@ -140,6 +157,8 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
     } catch (error) {
       console.error(error);
       setError(m.local_auth_error_disabling_password());
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -151,6 +170,7 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
             onSetPassword={handleCreatePassword}
             onCancel={onClose}
             error={error}
+            isSubmitting={isSubmitting}
           />
         )}
 
@@ -159,6 +179,7 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
             onDeletePassword={handleDeletePassword}
             onCancel={onClose}
             error={error}
+            isSubmitting={isSubmitting}
           />
         )}
 
@@ -167,6 +188,7 @@ export function Dialog({ onClose }: Readonly<{ onClose: () => void }>) {
             onUpdatePassword={handleUpdatePassword}
             onCancel={onClose}
             error={error}
+            isSubmitting={isSubmitting}
           />
         )}
 
@@ -202,10 +224,12 @@ function CreatePasswordModal({
   onSetPassword,
   onCancel,
   error,
+  isSubmitting,
 }: {
   onSetPassword: (password: string, confirmPassword: string) => void;
   onCancel: () => void;
   error: string | null;
+  isSubmitting: boolean;
 }) {
   const [password, setPassword] = useState("");
   const [confirmPassword, setConfirmPassword] = useState("");
@@ -214,8 +238,10 @@ function CreatePasswordModal({
     <div className="flex flex-col items-start justify-start space-y-4 text-left">
       <form
         className="space-y-4"
+        aria-busy={isSubmitting}
         onSubmit={e => {
           e.preventDefault();
+          onSetPassword(password, confirmPassword);
         }}
       >
         <div>
@@ -227,6 +253,7 @@ function CreatePasswordModal({
         <InputFieldWithLabel
           label={m.local_auth_create_new_password_label()}
           type="password"
+          disabled={isSubmitting}
           placeholder={m.local_auth_create_new_password_placeholder()}
           value={password}
           autoFocus
@@ -235,6 +262,7 @@ function CreatePasswordModal({
         <InputFieldWithLabel
           label={m.local_auth_confirm_new_password_label()}
           type="password"
+          disabled={isSubmitting}
           placeholder={m.local_auth_create_confirm_password_placeholder()}
           value={confirmPassword}
           onChange={e => setConfirmPassword(e.target.value)}
@@ -245,12 +273,16 @@ function CreatePasswordModal({
             size="SM"
             theme="primary"
             text={m.local_auth_create_secure_button()}
-            onClick={() => onSetPassword(password, confirmPassword)}
+            type="submit"
+            loading={isSubmitting}
+            disabled={isSubmitting}
           />
           <Button
             size="SM"
             theme="light"
             text={m.local_auth_create_not_now_button()}
+            type="button"
+            disabled={isSubmitting}
             onClick={onCancel}
           />
         </div>
@@ -264,16 +296,25 @@ function DeletePasswordModal({
   onDeletePassword,
   onCancel,
   error,
+  isSubmitting,
 }: {
   onDeletePassword: (password: string) => void;
   onCancel: () => void;
   error: string | null;
+  isSubmitting: boolean;
 }) {
   const [password, setPassword] = useState("");
 
   return (
     <div className="flex flex-col items-start justify-start space-y-4 text-left">
-      <div className="space-y-4">
+      <form
+        className="space-y-4"
+        aria-busy={isSubmitting}
+        onSubmit={e => {
+          e.preventDefault();
+          onDeletePassword(password);
+        }}
+      >
         <div>
           <h2 className="text-lg font-semibold dark:text-white">
             {m.local_auth_disable_local_device_protection_title()}
@@ -285,6 +326,7 @@ function DeletePasswordModal({
         <InputFieldWithLabel
           label={m.local_auth_current_password_label()}
           type="password"
+          disabled={isSubmitting}
           placeholder={m.local_auth_enter_current_password_placeholder()}
           value={password}
           onChange={e => setPassword(e.target.value)}
@@ -294,12 +336,21 @@ function DeletePasswordModal({
             size="SM"
             theme="danger"
             text={m.local_auth_disable_protection_button()}
-            onClick={() => onDeletePassword(password)}
+            type="submit"
+            loading={isSubmitting}
+            disabled={isSubmitting}
           />
-          <Button size="SM" theme="light" text={m.cancel()} onClick={onCancel} />
+          <Button
+            size="SM"
+            theme="light"
+            text={m.cancel()}
+            type="button"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          />
         </div>
         {error && <p className="text-sm text-red-500">{error}</p>}
-      </div>
+      </form>
     </div>
   );
 }
@@ -308,10 +359,12 @@ function UpdatePasswordModal({
   onUpdatePassword,
   onCancel,
   error,
+  isSubmitting,
 }: {
   onUpdatePassword: (oldPassword: string, newPassword: string, confirmNewPassword: string) => void;
   onCancel: () => void;
   error: string | null;
+  isSubmitting: boolean;
 }) {
   const [oldPassword, setOldPassword] = useState("");
   const [newPassword, setNewPassword] = useState("");
@@ -321,8 +374,10 @@ function UpdatePasswordModal({
     <div className="flex flex-col items-start justify-start space-y-4 text-left">
       <form
         className="space-y-4"
+        aria-busy={isSubmitting}
         onSubmit={e => {
           e.preventDefault();
+          onUpdatePassword(oldPassword, newPassword, confirmNewPassword);
         }}
       >
         <div>
@@ -336,6 +391,7 @@ function UpdatePasswordModal({
         <InputFieldWithLabel
           label={m.local_auth_current_password_label()}
           type="password"
+          disabled={isSubmitting}
           placeholder={m.local_auth_enter_current_password_placeholder()}
           value={oldPassword}
           onChange={e => setOldPassword(e.target.value)}
@@ -343,6 +399,7 @@ function UpdatePasswordModal({
         <InputFieldWithLabel
           label={m.local_auth_new_password_label()}
           type="password"
+          disabled={isSubmitting}
           placeholder={m.local_auth_enter_new_password_placeholder()}
           value={newPassword}
           onChange={e => setNewPassword(e.target.value)}
@@ -350,6 +407,7 @@ function UpdatePasswordModal({
         <InputFieldWithLabel
           label={m.local_auth_confirm_new_password_label()}
           type="password"
+          disabled={isSubmitting}
           placeholder={m.local_auth_reenter_new_password_placeholder()}
           value={confirmNewPassword}
           onChange={e => setConfirmNewPassword(e.target.value)}
@@ -359,9 +417,18 @@ function UpdatePasswordModal({
             size="SM"
             theme="primary"
             text={m.local_auth_update_password_button()}
-            onClick={() => onUpdatePassword(oldPassword, newPassword, confirmNewPassword)}
+            type="submit"
+            loading={isSubmitting}
+            disabled={isSubmitting}
           />
-          <Button size="SM" theme="light" text={m.cancel()} onClick={onCancel} />
+          <Button
+            size="SM"
+            theme="light"
+            text={m.cancel()}
+            type="button"
+            disabled={isSubmitting}
+            onClick={onCancel}
+          />
         </div>
         {error && <p className="text-sm text-red-500">{error}</p>}
       </form>


### PR DESCRIPTION
### Summary

Creating, changing, or disabling a password currently leaves the form active with no indication that a request is in progress. Show the existing button spinner and disable the password fields, submit button, and cancel button until the request finishes.

Guard against repeated submission, clear stale errors when retrying, and restore the controls after HTTP or network failures while preserving entered values. Use form submission consistently so Enter works in all three forms, and expose the pending state with `aria-busy`.

### Validation

- `npm run build:device` passed.
- Changed-file lint and formatting checks passed with no warnings or errors.
- Browser checks of all three dialogs with mocked delayed responses passed: validation, Enter submission, visible spinner, disabled controls, repeated-submit prevention, HTTP/network error recovery, retry, and success.
- Separate `tsc -b` check reports 289 diagnostics on both this change and the unchanged `dev` baseline, with identical counts by file and diagnostic code. These include existing shared Button typing and Vite configuration errors.
- Full device E2E suite was not run.

### Checklist

- [ ] Ran `make test_e2e` locally and passed
- [ ] Linked to issue(s) above by issue number (no linked issue)
- [x] One problem per PR (no unrelated changes)
- [ ] Lints pass; CI green (changed-file lint passed; CI pending)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes to device settings modals; same auth endpoints and validation, with no server or credential-handling logic changes.
> 
> **Overview**
> Local auth **create**, **update**, and **delete** password dialogs now show in-flight feedback instead of staying fully interactive while API calls run.
> 
> `Dialog` tracks **`isSubmitting`**, blocks duplicate submits, clears errors before a retry, and resets the flag in **`finally`** so failed HTTP or network requests re-enable the form with values kept. Each modal gets **`aria-busy`**, disabled inputs and cancel/submit actions, and the primary **`Button`** **`loading`** spinner; delete is wrapped in a **`<form>`** like the others so **Enter** submits consistently via **`type="submit"`** instead of **`onClick`** handlers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit acda08ca53891d9128634d09bea9bd74646d2f6e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->