### PR TITLE
Fix German translation of "keys" to "Tasten"

### DIFF
--- a/ui/localization/messages/de.json
+++ b/ui/localization/messages/de.json
@@ -384,7 +384,7 @@
     "info_hdmi_state": "HDMI-Status:",
     "info_hidrpc_state": "HidRPC-Status:",
     "info_kana": "Kana",
-    "info_keys": "Schlüssel:",
+    "info_keys": "Tasten:",
     "info_last_move": "Letzter Zug:",
     "info_num_lock": "Num Lock",
     "info_paste_enabled": "Ermöglicht",


### PR DESCRIPTION
In this context, "keys" refers to keyboard keys, which are "Tasten" in German.

"Schlüssel" would refer to physical keys (e.g. on a keychain) or cryptographic keys and is incorrect here.

### Summary
- Correct the German translation of "keys" from "Schlüssel" to "Tasten".
- In this context, "keys" refers to keyboard keys.

### Checklist
- [ ] Ran `make test_e2e` locally and passed
- [ ] Linked to issue(s) above by issue number (e.g. `Closes #<issue-number>`)
- [x] One problem per PR (no unrelated changes)
- [x] Lints pass; CI green
